### PR TITLE
Refactored levels.mod/modLevel, resolved inconsistencies, fixed some issues

### DIFF
--- a/scripts/gamevariables.js
+++ b/scripts/gamevariables.js
@@ -13,6 +13,9 @@ var dreams = {};
 var confession = {};
 gv.difficulty = 0;
 
+const LEVEL_CAP_DEFAULT = 15;
+const LEVEL_POINTS_CAP_DEFAULT = 100;
+
 sex.st = new Array();
 levels.st = new Array();
 daily.st = new Array();
@@ -217,32 +220,32 @@ gv.init = function () {
     ];
 
     levels.st = [
-        { id: 0, n: "pi", d: "Intelligence", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
-        { id: 1, n: "xdress", d: "Sissy", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: false },
-        { id: 2, n: "sub", d: "Submissive", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
-        { id: 3, n: "dom", d: "Dominance", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
-        { id: 4, n: "oral", d: "Oral", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
-        { id: 5, n: "anal", d: "Anal", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
-        { id: 6, n: "cum", d: "Cum", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
-        { id: 7, n: "piss", d: "Piss", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
-        { id: 8, n: "beast", d: "Beast", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
-        { id: 9, n: "heels", d: "Heels", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true },
-        { id: 10, n: "charisma", d: "Charisma", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
-        { id: 11, n: "fame", d: "Fame", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true }, //how likely you are to get raped
+        { id: 0, n: "pi", d: "Intelligence", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 1, n: "xdress", d: "Sissy", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: false, cap: 100 },
+        { id: 2, n: "sub", d: "Submissive", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 3, n: "dom", d: "Dominance", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 4, n: "oral", d: "Oral", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 5, n: "anal", d: "Anal", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 6, n: "cum", d: "Cum", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 7, n: "piss", d: "Piss", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 8, n: "beast", d: "Beast", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 9, n: "heels", d: "Heels", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 10, n: "charisma", d: "Charisma", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 11, n: "fame", d: "Fame", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT }, //how likely you are to get raped
 
-        { id: 12, n: "fitness", d: "Fitness", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
-        { id: 13, n: "strength", d: "Strength [STR]", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
-        { id: 14, n: "makeup", d: "Makeup", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
-        { id: 15, n: "notused1", d: "Pain Tolerance", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true },
-        { id: 16, n: "cheer", d: "Cheerleader", c: 0, l: 0, autoLevel: false, display: true, compoundLevel: true },
-        { id: 17, n: "stripper", d: "Stripping", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
-        { id: 18, n: "whore", d: "Whore", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true },
+        { id: 12, n: "fitness", d: "Fitness", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 13, n: "strength", d: "Strength [STR]", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 14, n: "makeup", d: "Makeup", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 15, n: "notused1", d: "Pain Tolerance", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 16, n: "cheer", d: "Cheerleader", c: 0, l: 0, autoLevel: false, display: true, compoundLevel: false, cap: LEVEL_CAP_DEFAULT },
+        { id: 17, n: "stripper", d: "Stripping", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 18, n: "whore", d: "Whore", c: 0, l: 0, autoLevel: true, display: true, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
 
-        { id: 19, n: "not used", d: "Lock Picking", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true },
-        { id: 20, n: "dick", d: "Cock", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true },
-        { id: 21, n: "beer", d: "Alcohol Tolerance", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true },
-        { id: 22, n: "milk", d: "Breast Milk", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true },
-        { id: 23, n: "noop", d: "Not used", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true },
+        { id: 19, n: "not used", d: "Lock Picking", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 20, n: "dick", d: "Cock", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 21, n: "beer", d: "Alcohol Tolerance", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 22, n: "milk", d: "Breast Milk", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
+        { id: 23, n: "noop", d: "Not used", c: 0, l: 0, autoLevel: true, display: false, compoundLevel: true, cap: LEVEL_CAP_DEFAULT },
 
     ];
 
@@ -847,90 +850,57 @@ levels.set = function (name, c, l) {
     sstat.makeGraph();
 };
 
-levels.modLevel = function (name, amount) {
+// Modify full levels directly
+levels.modLevel = function (name, amount, zeroPoints = false, showDefaultNotice = false) {
+    if (!amount) { // also takes care of amount === 0
+        return;
+    }
     if (name === "xdress" && !sissy.st[0].ach) {
         return;
     }
+    let level = levels.st[levels.i(name)]
+    let startingLevel = {l: level.l, c: level.c, compoundLevel: level.compoundLevel};
+    let l = level.l += amount;
 
-    let i = levels.i(name);
-    let startLevel = levels.st[i].l;
-    levels.st[i].l += amount;
-    
-    if (levels.st[i].l < 0) {
-        levels.st[i].l = 0;
-        levels.st[i].c = 0;
+    level.l = g.limitRange(l, 0, level.cap);
+    if (l < 0 || (zeroPoints && (amount < 0 || level.l > startingLevel.l))) {
+        // Don't reduce points to 0 if we wanted to increase level but were already at cap
+        level.c = 0;
+    } else if (!zeroPoints) {
+        // Keep relative value of points in level
+        let maxPoints = levels.getPointsCapForLevel(level);
+        level.c = g.limitRange(Math.round((maxPoints / levels.getPointsCapForLevel(startingLevel)) * level.c), 0, maxPoints);
     }
 
-    let levelsChange = levels.st[i].l - startLevel;
-
-    if (levelsChange < 0)
-        g.popUpNotice("You lost " + Math.abs(levelsChange) + " LEVEL" + (levelsChange === -1 ? "" : "S") + " for " + levels.st[i].d + "!");
-    else if (levelsChange > 0)
-        g.popUpNotice("You gained " + levelsChange + " LEVEL" + (levelsChange === 1 ? "" : "S") + " for " + levels.st[i].d + "!");
+    if (showDefaultNotice) {
+        levels.modLevelNotice(level, startingLevel, amount);
+    }
+    sstat.makeGraph();
 };
 
+// Modify level points
 levels.mod = function (name, amount) {
-    let i, startingLevel;
-    
-    i = levels.i(name);
-    startingLevel = levels.st[i].l;
+    if (!amount) { // also takes care of amount === 0
+        return;
+    }
+    let level = levels.st[levels.i(name)];
+    let startingLevel = {l: level.l, c: level.c};
 
     //fix for old old level system - remove in the future;
-    if (levels.st[i].c === null || isNaN(levels.st[i].c))
-        levels.st[i].c = 0;
+    if (level.c === null || isNaN(level.c))
+        level.c = 0;
 
-    if (!levels.st[i].autoLevel) {
-        levels.st[i].c += amount;
-        if (levels.st[i].c < 0)
-            levels.st[i].c = 0;
-        if (levels.st[i].c > 100)
-            levels.st[i].c = 100;
-        if (amount > 0) {
-            if (levels.st[i].l > 15)
-                g.popUpNoticeBottom("You're maxed out for " + levels.st[i].d);
-            else if(amount > 0)
-                g.popUpNoticeBottom("You gained "  + amount + " points for " + levels.st[i].d + "!");
-            else
-                g.popUpNoticeBottom("You lost " + Math.abs(amount) + " points for " + levels.st[i].d + "!");
+    level.c += amount;
+    if (level.autoLevel && amount > 0) { // Only level increase, not decrease, with autoLevel
+        let pCap = levels.getPointsCapForLevel(level);
+        while (level.l < level.cap && level.c >= pCap) {
+            level.c -= pCap;
+            level.l++;
+            pCap = levels.getPointsCapForLevel(level);
         }
     }
-    else if (amount > 0) {
-        if (levels.st[i].compoundLevel) {
-            levels.st[i].c += amount;
-            while (levels.st[i].c >= levels.getCap(levels.st[i].l)) {
-                levels.st[i].c -= levels.getCap(levels.st[i].l);
-                levels.st[i].l++;
-            }
-            let levelsChange = levels.st[i].l - startingLevel;
-           
-            if (levelsChange > 0)
-                g.popUpNoticeBottom("You gained " + levelsChange + " LEVEL" + (levelsChange === 1 ? "" : "S") + " for " + levels.st[i].d + "!");
-            else
-                g.popUpNoticeBottom("You gained " + amount + " POINT" + (amount === 1 ? "" : "S") + " for " + levels.st[i].d + "!");
-        }
-        else if (levels.st[i].autoLevel) {
-            levels.st[i].c += amount;
-            while (levels.st[i].c >= 100) {
-                levels.st[i].c -= 100;
-                levels.st[i].l++;
-            }
-            let levelsChange = levels.st[i].l - startingLevel;
-            if (levelsChange > 0)
-                g.popUpNoticeBottom("You gained " + levelsChange + " LEVEL" + (levelsChange === 1 ? "" : "S") + " for " + levels.st[i].d + "!");
-            else
-                g.popUpNoticeBottom("You gained " + amount + " POINT" + (amount === 1 ? "" : "S") + " for " + levels.st[i].d + "!");
-        }
-    }
-    else if (amount < 0) {
-        if (levels.st[i].l >= 15) {
-            levels.st[i].l = 15;
-            return;
-        }
-        levels.st[i].c -= amount;
-        if (levels.st[i].c < 0)
-            levels.st[i].c = 0;
-        g.popUpNoticeBottom(levels.st[i].d + " points have decreased. ");
-    }
+    levels.applyLevelLimits(level);
+    levels.modNotice(level, startingLevel, amount);
 
     if (name === "fitness") {
         var fitnessEnd = levels.get("fitness").l;
@@ -940,24 +910,37 @@ levels.mod = function (name, amount) {
     sstat.makeGraph();
 };
 
-levels.getCap = function (levels) {
-    let interestRate = .3;
-    if (levels > 7)
-        interestRate = interestRate + .05;
-    var initialComp = Math.floor(55 * Math.pow(1 + interestRate, levels));
-    //if (initialComp > 500)
-    //    return 500;
-    return initialComp;
-};
+// Limit level and points between min and max values
+levels.applyLevelLimits = function(level) {
+    level.l = g.limitRange(level.l, 0, level.cap);
 
-levels.compute = function (level) {
-    var total = 0;
-    let i;
-    for (i = 0; i < level; i++) {
-        total += levels.getCap(i);
-    }
-    return total;
+    let maxPoints = levels.getPointsCapForLevel(level);
+    level.c = g.limitRange(level.c, 0, maxPoints);
 }
+
+levels.modLevelNotice = (level, oldLevel, amount) => levels.modNotice(level, oldLevel, amount, true)
+
+levels.modNotice = function(level, oldLevel, amount, modLevel = false) {
+    if (level.l >= level.cap && (modLevel || level.c >= levels.getPointsCapForLevel(level))) {
+        g.popUpNoticeBottom("You're maxed out for " + level.d);
+        return;
+    }
+    // if level changed, notice level change, else notice point change
+    let type = (modLevel || oldLevel.l !== level.l) ? "LEVEL" : "POINT";
+    let change = type === "LEVEL" ? (level.l - oldLevel.l) : (level.c - oldLevel.c);
+    let absChange = Math.abs(change);
+    if (!modLevel || absChange > 0) {
+        g.popUpNoticeBottom(`You ${change > 0 ? "gained" : "lost"} ${absChange} ${type}${absChange !== 1 ? "S" : ""} for ${level.d}!`);
+    }
+}
+
+levels.getPointsCapForLevel = function (level) {
+    if (!level.compoundLevel) {
+        return LEVEL_POINTS_CAP_DEFAULT;
+    }
+    let interestRate = level.l > 7 ? .35 : .3;
+    return Math.floor(55 * Math.pow(1 + interestRate, level.l));
+};
 
 sex.get = function (type, gender) {
     let gr;
@@ -1325,7 +1308,7 @@ levels.anal = function (size, sissygasm = false, gender = null, creampie = false
     }
 
     if (creampie) {
-        levels.mod("cum", 25, 999);
+        levels.mod("cum", 25);
         sex.mod("mudpie", gender, who);
         if (beast === null) {
             gv.mod("analCum", 1);
@@ -1345,7 +1328,7 @@ levels.anal = function (size, sissygasm = false, gender = null, creampie = false
 
     if (beast !== null) {
         sex.mod(beast, "m", who);
-        levels.mod("beast", 50, 10);
+        levels.mod("beast", 50);
         switch (beast) {
             case "dog": gv.mod("analCumDog", 1); break;
             case "horse": gv.mod("analCumHorse", 1); break;
@@ -1541,7 +1524,7 @@ levels.gavebj = function (size, gender, who, swallow = false, facialOverride = f
 };
 
 levels.oral = function (size, gender = null, who = null, swallow = false, beast = null, facialOverride = false) {
-    //levels.mod("oral", 25, 999);
+    //levels.mod("oral", 25);
     levels.oralSizes(size);
     gv.mod("arousal", 25);
 
@@ -1804,19 +1787,19 @@ sex.masturbate = function (t = null) {
 levels.piss = function (drankpiss, analpiss, pissedon, gender, who = null) {
     if (analpiss) {
         sex.mod("analpiss", gender, who);
-        levels.mod("piss", 40, 999);
-        levels.mod("xdress", 40, 999);
+        levels.mod("piss", 40);
+        levels.mod("xdress", 40);
     }
     else if (pissedon) {
         sex.mod("piss", gender, who);
-        levels.mod("piss", 15, 999);
-        levels.mod("xdress", 5, 999);
+        levels.mod("piss", 15);
+        levels.mod("xdress", 5);
     }
     else if (drankpiss) {
         sex.mod("drankpiss", gender, who);
-        levels.mod("piss", 25, 999);
+        levels.mod("piss", 25);
         var pissLevel = levels.get("piss").l - 4;
-        levels.mod("xdress", 15, 999);
+        levels.mod("xdress", 15);
         gv.mod("bladder", .3);
         if (pissLevel > 0) {
             let pissEnergy = pissLevel * 5;
@@ -1826,14 +1809,14 @@ levels.piss = function (drankpiss, analpiss, pissedon, gender, who = null) {
         }
     }
     else {
-        levels.mod("xdress", 5, 999);
-        levels.mod("piss", 15, 999);
+        levels.mod("xdress", 5);
+        levels.mod("piss", 15);
     }
 }
 
 levels.fuckpussy = function (who, gender = "f") {
     cl.doCum(false);
-    levels.mod("dick", 20, 999);
+    levels.mod("dick", 20);
     sex.mod("pussiesfucked", gender, who);
 };
 
@@ -2076,7 +2059,7 @@ sissy.passclass = function (normalRoom) {
     var currentClass = gv.get("sissySchoolClass");
     gv.set("sissySchoolClass", null);
     gv.set("sissySchoolClassDays", 0);
-    levels.mod("xdress", 30, 999);
+    levels.mod("xdress", 30);
     for (var i = 0; i < sissy.st.length; i++) {
         if (sissy.st[i].icon === currentClass) {
             sissy.st[i].ach = true;

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -628,6 +628,11 @@ g.randn_bm = function() {
     return num
 }
 
+// Constrains a number to lower and upper bounds of a range
+g.limitRange = function(number, lowerBound, upperBound) {
+    return Math.min(Math.max(number, lowerBound), upperBound);
+}
+
 g.makeCss = function (height, width, top, left) {
     return " height:" + (height * g.ratio) + "px; width:" + (width * g.ratio) + "px; top:" + (top * g.ratio) + "px; left:" + (left * g.ratio) + "px; ";
 };

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -802,7 +802,7 @@ inv.createElements = function () {
                                 break;
                             case "cumjar":
                                 gv.mod("energy", 100);
-                                levels.mod("xdress", 10, 999);
+                                levels.mod("xdress", 10);
                                 levels.mod("cum", 25);
                                                                 break;
                             case "pissjarboy":
@@ -813,17 +813,17 @@ inv.createElements = function () {
                                 break;
                             case "dogcumjar":
                                 gv.mod("energy", 150);
-                                levels.mod("xdress", 10, 999);
+                                levels.mod("xdress", 10);
                                 levels.mod("cum", 25);
                                 break;
                             case "horsecumjar":
                                 gv.mod("energy", 200);
-                                levels.mod("xdress", 10, 999);
+                                levels.mod("xdress", 10);
                                 levels.mod("cum", 25);
                                 break;
                             case "pigcumjar":
                                 gv.mod("energy", 300);
-                                levels.mod("xdress", 10, 999);
+                                levels.mod("xdress", 10);
                                 levels.mod("cum", 25);
                                 break;
                             default:

--- a/scripts/lockpick.js
+++ b/scripts/lockpick.js
@@ -211,7 +211,7 @@ room1003.btnclick = function (callback) {
     }
     else if (callback === "lockpickq_success") {
         clearTimeout(g.roomTimeout2);
-        levels.mod("pi", 25, 999);
+        levels.mod("pi", 25);
         nav.killbuttonStartsWith("lockpickq_");
         $('#room_footer').show();
         window[g.room(g.fight.roomID)]["btnclick"](g.fight.btnPressWin);

--- a/scripts/phone.js
+++ b/scripts/phone.js
@@ -1327,7 +1327,7 @@ room9999.btnclick = function (name) {
         }
         else {
             var cheatLevel = name.replace("phone_cheatmod_level_", "");
-            levels.mod(cheatLevel, 100, 999);
+            levels.mod(cheatLevel, 100);
             phone.cheat();
             $('#char_alert').hide();
         }

--- a/scripts/quickFight.js
+++ b/scripts/quickFight.js
@@ -340,8 +340,8 @@ quickFight.drawFight = function () {
         if (meAbsTotal > enemyAbsTotal) {
             g.fight.aftermath = "win";
             gv.mod("energy", -5);
-            levels.mod("strength", 15, 999);
-            levels.mod("dom", 20, 999);
+            levels.mod("strength", 15);
+            levels.mod("dom", 20);
             nav.t({
                 type: "img",
                 name: "quickfight",

--- a/scripts/room/room009.js
+++ b/scripts/room/room009.js
@@ -531,7 +531,7 @@ room9.btnclick = function (name) {
             break;
         case "missyusbdoc":
             if (missy.get("reusableCaseCounter") < 3) {
-                levels.mod("pi", 50, 999);
+                levels.mod("pi", 50);
                 missy.set("reusableCaseCounter", 3);
             }
             nav.killall();

--- a/scripts/room/room012.js
+++ b/scripts/room/room012.js
@@ -467,7 +467,7 @@ room12.chatcatch = function (callback) {
             char.room(12);
             break;
         case "lotion2":
-            levels.mod("xdress", 10, 3);
+            levels.mod("xdress", 10);
             if (gender.pronoun("f") === "m") 
                 nav.bg("12_bathroom/lotion2_man.jpg");
             else 

--- a/scripts/room/room013.js
+++ b/scripts/room/room013.js
@@ -1543,19 +1543,19 @@ room13.chatcatch = function (callback) {
                 sc.modSecret("eva", 5);
                 break;
             case "dom":
-                levels.mod("dom", 20, 999);
+                levels.mod("dom", 20);
                 break;
             case "sub":
-                levels.mod("sub", 20, 999);
+                levels.mod("sub", 20);
                 break;
             case "beast":
-                levels.mod("beast", 20, 999);
+                levels.mod("beast", 20);
                 break;
             case "charisma":
-                levels.mod("charisma", 25, 999);
+                levels.mod("charisma", 25);
                 break;
             case "xdress1":
-                levels.mod("xdress", 33, 1);
+                levels.mod("xdress", 33);
                 break;
             case "reset":
                 char.room(13);
@@ -1575,7 +1575,7 @@ room13.chatcatch = function (callback) {
                 break;
             case 'takePanties':
                 cl.add("panties", "w");
-                levels.mod("xdress", 50, 999);
+                levels.mod("xdress", 50);
                 nav.killbutton("panties");
                 break;
             case "killPantyIcon":

--- a/scripts/room/room014.js
+++ b/scripts/room/room014.js
@@ -518,8 +518,8 @@ room14.btnclick = function (name) {
             break;
         case "task_9_b_2":
             nav.killbutton("task_9_b_2");
-            levels.mod("xdress", 20, 999);
-            levels.mod("cum", 20, 999);
+            levels.mod("xdress", 20);
+            levels.mod("cum", 20);
             chat(120, 14);
             break;
         case "screwdriver":
@@ -600,7 +600,7 @@ room14.btnclick = function (name) {
         case "bigguy_12_0":
             nav.modbutton("bigguy_12_0", "14_motherRoom/bigguy_12_" + g.internal + ".png", null, null);
             if (g.internal > 4) {
-                levels.mod("cum", 25, 999);
+                levels.mod("cum", 25);
                 sc.completeMissionTask("bigguy", "sissy", 1);
                 nav.killbutton("bigguy_12_0");
                 chat(134, 14);
@@ -800,7 +800,7 @@ room14.chatcatch = function (callback) {
         case "task1_3":
             nav.bg("14_motherRoom/" + callback + ".jpg");
             sc.modLevel("landlord", 30, 5);
-            levels.mod("dom", 53, 999);
+            levels.mod("dom", 53);
             break;
         case "reset":
             char.room(14);
@@ -810,11 +810,11 @@ room14.chatcatch = function (callback) {
             break;
         case "stealplug":
             cl.add("buttplug", "s");
-            levels.mod("xdress", 40, 2);
+            levels.mod("xdress", 40);
             room14.btnclick("dresser");
             break;
         case "domlaugh":
-            levels.mod("dom", 38, 999);
+            levels.mod("dom", 38);
             sc.modLevel("landlord", 20, 999);
             nav.modbutton("motherRobe", "14_motherRoom/14_motherRobeLaugh.png", null, null);
             break;
@@ -855,7 +855,7 @@ room14.chatcatch = function (callback) {
             char.room(21);
             break;
         case "dom":
-            levels.mod("dom", 20, 999);
+            levels.mod("dom", 20);
             break;
         case "leave":
             daily.set("landlord");
@@ -863,7 +863,7 @@ room14.chatcatch = function (callback) {
             break;
         case "leaveSub":
             daily.set("landlord");
-            levels.mod("sub", 30, 999);
+            levels.mod("sub", 30);
             char.room(16);
             break;
         case "bg_s_0_end":
@@ -875,13 +875,13 @@ room14.chatcatch = function (callback) {
             break;
         case "task2_1":
             nav.killall();
-            levels.mod("dom", 20, 999);
+            levels.mod("dom", 20);
             nav.bg("14_motherRoom/task1_2.jpg");
             break;
         
         case "task_3_1":
             nav.kill();
-            levels.mod("dom", 20, 999);
+            levels.mod("dom", 20);
             nav.bg("14_motherRoom/" + callback + ".jpg");
             break;
         case "task_3_3":
@@ -909,7 +909,7 @@ room14.chatcatch = function (callback) {
         case "task_3_end":
             levels.oral(3, "f", "landlord");
             gv.mod("arousal", 75);
-            levels.mod("oral", 50, 0);
+            levels.mod("oral", 50);
             char.addtime(60);
             sc.modLevel("landlord", 50, 10);
             sc.completeMissionTask("landlord", "man", 4, true);
@@ -919,7 +919,7 @@ room14.chatcatch = function (callback) {
         case "task_4_end":
             levels.oral(3, "f", "landlord");
             gv.mod("arousal", 75);
-            levels.mod("oral", 50, 0);
+            levels.mod("oral", 50);
             char.addtime(60);
             sc.modLevel("landlord", 5, 3);
             daily.set("landlord");

--- a/scripts/room/room019.js
+++ b/scripts/room/room019.js
@@ -452,13 +452,13 @@ room19.chatcatch = function (callback) {
         case "emptyMilk":
             gv.set("milk", .0);
             cl.display();
-            levels.mod("milk", 25, 999);
+            levels.mod("milk", 25);
             char.room(19);
             break;
         case "pumpDrink":
             gv.set("milk", .0);
             cl.display();
-            levels.mod("milk", 25, 999);
+            levels.mod("milk", 25);
             gv.mod("energy", 100);
             nav.bg("19_layInBed/pumpDrink.jpg");
             break;

--- a/scripts/room/room022.js
+++ b/scripts/room/room022.js
@@ -270,14 +270,14 @@ room22.chatcatch = function (callback) {
             break;
         case "finishPeeMan":
             gv.set("bladder", 0);
-            levels.mod("dom", 5, 999);
+            levels.mod("dom", 5);
             char.addtime(15);
             char.room(22);
             break;
         case "finishPeeBitch":
             gv.set("bladder", 0);
-            levels.mod("sub", 5, 999);
-            levels.mod("xdress", 10, 999);
+            levels.mod("sub", 5);
+            levels.mod("xdress", 10);
             char.addtime(15);
             char.room(22);
             break;
@@ -288,7 +288,7 @@ room22.chatcatch = function (callback) {
                 inv.add(getCum.cumType);
             }
             gv.clearButtCum();
-            levels.mod("xdress", 15, 999);
+            levels.mod("xdress", 15);
             char.addtime(20);
             char.room(22);
             break;

--- a/scripts/room/room023.js
+++ b/scripts/room/room023.js
@@ -1047,7 +1047,7 @@ room23.chatcatch = function (callback) {
             sc.modSecret("eva", 10);
             break;
         case "charisma":
-            levels.mod("charisma", 10, 999);
+            levels.mod("charisma", 10);
             break;
         case "arousal":
             gv.mod("arousal", 10);
@@ -1129,7 +1129,7 @@ room23.chatcatch = function (callback) {
             break;
         case "mepanties":
             nav.killall();
-            levels.mod("xdress", 25, 999);
+            levels.mod("xdress", 25);
             nav.bg("24_spinTheBottle/mepanties.jpg");
             cl.c.panties = "w";
             cl.display();

--- a/scripts/room/room028.js
+++ b/scripts/room/room028.js
@@ -253,7 +253,7 @@ room28.main = function () {
         }, 6000);
         return;
     }
-    if (cl.c.chest === 0 && levels.st[12].l > 0) {
+    if (cl.c.chest === 0 && levels.get("fitness").l > 0) {
         chat(0, 28);
         return;
     }
@@ -623,7 +623,7 @@ room28.btnclick = function (name) {
     }
     else if (name.startsWith("qgrow_")){
         var gid = parseInt(name.replace("qgrow_", ""));
-        levels.st[1].l = levels.st[1].l - qdress.st[gid].p;
+        levels.modLevel("xdress", -qdress.st[gid].p)
         qdress.st[gid].ach = true;
         switch (qdress.st[gid].icon) {
             case "qpanties":

--- a/scripts/room/room051.js
+++ b/scripts/room/room051.js
@@ -272,7 +272,7 @@ room51.chatcatch = function (callback) {
             sc.startMission("candy", "cuck");
             sc.completeMissionTask("candy", "cuck", 0);
             gv.set("xdress", true);
-            levels.mod("xdress", 30, 999);
+            levels.mod("xdress", 30);
             missy.set("activeCaseComplete", 1);
             missy.caseComplete(11);
             char.settime(19, 57);

--- a/scripts/room/room058.js
+++ b/scripts/room/room058.js
@@ -184,7 +184,7 @@ room58.btnclick = function (name) {
         case "icon_quit":
             clearTimeout(g.roomTimeout);
             gv.mod("money", g.internal.money);
-            gv.mod("xdress", 15);
+            levels.mod("xdress", 15);
             var maxfame = Math.ceil(g.internal.maxviews / 20);
             if (maxfame > 40)
                 maxfame = 40;

--- a/scripts/room/room101.js
+++ b/scripts/room/room101.js
@@ -141,12 +141,12 @@ room101.chatcatch = function (callback) {
                 "height": 715,
                 "image": "101_constFrontOffice/laugh1.png"
             }, 101);
-            levels.mod("charisma", 15, 999);
+            levels.mod("charisma", 15);
             sc.modLevel("tina", 55, 5);
 
             break;
         case "nicePickupLine":
-            levels.mod("charisma", 12, 999);
+            levels.mod("charisma", 12);
             if (sc.getLevel("tina") < 2) {
                 sc.modLevel("tina", 55);
                 chat(15, 101);

--- a/scripts/room/room102.js
+++ b/scripts/room/room102.js
@@ -49,7 +49,7 @@ room102.chatcatch = function (callback) {
             gv.set("jobConstGetRaise", true);
             break;
         case "dom":
-            levels.mod("dom", 10, 1);
+            levels.mod("dom", 10);
             break;
         case "showtits":
             nav.bg("102_constBoss/flash.jpg");
@@ -58,7 +58,7 @@ room102.chatcatch = function (callback) {
             nav.bg("102_constBoss/102_boss.jpg");
             break;
         case "sub":
-            levels.mod("sub", 10, 1);
+            levels.mod("sub", 10);
             break;
         default:
             break;

--- a/scripts/room/room103.js
+++ b/scripts/room/room103.js
@@ -59,7 +59,7 @@ room103.btnclick = function (name) {
         default:
             break;
         case "hole":
-            levels.mod("anal", 5, 1);
+            levels.mod("anal", 5);
             chat(25, 103);
             break;
         case "pamphlet":
@@ -113,7 +113,7 @@ room103.chatcatch = function (callback) {
     switch (callback) {
         case "complete":
             char.settime(17, 50);
-            levels.mod("fitness", 4, 999);
+            levels.mod("fitness", 4);
             gv.mod("jobapplyconst", 1);
             daily.set("construction");
             char.room(101);
@@ -325,7 +325,7 @@ room103.chatcatch = function (callback) {
             break;
         case "give20":
             if (gv.get("money") > 19) {
-                levels.mod("charisma", 5, 999);
+                levels.mod("charisma", 5);
                 gv.mod("money", -20);
                 chat(17, 103);
             }
@@ -337,7 +337,7 @@ room103.chatcatch = function (callback) {
             g.internal = true;
             break;
         case "panties":
-            levels.mod("xdress", 5, 1);
+            levels.mod("xdress", 5);
             nav.bg("103_constSite/worker4.jpg");
             break;
         case "hole0":
@@ -398,19 +398,19 @@ room103.chatcatch = function (callback) {
             char.room(10);
             break;
         case "adddom":
-            levels.mod("dom", 5, 1);
+            levels.mod("dom", 5);
             break;
         case "addsub":
-            levels.mod("sub", 5, 1);
+            levels.mod("sub", 5);
             break;
         
         case "pamphlet":
             nav.killbutton("pamphlet2");
             gv.mod("pamphletConstSite", true);
-            levels.mod("pi", 20, 999);
+            levels.mod("pi", 20);
             break;
         case "intPlus":
-            levels.mod("pi", 15, 999);
+            levels.mod("pi", 15);
             break;
         case "fight0":
             nav.bg("103_constSite/fight0.jpg");

--- a/scripts/room/room170.js
+++ b/scripts/room/room170.js
@@ -392,7 +392,7 @@ room170.chatcatch = function (callback) {
             break;
         case "classComplete":
             gv.mod("sissySchoolClassDays", 1);
-            levels.mod("xdress", 30, 999);
+            levels.mod("xdress", 30);
             levels.mod("fame", 100);
             char.settime(17, 15);
             char.room(201);

--- a/scripts/room/room171.js
+++ b/scripts/room/room171.js
@@ -378,7 +378,7 @@ room171.btnclick = function (name) {
                         break;
                 }
                 levels.mod("whore", 25);
-                levels.mod("xdress", 25, 999);
+                levels.mod("xdress", 25);
                 gv.mod("energy", -25);
 
                 if (depositCum && g.internal.i < 15) {

--- a/scripts/room/room172.js
+++ b/scripts/room/room172.js
@@ -216,8 +216,8 @@ room172.chatcatch = function (callback) {
             levels.anal(4, true, "m", true, "black");
             break;
         case "complete":
-            levels.mod("xdress", 30, 999);
-            levels.mod("sub", 45, 999);
+            levels.mod("xdress", 30);
+            levels.mod("sub", 45);
             cl.c.chastity = g.pass;
             cl.display();
             char.addtime(238);

--- a/scripts/room/room173.js
+++ b/scripts/room/room173.js
@@ -79,14 +79,14 @@ room173.btnclick = function (name) {
         case "save":
             var thisEntrySave = g.internal.a[g.internal.i];
             if (thisEntrySave.s)
-                levels.mod("pi", 4, 999);
+                levels.mod("pi", 4);
             g.internal.i++;
             room173.btnclick("next");
             break;
         case "trash":
             var thisEntryTrash = g.internal.a[g.internal.i];
             if (!thisEntryTrash.s)
-                levels.mod("pi", 4, 999);
+                levels.mod("pi", 4);
             g.internal.i++;
             room173.btnclick("next");
             break;
@@ -96,8 +96,8 @@ room173.btnclick = function (name) {
             else {
                 nav.killall();
                 nav.bg("173_trash/swallaw.jpg");
-                levels.mod("cum", 20, 999);
-                levels.mod("pi", 4, 999);
+                levels.mod("cum", 20);
+                levels.mod("pi", 4);
                 gv.mod("energy", 100);
                 chat(4, 173);
             }

--- a/scripts/room/room174.js
+++ b/scripts/room/room174.js
@@ -439,7 +439,7 @@ room174.chatcatch = function (callback) {
             break;
         case "club_end":
             missy.set("activeCaseComplete", 1);
-            levels.mod("pi", 75, 999);
+            levels.mod("pi", 75);
             char.addtime(60);
             char.room(0);
             break;

--- a/scripts/room/room175.js
+++ b/scripts/room/room175.js
@@ -71,7 +71,7 @@ room175.chatcatch = function (callback) {
         case "anal212_7_w":
             var tw = callback.replace("_w", "");
             nav.bg("175_anal/" + tw + ".jpg");
-            levels.mod("anal", 15, 999);
+            levels.mod("anal", 15);
             break;
         case "anal212_8":
             nav.bg("175_anal/" + callback + ".gif");
@@ -87,7 +87,7 @@ room175.chatcatch = function (callback) {
             break;
         case "anal10":
             nav.bg("175_anal/" + callback + ".jpg");
-            levels.mod("xdress", 20, 999);
+            levels.mod("xdress", 20);
             break;
         case "anal15":
             nav.bg("175_anal/" + callback + ".jpg");
@@ -129,7 +129,7 @@ room175.chatcatch = function (callback) {
             sissy.passclass(true);
             break;
         case "charisma":
-            levels.mod("charisma", 20, 999);
+            levels.mod("charisma", 20);
             break;
         case "lubenotme":
             g.internal = "";

--- a/scripts/room/room176.js
+++ b/scripts/room/room176.js
@@ -31,7 +31,7 @@ room176.main = function () {
 room176.btnclick = function (name) {
     switch (name) {
         case "blackmailSuccess":
-            levels.mod("charisma", 20, 999);
+            levels.mod("charisma", 20);
             chat(34, 176);
             break;
         case "blackmailFail":
@@ -142,7 +142,7 @@ room176.btnclick = function (name) {
             nav.killall();
             if (g.internal.love > 2) {
                 nav.bg("176_oral/oral203_l_3.jpg");
-                levels.mod("oral", 50, 999);
+                levels.mod("oral", 50);
                 chat(56, 176);
             }
             else if (g.internal.love < -1) {
@@ -208,14 +208,14 @@ room176.chatcatch = function (callback) {
             nav.bg("176_oral/" + callback + ".jpg");
             break;
         case "oral5":
-            levels.mod("oral", 100, 999);
-            //levels.mod("oral", 20, 999);
+            levels.mod("oral", 100);
+            //levels.mod("oral", 20);
             nav.bg("176_oral/" + callback + ".jpg");
             break;
         case "oral7":
             nav.bg("176_oral/" + callback + ".jpg");
-            levels.mod("oral", 100, 999);
-            //levels.mod("oral", 40, 999);
+            levels.mod("oral", 100);
+            //levels.mod("oral", 40);
             if (levels.get("oral").l < 2)
                 chat(17, 176);
             else
@@ -227,12 +227,12 @@ room176.chatcatch = function (callback) {
                 inv.add("whiteDildo");
             break;
         case "sub":
-            levels.mod("oral", 100, 999);
-            //levels.mod("sub", 20, 999);
+            levels.mod("oral", 100);
+            //levels.mod("sub", 20);
             break;
         case "dom":
-            levels.mod("oral", 100, 999);
-            //levels.mod("dom", 20, 999);
+            levels.mod("oral", 100);
+            //levels.mod("dom", 20);
             break;
         case "oralEnd":
             gv.mod("sissySchoolClassDays", 1);

--- a/scripts/room/room178.js
+++ b/scripts/room/room178.js
@@ -24,7 +24,7 @@ room178.btnclick = function (name) {
         case "cum201_2":
             nav.killbutton("cum201_2");
             gv.mod("energy", 200);
-            levels.mod("xdress", 10, 999);
+            levels.mod("xdress", 10);
             levels.mod("cum", 25);
             chat(29, 178);
             break;
@@ -65,7 +65,7 @@ room178.chatcatch = function (callback) {
             nav.bg("178_cum/" + callback + "_" + chastityx + ".jpg");
             break;
         case "cum9":
-            levels.mod("cum", 50, 999);
+            levels.mod("cum", 50);
             nav.bg("178_cum/" + callback + ".jpg");
             break;
         case "cumend":

--- a/scripts/room/room180.js
+++ b/scripts/room/room180.js
@@ -99,7 +99,7 @@ room180.chatcatch = function (callback) {
             nav.bg("180_ballroom/" + callback + ".jpg");
             break;
         case "charisma":
-            levels.mod("charisma", 40, 999);
+            levels.mod("charisma", 40);
             break;
         case "shaveEnd":
             cl.shave();
@@ -108,7 +108,7 @@ room180.chatcatch = function (callback) {
             sissy.passclass(true);
             break;
         case "femend":
-            levels.mod("xdress", 50, 2);
+            levels.mod("xdress", 50);
             sissy.passclass(true);
             break;
         case "pee1":
@@ -126,7 +126,7 @@ room180.chatcatch = function (callback) {
             char.addtime(60);
             break;
         case "peeend":
-            levels.mod("piss", 100, 7);
+            levels.mod("piss", 100);
             sissy.passclass(true);
             break;
         case "fem103_1":
@@ -151,7 +151,7 @@ room180.chatcatch = function (callback) {
             cl.c.socks = "ss";
             cl.c.shoes = "ss";
             cl.display();
-            levels.mod("xdress", 50, 999);
+            levels.mod("xdress", 50);
             sissy.passclass(true);
             break;
         case "fem201_end":
@@ -174,12 +174,12 @@ room180.chatcatch = function (callback) {
             zcl.assup(750, 80, .5);
             break;
         case "enema205_7":
-            levels.mod("xdress", 50, 999);
+            levels.mod("xdress", 50);
             sissy.passclass(true);
             break;
         case "fem121_end":
-            levels.mod("heels", 100, 999);
-            levels.mod("xdress", 50, 999);
+            levels.mod("heels", 100);
+            levels.mod("xdress", 50);
             sissy.passclass(true);
             break;
         case "laser1":

--- a/scripts/room/room182.js
+++ b/scripts/room/room182.js
@@ -38,7 +38,7 @@ room182.btnclick = function (name) {
             nav.killall();
             nav.bg("182_test/final0.jpg");
             if (grade > 89) { //crown
-                levels.mod("xdress", 100, 999);
+                levels.mod("xdress", 100);
                 cl.add("accessories", "crown");
 
                 chat(78, 182);
@@ -313,7 +313,7 @@ room182.chatcatch = function (callback) {
             break;
         case "t1_20":
             var analLevel = levels.get("anal").l;
-            levels.mod("anal", 50, 999);
+            levels.mod("anal", 50);
             var analImg = "";
             nav.kill();
             if (analLevel > 9) {
@@ -530,7 +530,7 @@ room182.chatcatch = function (callback) {
             break;
         case "end":
             $("#room-inv").show();
-            levels.mod("xdress", 100, 999);
+            levels.mod("xdress", 100);
             sissy.passclass(true);
             break;
         default:

--- a/scripts/room/room196.js
+++ b/scripts/room/room196.js
@@ -122,7 +122,7 @@ room196.chatcatch = function (callback) {
                 nav.bg("205_chastity/chast0_1.jpg");
             break;
         case "xdress":
-            levels.mod("xdress", 20, 2);
+            levels.mod("xdress", 20);
             break;
         default:
             break;

--- a/scripts/room/room197.js
+++ b/scripts/room/room197.js
@@ -209,13 +209,13 @@ room197.chatcatch = function (callback) {
             break;
         case "punish":
             g.pass = "insubordination";
-            levels.mod("dom", 25, 999);
+            levels.mod("dom", 25);
             missy.mod("mood", -25);
             char.room(217);
             break;
         case "sideDesk":
             nav.killall();
-            levels.mod("sub", 5, 5);
+            levels.mod("sub", 5);
             nav.bg("197_sub/sidedesk0.jpg");
             break;
         case "presentFoot":
@@ -276,7 +276,7 @@ room197.chatcatch = function (callback) {
             break;
        
         case "increaseSub":
-            levels.mod("sub", 5, 5);
+            levels.mod("sub", 5);
             break;
         case "oralup":
             levels.gavebj(5, "f", "missy");

--- a/scripts/room/room198.js
+++ b/scripts/room/room198.js
@@ -160,7 +160,7 @@ room198.chatcatch = function (callback) {
             chat(998, 198);
             break;
         case "correct":
-            levels.mod("pi", 40, 4);
+            levels.mod("pi", 40);
             missy.mod("mood", 3);
             char.addtime(120);
             chat(8, 198);

--- a/scripts/room/room199.js
+++ b/scripts/room/room199.js
@@ -86,7 +86,7 @@ room199.chatcatch = function (callback) {
         case "jump":
             nav.killall();
             gv.mod("energy", -15);
-            levels.mod("fitness", 7, 999);
+            levels.mod("fitness", 7);
             if (gv.get("energy") < 15) {
                 nav.bg("199_workout/tired.jpg");
                 chat(8, 199);
@@ -100,7 +100,7 @@ room199.chatcatch = function (callback) {
         case "toes":
             nav.killall();
             gv.mod("energy", -15);
-            levels.mod("fitness", 5, 999);
+            levels.mod("fitness", 5);
             if (gv.get("energy") < 15) {
                 nav.bg("199_workout/tired.jpg");
                 chat(8, 199);

--- a/scripts/room/room203.js
+++ b/scripts/room/room203.js
@@ -145,7 +145,7 @@ room203.chatcatch = function (callback) {
                         if ((cl.hasClothing("shirt", "s") && cl.hasClothing("pants", "s") &&
                             cl.hasClothing("socks", "b") && cl.hasClothing("shoes", "d")) ||
                             gv.get("money") > 245) {
-                            levels.mod("pi", -10, 999);
+                            levels.mod("pi", -10);
                             chat(9, 203);
                         }
                         else {
@@ -153,7 +153,7 @@ room203.chatcatch = function (callback) {
                         }
                     }
                     else {
-                        levels.mod("pi", -10, 999);
+                        levels.mod("pi", -10);
                         chat(9, 203);
                     }
                 }
@@ -164,21 +164,21 @@ room203.chatcatch = function (callback) {
                         chat(22, 203);
                     }
                     else {
-                        levels.mod("xdress", 5, 3);
+                        levels.mod("xdress", 5);
                         cl.c.pants = null;
                         cl.c.pants = "s";
                         chat(23, 203);
                     }
                 }
                 else {
-                    levels.mod("pi", -10, 999);
+                    levels.mod("pi", -10);
                     chat(24, 203);
                 }
             }
             else if (myUniform === 2) {
                 if (cl.hasoutfit("suitwithpanties") === null) {
                     if (cl.getBodyHair() === null) {
-                        levels.mod("xdress", 5, 5);
+                        levels.mod("xdress", 5);
                         cl.c.pants = null;
                         cl.c.pants = "s";
                         chat(23, 203);
@@ -191,14 +191,14 @@ room203.chatcatch = function (callback) {
                     }
                 }
                 else {
-                    levels.mod("pi", -10, 999);
+                    levels.mod("pi", -10);
                     chat(24, 203);
                 }
             }
             else if (myUniform === 3) {
                 g.internal = cl.hasoutfit("officegirl");
                 if (g.internal === null) {
-                    levels.mod("xdress", 5, 5);
+                    levels.mod("xdress", 5);
                     if (missy.get("uniformNew") === 2) {
                         chat(27, 203);
                     }
@@ -257,7 +257,7 @@ room203.chatcatch = function (callback) {
             break;
         case "uniform1_0":
             cl.c.pants = null;
-            levels.mod("xdress", 5, 3);
+            levels.mod("xdress", 5);
             zcl.displayMain(180, 800, .09, "clothes", false);
             cl.c.pants = "s";
             break;

--- a/scripts/room/room204.js
+++ b/scripts/room/room204.js
@@ -234,7 +234,7 @@ room204.chatcatch = function (callback) {
             g.internal.pay = pay;
             g.internal = { cardsLeft: g.pass.length, pay: pay, numberWrong: numberWrong };
             if (piPoints > 0) {
-                levels.mod("pi", piPoints, 999);
+                levels.mod("pi", piPoints);
             }
 
             if (cardsComplete === 12 && numberWrong === 0) {

--- a/scripts/room/room205.js
+++ b/scripts/room/room205.js
@@ -21,7 +21,7 @@ room205.chatcatch = function (callback) {
     switch (callback) {
         case "chastity0Dom":
             missy.mod("mood", -20);
-            levels.mod("dom", 40, 999);
+            levels.mod("dom", 40);
             break;
         case "chast0_0":
             nav.killall();
@@ -62,12 +62,12 @@ room205.chatcatch = function (callback) {
             break;
         case "chast0_9_bad":
             missy.mod("mood", -100);
-            levels.mod("dom", 100, 999);
+            levels.mod("dom", 100);
             nav.bg("205_chastity/chast0_9_bad.jpg");
             break;
         case "chast0_9_good":
             missy.mod("mood", 100);
-            levels.mod("sub", 100, 999);
+            levels.mod("sub", 100);
             nav.bg("222_errands/laundry3.jpg");
             break;
         case "chastity_0_endBad":

--- a/scripts/room/room206.js
+++ b/scripts/room/room206.js
@@ -175,7 +175,7 @@ room206.chatcatch = function (callback) {
                 }
                 if (g.internal[1].b[1].a) {
                     img = g.internal[1].b[1].t;
-                    levels.mod("pi", 20, 1);
+                    levels.mod("pi", 20);
                     chat(3, 206);
                 }
                 else if (g.internal[1].b[2].a) {
@@ -197,7 +197,7 @@ room206.chatcatch = function (callback) {
             case "q2":
                 if (g.internal[2].b[0].a) {
                     img = g.internal[2].b[0].t;
-                    levels.mod("xdress", 10, 1);
+                    levels.mod("xdress", 10);
                     chat(7, 206);
                 }
                 else if (g.internal[2].b[1].a) {
@@ -222,12 +222,12 @@ room206.chatcatch = function (callback) {
             case "q3":
                 if (g.internal[3].b[0].a) {
                     img = g.internal[3].b[0].t;
-                    levels.mod("charisma", 20, 1);
+                    levels.mod("charisma", 20);
                     missy.mod("mood", 5);
                     chat(39, 206);
                 }
                 else {
-                    levels.mod("sub", 10, 1);
+                    levels.mod("sub", 10);
                     img = g.internal[3].b[1].t;
                     chat(40, 206);
                 }
@@ -250,7 +250,7 @@ room206.chatcatch = function (callback) {
                 else {
                     chat(10, 206);
                     img = g.internal[4].b[1].t;
-                    levels.mod("piss", 10, 1);
+                    levels.mod("piss", 10);
                 }
                 nav.killbutton("question");
                 nav.button({
@@ -272,7 +272,7 @@ room206.chatcatch = function (callback) {
                 else {
                     chat(13, 206);
                     img = g.internal[5].b[1].t;
-                    levels.mod("sub", 10, 1);
+                    levels.mod("sub", 10);
                 }
 
                 nav.killbutton("question");
@@ -294,13 +294,13 @@ room206.chatcatch = function (callback) {
                 else if (g.internal[6].b[1].a) {
                     chat(15, 206);
                     img = g.internal[6].b[1].t;
-                    levels.mod("dom", 10, 1);
+                    levels.mod("dom", 10);
                 }
                 else {
                     nav.bg("206_questions/butt.jpg");
                     chat(16, 206);
                     img = g.internal[6].b[2].t;
-                    levels.mod("sub", 10, 1);
+                    levels.mod("sub", 10);
                     missy.mod("mood", 5);
                 }
 
@@ -320,19 +320,19 @@ room206.chatcatch = function (callback) {
                 if (g.internal[7].b[0].a) {
                     chat(21, 206);
                     img = g.internal[7].b[0].t;
-                    levels.mod("pi", 20, 1);
+                    levels.mod("pi", 20);
                 }
                 else if (g.internal[7].b[1].a) {
                     chat(22, 206);
                     img = g.internal[7].b[1].t;
-                    levels.mod("charisma", 20, 1);
+                    levels.mod("charisma", 20);
                 }
                 else {
                     chat(23, 206);
                     img = g.internal[7].b[2].t;
-                    levels.mod("xdress", 20, 999);
-                    levels.mod("anal", 5, 1);
-                    levels.mod("oral", 5, 1);
+                    levels.mod("xdress", 20);
+                    levels.mod("anal", 5);
+                    levels.mod("oral", 5);
                 }
 
                 nav.killbutton("question");
@@ -356,15 +356,15 @@ room206.chatcatch = function (callback) {
                     nav.bg("206_questions/butt.jpg");
                     chat(25, 206);
                     img = g.internal[8].b[1].t;
-                    levels.mod("anal", 5, 1);
-                    levels.mod("oral", 5, 1);
+                    levels.mod("anal", 5);
+                    levels.mod("oral", 5);
                 }
                 else {
                     nav.bg("206_questions/butt.jpg");
                     chat(26, 206);
                     img = g.internal[8].b[2].t;
-                    levels.mod("anal", 5, 1);
-                    levels.mod("oral", 5, 1);
+                    levels.mod("anal", 5);
+                    levels.mod("oral", 5);
                     missy.mod("mood", 5);
                 }
 
@@ -405,7 +405,7 @@ room206.chatcatch = function (callback) {
                 }
                 else if (g.internal[9].b[4].a) {
                     gv.set("breastSelect", 6);
-                    levels.mod("xdress", 10, 1);
+                    levels.mod("xdress", 10);
                     img = g.internal[9].b[4].t;
                     chat(47, 206);
                 }
@@ -443,7 +443,7 @@ room206.chatcatch = function (callback) {
                 }
                 else if (g.internal[10].b[4].a) {
                     gv.set("assSelect", 5);
-                    levels.mod("xdress", 10, 1);
+                    levels.mod("xdress", 10);
                     img = g.internal[10].b[4].t;
                     chat(50, 206);
                 }
@@ -485,13 +485,13 @@ room206.chatcatch = function (callback) {
                 if (g.internal[12].b[0].a) {
                     nav.bg("206_questions/desk.jpg");
                     chat(27, 206);
-                    levels.mod("sub", 15, 1);
+                    levels.mod("sub", 15);
                     img = g.internal[12].b[0].t;
                 }
                 else {
                     nav.bg("206_questions/angry.jpg");
                     chat(28, 206);
-                    levels.mod("dom", 15, 1);
+                    levels.mod("dom", 15);
                     img = g.internal[12].b[1].t;
                 }
 

--- a/scripts/room/room211.js
+++ b/scripts/room/room211.js
@@ -244,7 +244,7 @@ room211.btnclick = function (name) {
             }
             break;
         case "icon_dress":
-            levels.mod("xdress", 10, 7);
+            levels.mod("xdress", 10);
             cl.c.bra = "p";
             cl.c.pants = "ss";
             cl.c.shirt = "ss";
@@ -256,7 +256,7 @@ room211.btnclick = function (name) {
             char.room(211);
             break;
         case "icon_dress1":
-            levels.mod("xdress", 20, 7);
+            levels.mod("xdress", 20);
             cl.nude();
             cl.c.pants = "sq";
             cl.c.shirt = "sq";

--- a/scripts/room/room212.js
+++ b/scripts/room/room212.js
@@ -160,7 +160,7 @@ room212.btnclick = function (name) {
             else {
                 gv.mod("money", -5);
                 gv.mod("energy", 60);
-                levels.mod("fitness", -25, 999);
+                levels.mod("fitness", -25);
             }
             break;
         case "chips":

--- a/scripts/room/room214.js
+++ b/scripts/room/room214.js
@@ -88,10 +88,10 @@ room214.btnclick = function (name) {
         case "gw4":
             nav.killall();
             nav.bg("214_pinkgame/gw1.jpg");
-            levels.mod("xdress", 20, 999);
+            levels.mod("xdress", 20);
             gv.mod("energy", -25);
             levels.mod("whore", 25);
-            levels.mod("fame", 10, 999);
+            levels.mod("fame", 10);
             gv.mod("pink", 1);
             char.addtime(47);
             chat(6, 214);
@@ -118,7 +118,7 @@ room214.chatcatch = function (callback) {
             break;
         case "gmEnd":
             gv.mod("energy", -33);
-            levels.mod("fame", 10, 999);
+            levels.mod("fame", 10);
             levels.mod("whore", 25);
             levels.oral(3, "m", "!man", true);
             gv.mod("pink", 1);
@@ -139,8 +139,8 @@ room214.chatcatch = function (callback) {
             }, 214);
             break;
         case "groupEnd":
-            levels.mod("fame", 20, 999);
-            levels.mod("xdress", 40, 999);
+            levels.mod("fame", 20);
+            levels.mod("xdress", 40);
             gv.mod("pink", 1);
             levels.mod("whore", 25);
             levels.anal(3, true, "m", true, "!gameman");

--- a/scripts/room/room216.js
+++ b/scripts/room/room216.js
@@ -51,7 +51,7 @@ room216.btnclick = function (name) {
             nav.killall();
             nav.bg("216_pinkglory/pull3_" + gender.pronoun("f") + ".jpg");
             cl.c.cumface = true;
-            levels.mod("cum", 20, 999);
+            levels.mod("cum", 20);
             chat(5, 216);
             break;
         case "plugclean":
@@ -112,7 +112,7 @@ room216.btnclick = function (name) {
             nav.killall();
             nav.bg("216_pinkglory/clean_" + gender.pronoun("f") + ".jpg");
             gv.mod("energy", 100);
-            levels.mod("cum", 25, 999);
+            levels.mod("cum", 25);
             chat(7, 216);
             break;
     }

--- a/scripts/room/room217.js
+++ b/scripts/room/room217.js
@@ -32,11 +32,11 @@ room217.chatcatch = function (callback) {
             else
                 nav.bg("217_punish/squeezef.jpg");
 
-            levels.mod("dom", 20, 999);
+            levels.mod("dom", 20);
             missy.mod("mood", -10);
             break;
         case "disrobeVoluntary":
-            levels.mod("sub", 20, 999);
+            levels.mod("sub", 20);
             room217.chatcatch("disrobe");
             break;
         case "disrobe":
@@ -108,7 +108,7 @@ room217.chatcatch = function (callback) {
             }
             break;
         case "punishmentEnd":
-            levels.mod("sub", 50, 999);
+            levels.mod("sub", 50);
             gv.set("energy", 0);
             char.settime(17, 35);
             char.room(0);

--- a/scripts/room/room219.js
+++ b/scripts/room/room219.js
@@ -85,7 +85,7 @@ room219.btnclick = function (name) {
             }, 219);
             missy.st[13].c++;
             g.roomTimeout = setTimeout(function () {
-                levels.mod("sub", 50, 1);
+                levels.mod("sub", 50);
                 chat(6, 219);
                 room219.btnclick("hypnoComplete");
             }, 7000);
@@ -119,9 +119,8 @@ room219.btnclick = function (name) {
                 case "hypno4":
                     missy.st[16].c++;
                     hchatid = 12;
-                    var wi = levels.i("strength");
-                    if (levels.st[wi].l > 0) {
-                        levels.st[wi].l--;
+                    if (levels.get("strength").l > 0) {
+                        levels.modLevel("strength", -1);
                         g.popUpNotice("You are now weaker. ");
                     }
                     break;
@@ -150,9 +149,8 @@ room219.btnclick = function (name) {
                     "height": 411,
                     "image": "219_dataEntry/hypno4.jpg"
                 }, 219);
-                var wi1 = levels.i("strength");
-                if (levels.st[wi1].l > 0) {
-                    levels.st[wi1].l--;
+                if (levels.get("strength").l > 0) {
+                    levels.modLevel("strength", -1);
                     g.popUpNotice("You are now weaker. ");
                 }
                 g.roomTimeout = setTimeout(function () {

--- a/scripts/room/room221.js
+++ b/scripts/room/room221.js
@@ -309,7 +309,7 @@ room221.chatcatch = function (callback) {
             nav.bg("221_recip/" + callback + ".jpg");
             break;
         case "jefferyPanties1":
-            levels.mod("xdress", 10, 8);
+            levels.mod("xdress", 10);
             gv.mod("money", 50);
             nav.bg("221_recip/jefferyPanties1.jpg");
             break;
@@ -342,13 +342,13 @@ room221.chatcatch = function (callback) {
                 chat(400, 221);
             }
             else {
-                levels.mod("pi", 15, 999);
+                levels.mod("pi", 15);
                 chat(401, 221);
             }
             break;
         case "appNo":
             if (g.pass.events[0].pcDisplay === "Nothing") {
-                levels.mod("pi", 15, 999);
+                levels.mod("pi", 15);
                 chat(500, 221);
             }
             else
@@ -370,7 +370,7 @@ room221.chatcatch = function (callback) {
             break;
         case "zpeeguy2":
             missy.mod("mood", -20);
-            levels.mod("piss", 20, 999);
+            levels.mod("piss", 20);
             nav.bg("221_recip/blank.jpg");
 
             break;

--- a/scripts/room/room222.js
+++ b/scripts/room/room222.js
@@ -41,7 +41,7 @@ room222.btnclick = function (name) {
         case "laudry-panties":
             nav.killall();
             nav.bg("222_errands/laundry1-panties.jpg");
-            levels.mod("xdress", 25, 0);
+            levels.mod("xdress", 25);
             if (levels.get("xdress").l > 0 && !cl.hasClothing("panties", "missy")) {
                 chat(21, 222);
             }
@@ -189,7 +189,7 @@ room222.chatcatch = function (callback) {
             charisma.init(5, "case0charismaWin", "case0charismaLose", 222)
             break;
         case "case0-end":
-            levels.mod("pi", 20, 999); 
+            levels.mod("pi", 20); 
             room222.chatcatch("lunch");
             break;
         case "case0-2-bj":
@@ -220,7 +220,7 @@ room222.chatcatch = function (callback) {
             break;
         case "punishLunch":
             missy.didJob(4, .5, null);
-            levels.mod("pi", -10, 999); //pi skillz
+            levels.mod("pi", -10); //pi skillz
             g.pass = "punish";
             char.room(224);
             break;

--- a/scripts/room/room316.js
+++ b/scripts/room/room316.js
@@ -78,8 +78,8 @@ room316.main = function () {
                     if (!daily.get("dsniff")) {
                         daily.set("dsniff");
                         sc.modLevel("dog", 20, 5);
-                        levels.mod("sub", 15, 999);
-                        levels.mod("beast", 10, 0);
+                        levels.mod("sub", 15);
+                        levels.mod("beast", 10);
                     }
 
                     zcl.assup(650, 500, .55, "");
@@ -87,7 +87,7 @@ room316.main = function () {
                 }
                 else if (cl.c.dress !== null) {
                     gv.mod("arousal", 10);
-                    levels.mod("beast", 10, 0);
+                    levels.mod("beast", 10);
                     zcl.assup(650, 500, .55, "reddress");
                     nav.bg("316_livingroom/dog_snif.jpg");
                 }
@@ -313,8 +313,8 @@ room316.btnclick = function (name) {
             if (!daily.get("dsniff")) {
                 daily.set("dsniff");
                 sc.modLevel("dog", 20, 5);
-                levels.mod("sub", 15, 999);
-                levels.mod("beast", 10, 0);
+                levels.mod("sub", 15);
+                levels.mod("beast", 10);
             }
             char.room(316);
             break;
@@ -332,7 +332,7 @@ room316.btnclick = function (name) {
                     nav.bg("316_livingroom/pbStand.jpg");
                     daily.set("dpb");
                     sc.modLevel("dog", 50, 2);
-                    levels.mod("beast", 10, 0);
+                    levels.mod("beast", 10);
                     chat(88, 316);
                 }
             }
@@ -466,7 +466,7 @@ room316.btnclick = function (name) {
             }
             if (g.internal === 5) {
                 levels.anal(3, false, "m", true, "dog", "dog");
-                levels.mod("fame", 25, 999);
+                levels.mod("fame", 25);
                 nav.killbutton("dwalkfuck");
                 chat(101, 316);
             }
@@ -493,7 +493,7 @@ room316.btnclick = function (name) {
             nav.killall();
             nav.bg("316_livingroom/pbStand.jpg");
             daily.set("dpb");
-            levels.mod("beast", 10, 0);
+            levels.mod("beast", 10);
             sc.modLevel("dog", 50, 1);
             chat(88, 316);
             break;
@@ -512,7 +512,7 @@ room316.btnclick = function (name) {
         case "icon_dcrawlpbButt1":
             nav.killbutton("icon_dcrawlpbButt1");
             daily.set("dpb");
-            levels.mod("beast", 20, 4);
+            levels.mod("beast", 20);
             sc.modLevel("dog", 35, 999);
             chat(90, 316);
             break;
@@ -671,7 +671,7 @@ room316.btnclick = function (name) {
             nav.killall();
             nav.bg("316_livingroom/task0_2.jpg");
             sc.modLevel("dog", 30, 4);
-            levels.mod("beast", 15, 2);
+            levels.mod("beast", 15);
             nav.next("buildMenu");
             break;
         case "iconPb":
@@ -715,7 +715,7 @@ room316.btnclick = function (name) {
             break;
         case "iconDickx":
             if (cl.c.chastity === null) {
-                levels.mod("dom", 25, 999);
+                levels.mod("dom", 25);
                 nav.bg("316_livingroom/dick.jpg");
                 chat(116, 316);
             }
@@ -731,7 +731,7 @@ room316.btnclick = function (name) {
             g.pass.dick = true;
             nav.killall();
             if (cl.c.chastity === null) {
-                levels.mod("dom", 25, 999);
+                levels.mod("dom", 25);
                 nav.bg("316_livingroom/dick.jpg");
                 chat(81, 316);
             }
@@ -1005,11 +1005,11 @@ room316.chatcatch = function (callback) {
             break;
         case "likedom":
             sc.modLevel("janice", -25, 999);
-            levels.mod("dom", 30, 999);
+            levels.mod("dom", 30);
             break;
         case "sub":
             sc.modLevel("janice", 25, 999);
-            levels.mod("sub", 50, 999);
+            levels.mod("sub", 50);
             break;
        
         case "peanutbutter":
@@ -1231,7 +1231,7 @@ room316.chatcatch = function (callback) {
         //    char.room(0);
         //    break;
         case "cuck_1_complete":
-            levels.mod("xdress", 15, 999);
+            levels.mod("xdress", 15);
             sc.completeMissionTask("janice", "femdom", 5);
             daily.set("janice");
             char.addtime(60);

--- a/scripts/room/room319.js
+++ b/scripts/room/room319.js
@@ -52,9 +52,9 @@ room319.main = function () {
         displayMenu = false;
         daily.set("dpee");
         sc.modLevel("dog", 50, 999);
-        levels.mod("piss", 25, 999);
-        levels.mod("beast", 25, 999);
-        levels.mod("sub", 25, 999);
+        levels.mod("piss", 25);
+        levels.mod("beast", 25);
+        levels.mod("sub", 25);
         zcl.assup(600, 790, .55, "");
         nav.button({
             "type": "img",
@@ -149,7 +149,7 @@ room319.btnclick = function (name) {
                 if (!daily.get("dball")) {
                     daily.set("dball");
                     sc.modLevel("dog", 15, 4);
-                    levels.mod("beast", 15, 4);
+                    levels.mod("beast", 15);
                 }
                 nav.button({
                     "type": "img",
@@ -223,7 +223,7 @@ room319.chatcatch = function (callback) {
     switch (callback) {
         case "finishPeeing":
             gv.mod("arousal", 50);
-            levels.mod("piss", 25, 2);
+            levels.mod("piss", 25);
             gv.mod("bladder", -1);
             sc.modLevel("dog", 25, 5);
             char.room(319);

--- a/scripts/room/room326.js
+++ b/scripts/room/room326.js
@@ -164,14 +164,14 @@ room326.chatcatch = function (callback) {
             if (sc.getMission("rachel", "ranch").notStarted) {
                 g.internal = "brush";
                 sc.modLevel("horse", 40, 4);
-                levels.mod("beast", 34, 3);
+                levels.mod("beast", 34);
                 gv.mod("money", 20);
                 char.addtime(60);
                 char.room(0);
             }
             else {
                 sc.modLevel("horse", 40, 4);
-                levels.mod("beast", 34, 3);
+                levels.mod("beast", 34);
                 char.addtime(60);
                 char.room(329);
             }

--- a/scripts/room/room329.js
+++ b/scripts/room/room329.js
@@ -210,7 +210,7 @@ room329.btnclick = function (name) {
             g.map.jars[3].t--;
             g.popUpNotice("You drank cum");
             gv.mod("energy", 100);
-            levels.mod("xdress", 10, 999);
+            levels.mod("xdress", 10);
             levels.mod("cum", 25);
             if (g.room === 329)
                 room329.btnclick("icon_stall");
@@ -221,7 +221,7 @@ room329.btnclick = function (name) {
             g.map.jars[4].t--;
             g.popUpNotice("You drank doggy cum");
             gv.mod("energy", 150);
-            levels.mod("xdress", 10, 999);
+            levels.mod("xdress", 10);
             levels.mod("cum", 25);
             if (g.room === 329)
                 room329.btnclick("icon_stall");
@@ -232,7 +232,7 @@ room329.btnclick = function (name) {
             g.map.jars[5].t--;
             g.popUpNotice("You drank horsey cum");
             gv.mod("energy", 200);
-            levels.mod("xdress", 10, 999);
+            levels.mod("xdress", 10);
             levels.mod("cum", 25);
             if (g.room === 329)
                 room329.btnclick("icon_stall");
@@ -243,7 +243,7 @@ room329.btnclick = function (name) {
             g.map.jars[6].t--;
             g.popUpNotice("You drank piggy cum");
             gv.mod("energy", 300);
-            levels.mod("xdress", 10, 999);
+            levels.mod("xdress", 10);
             levels.mod("cum", 25);
             if(g.room === 329)
                 room329.btnclick("icon_stall");
@@ -300,7 +300,7 @@ room329.btnclick = function (name) {
                 }
             }
             gv.clearButtCum();
-            levels.mod("xdress", 15, 999);
+            levels.mod("xdress", 15);
             if (g.roomID === 328)
                 room328.btnclick("icon_bedturn");
             else

--- a/scripts/room/room350.js
+++ b/scripts/room/room350.js
@@ -153,7 +153,7 @@ room350.chatcatch = function (callback) {
             sc.startMission("raven", "bitch");
             sc.completeMissionTask("raven", "bitch", 0);
             sc.show("raven");
-            levels.mod("pi", 30, 999);
+            levels.mod("pi", 30);
             char.addtime(20);
             nav.bg("350_spermBank/350_spermbank.jpg");
             nav.button({

--- a/scripts/room/room461.js
+++ b/scripts/room/room461.js
@@ -68,7 +68,7 @@ room461.main = function () {
                 }
 
                 gv.mod("energy", -30);
-                levels.mod("fitness", 30, 999);
+                levels.mod("fitness", 30);
                 char.addtime(60);
 
                 if (cl.c.chest < 1)
@@ -79,7 +79,7 @@ room461.main = function () {
         }
         else {
             gv.mod("energy", -30);
-            levels.mod("fitness", 30, 999);
+            levels.mod("fitness", 30);
             char.addtime(60);
 
             if (cl.c.chest < 1)
@@ -156,7 +156,7 @@ room461.btnclick = function (name) {
             nav.killall();
             nav.bg("461_run/path2.jpg");
             gv.mod("energy", -30);
-            levels.mod("fitness", 30, 999);
+            levels.mod("fitness", 30);
             char.addtime(60);
 
             if (cl.c.chest < 1)
@@ -182,7 +182,7 @@ room461.btnclick = function (name) {
                 sc.show("ppgirl");
             if (sc.getMission("ppgirl", "pp").notStarted) {
                 sc.modLevel("ppgirl", 100, 2);
-                levels.mod("piss", 25, 1);
+                levels.mod("piss", 25);
                 sc.startMission("ppgirl", "pp");
                 sc.completeMissionTask("ppgirl", "pp", 0);
                 nav.killall();
@@ -191,13 +191,13 @@ room461.btnclick = function (name) {
                 chat(22, 461);
             }
             else if (ppgirlStep === 1) {
-                levels.mod("piss", 25, 1);
+                levels.mod("piss", 25);
                 nav.killall();
                 nav.bg("461_run/pee3.jpg");
                 chat(25, 461);
             }
             else if (ppgirlStep === 2) {
-                levels.mod("piss", 25, 1);
+                levels.mod("piss", 25);
                 nav.killall();
                 nav.bg("461_run/pee3.jpg");
                 sc.setEvent("ppgirl", 2);
@@ -212,7 +212,7 @@ room461.btnclick = function (name) {
         case "pppee":
             nav.killall();
             if (levels.get("piss") < 2) {
-                levels.mod("piss", 25, 1);
+                levels.mod("piss", 25);
                 chat(37, 461);
             }
             else {
@@ -230,7 +230,7 @@ room461.btnclick = function (name) {
         case "ppcup":
             nav.killall();
             if (levels.get("piss") < 2) {
-                levels.mod("piss", 25, 1);
+                levels.mod("piss", 25);
                 chat(46, 461);
             }
             else {
@@ -253,7 +253,7 @@ room461.btnclick = function (name) {
             nav.bg("461_run/pee5.jpg");
             inv.use("emptyjar");
             inv.add("pissjargirl");
-            levels.mod("piss", 15, 999);
+            levels.mod("piss", 15);
             chat(29, 461);
             break;
         default:
@@ -368,7 +368,7 @@ room461.chatcatch = function (callback) {
         case "completeRun":
             nav.bg("461_run/path2.jpg");
             gv.mod("energy", -30);
-            levels.mod("fitness", 30, 999);
+            levels.mod("fitness", 30);
             char.addtime(60);
 
             if (cl.c.chest < 1)
@@ -409,13 +409,13 @@ room461.chatcatch = function (callback) {
             break;
        
         case "ppsub":
-            levels.mod("sub", 15, 999);
+            levels.mod("sub", 15);
             break;
         case "pporal":
-            levels.mod("oral", 15, 999);
+            levels.mod("oral", 15);
             break;
         case "ppcharisma":
-            levels.mod("charisma", 15, 999);
+            levels.mod("charisma", 15);
             break;
         case "pp5":
             sc.modLevel("ppgirl", 100, 4);
@@ -426,7 +426,7 @@ room461.chatcatch = function (callback) {
             //sc.completeMissionTask("ppgirl", "pp", 2);
             nav.bg("461_run/path2.jpg");
             gv.mod("energy", -30);
-            levels.mod("fitness", 30, 999);
+            levels.mod("fitness", 30);
             char.addtime(60);
 
             if (cl.c.chest < 1)

--- a/scripts/room/room486.js
+++ b/scripts/room/room486.js
@@ -798,18 +798,12 @@ room486.btnclick = function (name) {
             nav.killbutton("room8_0");
             nav.killbutton("room8_1");
             if (g.rand(0, 2) === 0) {
-                pil = levels.get("pi");
-                if (pil.l < 1)
-                    pil.l = 1;
-                levels.set("pi", 0, pil.l - 1);
+                levels.modLevel("pi", -1, true);
                 g.popUpNotice("You have become dumber");
                 chat(24, 486);
             }
             else {
-                pil = levels.get("strength");
-                if (pil.l < 1)
-                    pil.l = 1;
-                levels.set("strength", 0, pil.l - 1);
+                levels.modLevel("strength", -1, true);
                 g.popUpNotice("You have become weaker");
                 chat(25, 486);
             }

--- a/scripts/room/room526.js
+++ b/scripts/room/room526.js
@@ -290,7 +290,7 @@ room526.chatcatch = function (callback) {
         case "sex1_15":
             sc.completeMissionTask("zoey", "sex", 2);
             levels.piss(false, false, true, "f", "stormy");
-            levels.mod("xdress", 40, 999);
+            levels.mod("xdress", 40);
             sc.show("stormy");
             sc.startMission("stormy", "property");
             sc.completeMissionTask("stormy", "property", 0);

--- a/scripts/room/room527.js
+++ b/scripts/room/room527.js
@@ -139,7 +139,7 @@ room527.chatcatch = function (callback) {
             break;
         case "w2":
             if (levels.get("piss").l < 5) {
-                levels.mod("piss", 15, 999);
+                levels.mod("piss", 15);
                 chat(11, 527);
             }
             else {

--- a/scripts/room/room551.js
+++ b/scripts/room/room551.js
@@ -288,8 +288,8 @@ room551.chatcatch = function (callback) {
             break;
         case "workedout":
             gv.mod("energy", -50);
-            levels.mod("fitness", 15, 999);
-            levels.mod("strength", 34, 999);
+            levels.mod("fitness", 15);
+            levels.mod("strength", 34);
             sc.completeMissionTask("g", "workout", 1, true);
             daily.set("g");
             nav.killall();
@@ -381,8 +381,8 @@ room551.chatcatch = function (callback) {
             break;
         case "endDay":
             gv.mod("energy", -50);
-            levels.mod("fitness", 15, 999);
-            levels.mod("strength", 30, 999);
+            levels.mod("fitness", 15);
+            levels.mod("strength", 30);
             daily.set("g");
             nav.killall();
             nav.bg("551_gymInside/551_gym.jpg");
@@ -460,7 +460,7 @@ room551.chatcatch = function (callback) {
             break;
         case "completeRun":
             gv.mod("energy", -30);
-            levels.mod("fitness", 51, 999);
+            levels.mod("fitness", 51);
             char.addtime(47);
             char.room(551);
             break;

--- a/scripts/room/room555.js
+++ b/scripts/room/room555.js
@@ -425,22 +425,22 @@ room555.chatcatch = function (callback) {
             setTimeout(function () { chat(15, 555); }, 5000);
             break;
         case "exitUpper":
-            levels.mod("strength", 55, 999);
-            levels.mod("fitness", 15, 999);
+            levels.mod("strength", 55);
+            levels.mod("fitness", 15);
             gv.mod("energy", -75);
             char.addtime(60);
             char.room(555);
             break;
         case "exitCardio":
-            levels.mod("fitness", 85, 999);
+            levels.mod("fitness", 85);
             gv.mod("energy", -75);
             levels.anal(3);
             char.addtime(60);
             char.room(555);
             break;
         case "exitMachine":
-            levels.mod("fitness", 50, 999);
-            levels.mod("strength", 25, 999);
+            levels.mod("fitness", 50);
+            levels.mod("strength", 25);
             gv.mod("energy", -75);
             levels.anal(3);
             char.addtime(60);
@@ -451,8 +451,8 @@ room555.chatcatch = function (callback) {
             room555.chatcatch("exitUpper");
             break;
         case "exitOral":
-            levels.mod("strength", 55, 999);
-            levels.mod("fitness", 15, 999);
+            levels.mod("strength", 55);
+            levels.mod("fitness", 15);
             gv.mod("energy", -75);
             levels.oral(3);
             char.addtime(60);
@@ -630,8 +630,8 @@ room555.chatcatch = function (callback) {
             nav.drawButton("555_backgym/down.png", "chad_squats");
             break;
         case "squatEnd":
-            levels.mod("fitness", 50, 999);
-            levels.mod("strength", 25, 999);
+            levels.mod("fitness", 50);
+            levels.mod("strength", 25);
             gv.mod("energy", -75);
             levels.anal(4, false, "m", true, "chad");
             char.addtime(60);

--- a/scripts/room/room556.js
+++ b/scripts/room/room556.js
@@ -96,7 +96,7 @@ room556.btnclick = function (name) {
                 nav.bg("556_spar/loss" + g.internal + appendString + ".jpg");
                 if (g.internal === 6) {
                     levels.anal(3, true, "f", false, "g");
-                    levels.mod("fame", 30, 999);
+                    levels.mod("fame", 30);
                 }
             }
             else {

--- a/scripts/room/room575.js
+++ b/scripts/room/room575.js
@@ -90,7 +90,7 @@ room575.chatcatch = function (callback) {
         case "e_footsie3":
             nav.bg("575_fastfood/" + callback + ".jpg");
             levels.gavefootjob("m", "elijah");
-            levels.mod("xdress", 50, 999);
+            levels.mod("xdress", 50);
             break;
         case "e_horny2":
         case "e_horny":
@@ -98,7 +98,7 @@ room575.chatcatch = function (callback) {
         case "e_footsie2":
             nav.bg("575_fastfood/" + callback + ".jpg");
             g.popUpNotice("Elijah liked that");
-            levels.mod("pi", 15, 999);
+            levels.mod("pi", 15);
             break;
         
         case "e_fail":
@@ -112,7 +112,7 @@ room575.chatcatch = function (callback) {
             break;
         case "like":
             g.popUpNotice("Elijah liked that");
-            levels.mod("pi", 20, 999);
+            levels.mod("pi", 20);
             break;
         case "hit1":
             if (cl.c.cumface)

--- a/scripts/room/room661.js
+++ b/scripts/room/room661.js
@@ -51,7 +51,7 @@ room661.chatcatch = function (callback) {
         case "recycle":
             char.addtime(60);
             g.internal++;
-            levels.mod("pi", 2, 3);
+            levels.mod("pi", 2);
             if (g.internal > 0 && missy.get("reusableCaseCounter") > 1) {
                 nav.bg("661_peephole/661_peephole8.jpg");
                 chat(17, 661);

--- a/scripts/room/room700.js
+++ b/scripts/room/room700.js
@@ -91,7 +91,7 @@ room700.chatcatch = function (callback) {
             cl.display();
             break;
         case "nurseApply":
-            levels.mod("xdress", 5, 1);
+            levels.mod("xdress", 5);
             gv.set("jobapplynurse", 2);
             char.room(700);
             break;

--- a/scripts/room/room701.js
+++ b/scripts/room/room701.js
@@ -29,23 +29,23 @@ room701.chatcatch = function (callback) {
             char.room(0);
             break;
         case "wake1":
-            levels.mod("charisma", 20, 999);
+            levels.mod("charisma", 20);
             nav.bg("701_hospitalroom/wake1.jpg");
             break;
         case "wake1CheckDick":
             if (cl.c.chastity !== null) {
                 nav.bg("701_hospitalroom/wake1laugh.jpg");
-                levels.mod("charisma", -20, 999);
+                levels.mod("charisma", -20);
                 chat(3, 701);
             }
             else if (cl.c.cock > 1) {
                 nav.bg("701_hospitalroom/wake1laugh.jpg");
-                levels.mod("charisma", -10, 999);
+                levels.mod("charisma", -10);
                 chat(4, 701);
             }
             else {
                 nav.bg("701_hospitalroom/wake2.jpg");
-                levels.mod("charisma", 30, 999);
+                levels.mod("charisma", 30);
                 chat(5, 701);
             }
             break;

--- a/scripts/room/room725.js
+++ b/scripts/room/room725.js
@@ -90,7 +90,7 @@ room725.btnclick = function (name) {
             }
             else {
                 gv.mod("money", -15);
-                levels.mod("xdress", 4, 999);
+                levels.mod("xdress", 4);
                 char.addtime(20);
                 beer725 = levels.beer(1);
                 g.internal = { n: "Pink Barbie Cocktail ", b: beer725 };
@@ -225,7 +225,7 @@ room725.chatcatch = function (callback) {
             levels.oral(3, "f", "chloe");
             levels.fuckass("chloe", "f");
             levels.fuckpussy("!emily");
-            levels.mod("xdress", 25, 999);
+            levels.mod("xdress", 25);
             char.addtime(185);
             char.room(0);
             break;

--- a/scripts/room/room750.js
+++ b/scripts/room/room750.js
@@ -360,10 +360,10 @@ room750.chatcatch = function (callback) {
             char.room(750);
             break;
         case "char":
-            levels.mod("charisma", 40, 999);
+            levels.mod("charisma", 40);
             break;
         case "int":
-            levels.mod("pi", 40, 999);
+            levels.mod("pi", 40);
             break;
         case "pocketSand":
             if (inv.get("pocketsand").count > 0) {

--- a/scripts/room/room752.js
+++ b/scripts/room/room752.js
@@ -91,11 +91,11 @@ room752.btnclick = function (name) {
                 chat(16, 752);
             break;
         case "charisma_win":
-            levels.mod("charisma", 25, 999);
+            levels.mod("charisma", 25);
             chat(12, 752);
             break;
         case "charisma_lose":
-            levels.mod("charisma", 15, 999);
+            levels.mod("charisma", 15);
             missy.set("reusableCaseCounter", 1);
             chat(15, 752);
             break;
@@ -141,13 +141,13 @@ room752.chatcatch = function (callback) {
             }
             break;
         case "getlocket":
-            levels.mod("pi", 100, 999);
+            levels.mod("pi", 100);
             inv.add("locket");
             missy.set("activeCaseComplete", 1);
             nav.bg("752_whore/bg.jpg");
             break;
         case "getlocketPanties":
-            levels.mod("pi", 100, 999);
+            levels.mod("pi", 100);
             inv.add("locket");
             missy.set("activeCaseComplete", 1);
             nav.killall();

--- a/scripts/room/room776.js
+++ b/scripts/room/room776.js
@@ -151,7 +151,7 @@ room776.chatcatch = function (callback) {
                 chat(2, 776);
             else {
                 daily.set("pray_pi");
-                levels.modLevel("pi", -1);
+                levels.modLevel("pi", -1, false, true);
                 chat(3, 776);
             }
             break;
@@ -166,7 +166,7 @@ room776.chatcatch = function (callback) {
                 chat(2, 776);
             else {
                 daily.set("pray_strength");
-                levels.modLevel("strength", -1);
+                levels.modLevel("strength", -1, false, true);
                 chat(3, 776);
             }
             break;

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -32,10 +32,7 @@ sstat.updateGraph = function () {
 
     for (i = 0; i < levels.st.length; i++) {
         if (levels.st[i].display) {
-            if (levels.st[i].compoundLevel)
-                barWidth = (levels.st[i].c / levels.getCap(levels.st[i].l)) * 100
-            else
-                barWidth = levels.st[i].c;
+            barWidth = (levels.st[i].c / levels.getPointsCapForLevel(levels.st[i])) * 100;
 
             var levelDesc = levels.desc(levels.st[i].n, levels.st[i].l);
             //console.log($(".rl-levelheader[data-name='" + levels.st[i].n + "']"));

--- a/scripts/trap.js
+++ b/scripts/trap.js
@@ -1469,19 +1469,12 @@ room1005.chatcatch = function (callback) {
                     }, 6000);
                     break;
                 default:
-                    var pil
                     if (g.rand(0, 2) === 0) {
-                        pil = levels.get("pi");
-                        if (pil.l < 1)
-                            pil.l = 1;
-                        levels.set("pi", 0, pil.l - 1);
+                        levels.modLevel("pi", -1);
                         g.popUpNotice("You have become dumber");
                     }
                     else {
-                        pil = levels.get("strength");
-                        if (pil.l < 1)
-                            pil.l = 1;
-                        levels.set("strength", 0, pil.l - 1);
+                        levels.modLevel("strength", -1);
                         g.popUpNotice("You have become weaker");
                     }
                     chat(40, 1005);


### PR DESCRIPTION
I refactored those levels.mod/modLevel functions quite a bit as I think there some bigger inconsistencies there.
List of changes:

- Removed leftover 3rd parameter from many `levels.mod()` calls (e.g. `levels.mod("sub", 15, 999)` -> `levels.mod("sub", 15)`)
- Replaced `levels.set()` calls with `levels.modLevel()` calls where it was sensible (relative level change) 
- A level cap (15) was inconsistently and hardcoded applied in the mod function.
Made this consistent and configurable per level-stat
(kept 15 as default and set "xdress" to 100 as I think there a larger cap makes sense as it is used as a resource pool for transformation points and it also has a linear 100 points cap per level)
- Refactored the `levels.mod()` function, keeping the old behavior in general but removing the old inconsistencies that just didn't make sense:
    * Level and level points cap consistently checked and applied after changes (before level cap of was applied only when reducing points [amount < 0] or used for non-autolevel stats)
    * If a level-stat was autoLevel==false but compoundLevel==true, compoundLevel was ignored and fixed points cap of 100 was used.
    Changed that to apply compoundLevel correctly regardles of autoLevel.
    Only currently affected the "cheer" stat, configured that for compoundLevel==false to keep original behaviour (though has little impact anyway, see minor notes regarding "cheer" at the end)
    * Consistent format for display messages
- Brought `levels.modLevel()` in line with the changes to mod:
    * Same logic for applying level caps as mod
    * Same format for display messages as mod
    * Option to show display message or reset points to 0 when changing level
        This is to keep behaviour existing options, like when the caller handles it's own notice or set the points to 0 via levels.set
    * If not set to 0, current points are rescaled to match the relative progress in the level. Otherwise when decreasing a level with compoundLevel==true, you could end up with points greater than the points cap for that level. I think keeping the relative progress makes the most sense when not forcing it to 0.
- Some minor improvents like replacing calls to a specific level by its index number to the more readable and robust call by its name.
    
Minor notes:

- "cheer": This is almost exclusively controlled by directly setting an absolute value via levels.set(). There is only one call using mod (`levels.mod("cheer", 32);` in `room010.js`). I am not sure if that is intended as it does not fall in line with rest.
Also as mentioned above, "cheer" was the only stat with autoLevel==false and compoundLevel==true, but due to weird behaviour in the mod function that combination would ignore the compounding in the mod function and there is also no levels.set on "cheer" that would set any points higher than 100. Thats why I changed it to compoundLevel==false.

- In `room556.js` there is one statement `else if (levels.get("strength").l < 50) {`. This seems unintentional to me, as "strength" is a compoundLevel it would take almost 700 million points to bring it to level 50.