### PR TITLE
Add invoker dispatch and shared UI cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <script src="./scripts/jquery-3.2.1.min.js" type="text/javascript"></script>
 
     <script src="./scripts/global.js" type="text/javascript"></script>
+    <script src="./scripts/invoker.js" type="text/javascript"></script>
     <script src="./scripts/gamevariables.js" type="text/javascript"></script>
     <script src="./scripts/clothes.js" type="text/javascript"></script>
     <script src="./scripts/clothes_zcl.js" type="text/javascript"></script>
@@ -382,7 +383,7 @@
             <div id="room_left_map" class="left-menu">
             </div>
             <div id="room_left_walk" class="left-menu">
-                <div id="room_left_walk_sub" class="resize"></div>
+                <div id="room_left_walk_sub" class="glob-bg"></div>
             </div>
             <div id="room_left_graph" class="left-menu">
                 <div style="padding:5px; color: #fff; text-align:center;" class="glob-bg">
@@ -667,7 +668,7 @@
         <img src="./images/general/btnGraph.jpg" title="Graph" style="width:100%;" />
     </button>
     <button class="resize rl-change" data-type="walk" style="display:none;">
-        <img src="./images/general/btnHide.jpg" title="Walkthrough" style="width:100%;" />
+        <img src="./images/general/btnHide.jpg" title="History" style="width:100%;" />
     </button>
     <img src="./images/room/1001_rand/back_1.png" class="help-history hover-noevent" title="Back" style="width: 200px; height: 66.6px; z-index: 100; top:75px; left: 30px; position: absolute; display:none;" id="help_backButton" />
 </body>

--- a/scripts/char.js
+++ b/scripts/char.js
@@ -2,6 +2,104 @@
 var menu = {};
 //char.clothesholder = null;
 
+char.isTypingTarget = function (target) {
+    if (!target)
+        return false;
+
+    var tagName = target.tagName ? target.tagName.toLowerCase() : "";
+    return tagName === "input" || tagName === "textarea" || tagName === "select" || target.isContentEditable;
+};
+
+char.toggleMainInventoryHotkey = function () {
+    if (!$("#room-inv").is(":visible"))
+        return false;
+
+    if (inv.isOpen) {
+        inv.close();
+        return true;
+    }
+
+    return inv.openMain();
+};
+
+char.getVisibleAdvanceRoomButtons = function (selector) {
+    var buttons = $('#room-buttons .rom-event:visible').filter(function () {
+        var name = $(this).data('name');
+        return name !== "zzzNOOPzzzIgnore";
+    });
+
+    if (selector)
+        buttons = buttons.filter(selector);
+
+    return buttons;
+};
+
+char.getSingleSharedActionButton = function (buttons) {
+    if (buttons.length === 1)
+        return buttons.eq(0);
+    if (buttons.length === 0)
+        return null;
+
+    var firstName = buttons.eq(0).data('name');
+    var firstRoom = buttons.eq(0).data('room');
+    var isSingleAction = true;
+
+    buttons.each(function () {
+        if ($(this).data('name') !== firstName || $(this).data('room') !== firstRoom) {
+            isSingleAction = false;
+            return false;
+        }
+    });
+
+    return isSingleAction ? buttons.eq(0) : null;
+};
+
+char.isLegacySpaceAdvanceButton = function (button) {
+    var $button = $(button);
+    var name = ($button.data('name') || "").toString().toLowerCase();
+    var image = ($button.attr('src') || "").toString().toLowerCase();
+
+    if (name.indexOf("cancel") !== -1 || name.indexOf("back") !== -1 || name.indexOf("exit") !== -1)
+        return true;
+
+    return image.indexOf("/next.png") !== -1 ||
+        image.indexOf("/back.png") !== -1 ||
+        image.indexOf("/cancel.png") !== -1 ||
+        image.indexOf("/close.png") !== -1 ||
+        image.indexOf("/up.png") !== -1 ||
+        image.indexOf("/down.png") !== -1;
+};
+
+char.getSingleAdvanceRoomButton = function () {
+    var explicitAdvanceButtons = char.getVisibleAdvanceRoomButtons('[data-space-advance="true"]');
+    var explicitButton = char.getSingleSharedActionButton(explicitAdvanceButtons);
+    if (explicitButton !== null)
+        return explicitButton;
+
+    var legacyAdvanceButtons = char.getVisibleAdvanceRoomButtons().filter(function () {
+        return char.isLegacySpaceAdvanceButton(this);
+    });
+
+    return char.getSingleSharedActionButton(legacyAdvanceButtons);
+};
+
+char.triggerSpaceAdvanceHotkey = function () {
+    if ($('.room-nativeChoice:visible').length > 0)
+        return false;
+
+    var button = char.getSingleAdvanceRoomButton();
+    if (button === null)
+        return false;
+
+    button.click();
+    return true;
+};
+
+char.roomWithoutHistory = function (roomID) {
+    g.skipNextRoomSave = true;
+    char.room(roomID);
+};
+
 $(document).ready(function () {
 
     nav.setRatio();
@@ -13,13 +111,16 @@ $(document).ready(function () {
     //    $('.menu-close').click();
     //});
     $('#room_footer').on('click', '.room-changeRoomBtn', function () {
-        char.room(parseInt($(this).data('roomid')));
+        var targetRoomID = parseInt($(this).data('roomid'));
+        if (g.roomID === 401 && typeof room401 !== "undefined")
+            room401.restoreExitState(targetRoomID);
+        char.room(targetRoomID);
     });
 
     $('#room-buttons').on('click', '.rom-event', function () {
         var name = $(this).data('name');
         var roomID = parseInt($(this).data('room'));
-        window[g.room(roomID)]["btnclick"](name);
+        invoker.invoke(roomID, "btnclick", name);
     });
 
     $('#room_closeVideo').click(function () {
@@ -32,8 +133,7 @@ $(document).ready(function () {
         else
             g.pastSaves.splice(g.pastSaves.length - 1, 1);
         privateChat.kill();
-        clearTimeout(g.roomTimeout);
-        clearTimeout(g.roomTimeout2);
+        nav.clearRoomTimeouts();
         char.import(g.pastSaves[g.pastSaves.length - 1].data);
         g.pastSaves.splice(g.pastSaves.length - 1, 1);
         char.makeWalk();
@@ -48,49 +148,11 @@ $(document).ready(function () {
         g.setRatio();
         var gameWidth = 1920 * g.ratio;
         var gameHeight = 1080 * g.ratio;
-        let w, h, t, l, f;
         cl.display();
         $('#room-background').find('img').css({ "width": gameWidth + "px", "height": gameHeight + "px" });
-        $('#room-buttons').find('img').each(function () {
-            w = $(this).css("width").replace('px', '') / ogRatio;
-            h = $(this).css("height").replace('px', '') / ogRatio;
-            t = $(this).css("top").replace('px', '') / ogRatio;
-            l = $(this).css("left").replace('px', '') / ogRatio;
-            $(this).css({
-                "width": (w * g.ratio) + "px",
-                "height": (h * g.ratio) + "px",
-                "top": (t * g.ratio) + "px",
-                "left": (l * g.ratio) + "px"
-            });
-        });
-
-        $(".resize").each(function () {
-            w = $(this).css("width").replace('px', '') / ogRatio;
-            h = $(this).css("height").replace('px', '') / ogRatio;
-            t = $(this).css("top").replace('px', '') / ogRatio;
-            l = $(this).css("left").replace('px', '') / ogRatio;
-            $(this).css({
-                "width": (w * g.ratio) + "px",
-                "height": (h * g.ratio) + "px",
-                "top": (t * g.ratio) + "px",
-                "left": (l * g.ratio) + "px"
-            });
-        });
-
-        $(".resize-font").each(function () {
-            w = $(this).css("width").replace('px', '') / ogRatio;
-            h = $(this).css("height").replace('px', '') / ogRatio;
-            t = $(this).css("top").replace('px', '') / ogRatio;
-            l = $(this).css("left").replace('px', '') / ogRatio;
-            f = $(this).css("font-size").replace('px', '') / ogRatio;
-            $(this).css({
-                //"width": (w * g.ratio) + "px",
-                //"height": (h * g.ratio) + "px",
-                "top": (t * g.ratio) + "px",
-                "left": (l * g.ratio) + "px",
-                "font-size": (f * g.ratio) + "px"
-            });
-        });
+        char.rescaleRoomImages($('#room-buttons').find('img'), ogRatio);
+        char.rescalePositionedElements($(".resize"), ogRatio);
+        char.rescaleFontElements($(".resize-font"), ogRatio);
 
         $('.room-left').css({ "height": 1050 * g.ratio + "px", "top": (30 * g.ratio) + "px" });
 
@@ -101,59 +163,21 @@ $(document).ready(function () {
             width: 75 * g.ratio + "px",
             height: 75 * g.ratio + "px"
         });
-        $(".rl-change[data-type='body']").css({
-            left: "0px",
-            top: "0px",
-            width: 75 * g.ratio + "px",
-            height: 50 * g.ratio + "px"
-        });
-        $(".rl-change[data-type='map']").css({
-            left: 75 * g.ratio + "px",
-            top: "0px",
-            width: 75 * g.ratio + "px",
-            height: 50 * g.ratio + "px"
-        });
-        $(".rl-change[data-type='graph']").css({
-            left: 150 * g.ratio + "px",
-            top: "0px",
-            width: 75 * g.ratio + "px",
-            height: 50 * g.ratio + "px"
-        });
-        $(".rl-change[data-type='walk']").css({
-            left: 225 * g.ratio + "px",
-            top: "0px",
-            width: 75 * g.ratio + "px",
-            height: 50 * g.ratio + "px"
-        });
-        $(".left-menu").css({
-            width: 300 * g.ratio + "px",
-        });
-        $(".char-12").css({
-            "font-size": 12 * g.ratio + "px"
-        });
-        $(".char-20").css({
-            "font-size": 20 * g.ratio + "px"
-        });
         $(".char-30").css({
             "font-size": 30 * g.ratio + "px"
         });
-        $(".mt-10").css({
-            "margin-top": 20 * g.ratio + "px"
-        });
-        $(".mt-60").css({
-            "margin-top": 60 * g.ratio + "px"
-        });
-        $(".resize-height").css({
-            height: 12 * g.ratio + "px"
+        char.applyScaledShellStyles({
+            leftMenuWidth: 300,
+            menuBoxWidth: 300,
+            menuBoxHeight: 90,
+            menuBoxImgWidth: 296,
+            menuBoxImgHeight: 90,
+            resizeHeight: 12
         });
         $("#room_chatskip").css({
             "height": (54 * g.ratio) + "px",
             "width": (72 * g.ratio) + "px"
         });
-        $(".mt-300x").css({ "margin-top": (400 * g.ratio) + "px" });
-        $(".mt-50x").css({ "margin-top": (50 * g.ratio) + "px" });
-        $(".menu-box").css({ "width": (300 * g.ratio) + "px", "height": (90 * g.ratio) + "px", "margin-top": (15 * g.ratio) + "px" });
-        $(".menu-box-img").css({ "width": (296 * g.ratio) + "px", "height": (90 * g.ratio) + "px" });
         $("#help_backButton").css({"width": (200 * g.ratio) + "px", "height": (66.6 * g.ratio) + "px", "top": (75 * g.ratio) + "px", "left": (30 * g.ratio) + "px" });
         char.menu();
     };
@@ -183,7 +207,42 @@ $(document).ready(function () {
     });
 
     $("#room_export_hide").click(function () {
-        $("#room_export").slideUp();
+        char.hideExportDialog();
+    });
+
+    $(document).bind('keyup', function (e) {
+        if (e.which !== 73 || e.altKey || e.ctrlKey || e.metaKey)
+            return;
+        if (char.isTypingTarget(e.target))
+            return;
+        if ($('#room_export').is(":visible"))
+            return;
+        if ($('#room_chatOverlay').is(":visible"))
+            return;
+
+        if (char.toggleMainInventoryHotkey())
+            e.preventDefault();
+    });
+
+    $(document).bind('keyup', function (e) {
+        if (e.which !== 32 || e.altKey || e.ctrlKey || e.metaKey)
+            return;
+        if (char.isTypingTarget(e.target))
+            return;
+        if (g.suppressSpaceAdvanceKeyup) {
+            g.suppressSpaceAdvanceKeyup = false;
+            e.preventDefault();
+            return;
+        }
+        if ($('#room_export').is(":visible"))
+            return;
+        if ($('#room_chatOverlay').is(":visible"))
+            return;
+        if ($('#room-menuButtons').is(":visible"))
+            return;
+
+        if (char.triggerSpaceAdvanceHotkey())
+            e.preventDefault();
     });
 
     $('.char-modBtn').click(function () {
@@ -200,6 +259,220 @@ $(document).ready(function () {
             cl.display();
         }
     });
+    char.applyScaledShellStyles({
+        leftMenuWidth: 300,
+        menuBoxWidth: 290,
+        menuBoxHeight: 88,
+        menuBoxImgWidth: 290,
+        menuBoxImgHeight: 88,
+        resizeHeight: 4,
+        graphBarHeight: 15,
+        hideLeftMenu: true,
+        walkSubHeight: 1000
+    });
+    $(".rl-change").click(function () {
+        char.changeMenu($(this).data("type"), true, false);
+    });
+    $("#room-change").click(function () {
+        g.pass = g.roomID;
+        char.room(8);
+    });
+    $("#room-time").click(function () {
+        phone.build("time");
+        //$("#room-menu").click();
+        //menu.mClick("time");
+
+    });
+    $("#rl_pageSelect").children("button").click(function () {
+        g.statpage = $(this).data("number");
+        $(".rl-selectButton-active").removeClass("rl-selectButton-active");
+        $(this).addClass("rl-selectButton-active");
+        sstat.makeGraph();
+    });
+
+    $('.rl-bar').css({ "height": (15 * g.ratio) + "px" });
+    char.init();
+    char.resizewindow();
+});
+
+char.changeMenu = function (menu, update, override) {
+    if (update)
+        g.prevview = menu;
+    $("#help_backButton").hide();
+    switch (menu) {
+        case "body":
+            char.setMenuPanel("body", override);
+            break;
+        case "map":
+            char.setMenuPanel("map", override);
+            char.map();
+            break;
+        case "graph":
+            char.setMenuPanel("graph", override);
+            sstat.makeGraph();
+            break;
+        case "walk":
+            char.setMenuPanel("walk", override);
+            char.makeWalk();
+            break;
+        case "hide":
+            char.hideMenuPanels();
+            break;
+        default:
+            console.log("invalid menu: " + menu);
+            break;
+    }
+};
+
+char.showGameShell = function () {
+    $('.room-left').show();
+    $('#room_footer').show();
+    $(".room-topper").show();
+    $('.menu-tab').show();
+};
+
+char.rescaleRoomImages = function (elements, originalRatio) {
+    elements.each(function () {
+        const width = $(this).css("width").replace('px', '') / originalRatio;
+        const height = $(this).css("height").replace('px', '') / originalRatio;
+        const top = $(this).css("top").replace('px', '') / originalRatio;
+        const left = $(this).css("left").replace('px', '') / originalRatio;
+        $(this).css({
+            "width": (width * g.ratio) + "px",
+            "height": (height * g.ratio) + "px",
+            "top": (top * g.ratio) + "px",
+            "left": (left * g.ratio) + "px"
+        });
+    });
+};
+
+char.rescalePositionedElements = function (elements, originalRatio) {
+    elements.each(function () {
+        const css = {};
+        const width = $(this).css("width");
+        const height = $(this).css("height");
+        const top = $(this).css("top");
+        const left = $(this).css("left");
+
+        if (width.endsWith("px"))
+            css.width = ((parseFloat(width) / originalRatio) * g.ratio) + "px";
+        if (height.endsWith("px"))
+            css.height = ((parseFloat(height) / originalRatio) * g.ratio) + "px";
+        if (top.endsWith("px"))
+            css.top = ((parseFloat(top) / originalRatio) * g.ratio) + "px";
+        if (left.endsWith("px"))
+            css.left = ((parseFloat(left) / originalRatio) * g.ratio) + "px";
+
+        $(this).css(css);
+    });
+};
+
+char.rescaleFontElements = function (elements, originalRatio) {
+    elements.each(function () {
+        const css = {};
+        const top = $(this).css("top");
+        const left = $(this).css("left");
+        const fontSize = $(this).css("font-size");
+
+        if (top.endsWith("px"))
+            css.top = ((parseFloat(top) / originalRatio) * g.ratio) + "px";
+        if (left.endsWith("px"))
+            css.left = ((parseFloat(left) / originalRatio) * g.ratio) + "px";
+        if (fontSize.endsWith("px"))
+            css["font-size"] = ((parseFloat(fontSize) / originalRatio) * g.ratio) + "px";
+
+        $(this).css(css);
+    });
+};
+
+char.menuPanels = {
+    body: "#room_left_char",
+    map: "#room_left_map",
+    graph: "#room_left_graph",
+    walk: "#room_left_walk"
+};
+
+char.hideMenuPanels = function () {
+    $("#room_left_char").hide();
+    $("#room_left_map").hide();
+    $("#room_left_graph").hide();
+    $("#room_left_walk").hide();
+    $("#help_backButton").hide();
+};
+
+char.setMenuPanel = function (panel, override) {
+    var selector = char.menuPanels[panel];
+    var wasVisible;
+    if (!selector)
+        return false;
+
+    wasVisible = $(selector).is(":visible");
+    char.hideMenuPanels();
+    if (override)
+        $(selector).show();
+    else if (!wasVisible)
+        $(selector).toggle();
+    return true;
+};
+
+char.currentMenuPanel = function () {
+    if ($("#room_left_char").is(":visible"))
+        return "body";
+    if ($("#room_left_map").is(":visible"))
+        return "map";
+    if ($("#room_left_graph").is(":visible"))
+        return "graph";
+    if ($("#room_left_walk").is(":visible"))
+        return "walk";
+    return "hide";
+};
+
+char.showExportDialog = function (options) {
+    $("#room_export").slideDown();
+    $("#room_export_data").val(options.data === undefined ? '' : options.data);
+
+    $('#room_export_load').toggle(!!options.showLoad);
+    $('#room_export_load_file').toggle(!!options.showLoadFile);
+    $('#room_export_file').toggle(!!options.showSaveFile);
+    $('#room-export-text').toggle(!!options.showExportText);
+    $('#room-import-text').toggle(!!options.showImportText);
+
+    if (options.saveID !== undefined)
+        $('#room_export_file').data('saveID', options.saveID);
+};
+
+char.hideExportDialog = function () {
+    $("#room_export").slideUp();
+};
+
+char.updateRoomActionButtons = function () {
+    if (g.roomChange.includes(g.roomID))
+        $("#room-change").show();
+    else if (g.roomID === 354) {
+        if (sc.getMissionTask("landlord", "spermbank", 2).complete)
+            $("#room-change").show();
+        else
+            $("#room-change").hide();
+    }
+    else
+        $("#room-change").hide();
+
+    if (g.passtime.includes(g.roomID))
+        $("#room-time").show();
+    else
+        $("#room-time").hide();
+};
+
+char.applyScaledShellStyles = function (options) {
+    const rlHeight = options.rlHeight;
+    const leftMenuWidth = options.leftMenuWidth;
+    const menuBoxWidth = options.menuBoxWidth;
+    const menuBoxHeight = options.menuBoxHeight;
+    const menuBoxImgWidth = options.menuBoxImgWidth;
+    const menuBoxImgHeight = options.menuBoxImgHeight;
+    const resizeHeight = options.resizeHeight;
+    const graphBarHeight = options.graphBarHeight === undefined ? null : options.graphBarHeight;
+
     $(".rl-change[data-type='body']").css({
         left: "0px",
         top: "0px",
@@ -225,10 +498,7 @@ $(document).ready(function () {
         height: 50 * g.ratio + "px"
     });
     $(".left-menu").css({
-        width: 300 * g.ratio + "px",
-    }).hide();
-    $(".rl-change").click(function () {
-        char.changeMenu($(this).data("type"), true, false);
+        width: leftMenuWidth * g.ratio + "px",
     });
     $(".char-12").css({
         "font-size": 12 * g.ratio + "px"
@@ -243,93 +513,53 @@ $(document).ready(function () {
         "margin-top": 60 * g.ratio + "px"
     });
     $(".resize-height").css({
-        height: 4 * g.ratio + "px"
+        height: resizeHeight * g.ratio + "px"
     });
     $(".mt-300x").css({ "margin-top": (400 * g.ratio) + "px" });
     $(".mt-50x").css({ "margin-top": (50 * g.ratio) + "px" });
-    $("#room-change").click(function () {
-        g.pass = g.roomID;
-        char.room(8);
+    $(".menu-box").css({
+        "width": menuBoxWidth * g.ratio + "px",
+        "height": menuBoxHeight * g.ratio + "px",
+        "margin-top": (15 * g.ratio) + "px"
     });
-    $("#room_left_walk_sub").css({
-        height: 1000 * g.ratio + "px"
+    $(".menu-box-img").css({
+        "width": menuBoxImgWidth * g.ratio + "px",
+        "height": menuBoxImgHeight * g.ratio + "px"
     });
-    $("#room-time").click(function () {
-        phone.build("time");
-        //$("#room-menu").click();
-        //menu.mClick("time");
+    if (graphBarHeight !== null)
+        $('.left-graph-char-bar').css({ "height": (graphBarHeight * g.ratio) + "px" });
 
-    });
-    $("#rl_pageSelect").children("button").click(function () {
-        g.statpage = $(this).data("number");
-        $(".rl-selectButton-active").removeClass("rl-selectButton-active");
-        $(this).addClass("rl-selectButton-active");
-        sstat.makeGraph();
-    });
+    if (options.hideLeftMenu)
+        $(".left-menu").hide();
 
-    $(".menu-box").css({ "width": (290 * g.ratio) + "px", "height": (88 * g.ratio) + "px", "margin-top": (15 * g.ratio) + "px" });
-    $(".menu-box-img").css({ "width": (290 * g.ratio) + "px", "height": (88 * g.ratio) + "px" });
-    $('.rl-bar').css({ "height": (15 * g.ratio) + "px" });
-    $('.left-graph-char-bar').css({ "height": (15 * g.ratio) + "px" });
-    char.init();
-    char.resizewindow();
-});
+    if (options.walkSubHeight !== undefined)
+        $("#room_left_walk_sub").css({ height: options.walkSubHeight * g.ratio + "px" });
+};
 
-char.changeMenu = function (menu, update, override) {
-    if (update)
-        g.prevview = menu;
-    $("#help_backButton").hide();
-    switch (menu) {
-        case "body":
-            if (override)
-                $("#room_left_char").show();
-            else
-                $("#room_left_char").is(":visible") ? $("#room_left_char").hide() : $("#room_left_char").show();
-            $("#room_left_map").hide();
-            $("#room_left_graph").hide();
-            $("#room_left_walk").hide();
-            break;
-        case "map":
-            $("#room_left_char").hide();
-            if (override)
-                $("#room_left_map").show();
-            else
-                $("#room_left_map").is(":visible") ? $("#room_left_map").hide() : $("#room_left_map").show();
-            $("#room_left_graph").hide();
-            $("#room_left_walk").hide();
-            char.map();
-            break;
-        case "graph":
-            $("#room_left_char").hide();
-            $("#room_left_map").hide();
-            if (override)
-                $("#room_left_graph").show();
-            else
-                $("#room_left_graph").is(":visible") ? $("#room_left_graph").hide() : $("#room_left_graph").show();
-            $("#room_left_walk").hide();
-            sstat.makeGraph();
-            break;
-        case "walk":
-            $("#room_left_char").hide();
-            $("#room_left_map").hide();
-            $("#room_left_graph").hide();
-            if (override) {
-                $("#room_left_walk").show();
-            }
-            else
-                $("#room_left_walk").is(":visible") ? $("#room_left_walk").hide() : $("#room_left_walk").show();
-            char.makeWalk();
-            break;
-        case "hide":
-            $("#room_left_char").hide();
-            $("#room_left_map").hide();
-            $("#room_left_graph").hide();
-            $("#room_left_walk").hide();
-            break;
-        default:
-            console.log("invalid menu: " + menu);
-            break;
-    }
+char.clearMapPanel = function () {
+    $('#room_left_map').html('');
+};
+
+char.addMapText = function (left, top, text, color = "#fff") {
+    $('#room_left_map').append('<div class="width-l resize-font killmap" style="color: ' + color + '; position:absolute; font-size: ' + 20 * g.ratio + 'px; left: ' + left * g.ratio + 'px; top: ' + (top + 5) * g.ratio + 'px; " >' +
+        text +
+        '</div>');
+};
+
+char.addMapImage = function (src, height, width, top, left) {
+    $('#room_left_map').append('<img src="' + src + '" class="width-l resize killmap" style="position:absolute; ' +
+        g.makeCss(height, width, top, left) + '" />');
+};
+
+char.getMapDayNightIcons = function (roomMapEntry, top) {
+    var dayNight = roomMapEntry.access ? '<img src="./images/general/day.png" class="resize" style="position:absolute; ' + g.makeCss(16, 16, top + 5, 260) + '"/>' : '';
+    dayNight += roomMapEntry.darkAccess ? '<img src="./images/general/night.png" class="resize" style="position:absolute; ' + g.makeCss(16, 16, top + 5, 280) + '"/>' : '';
+    return dayNight;
+};
+
+char.addWalkText = function (text, fontSize = null, className = "resize-font") {
+    var style = fontSize === null ? '' : ' style="font-size: ' + fontSize * g.ratio + 'px"';
+    $("#room_left_walk_sub").append('<div class="' + className + '"' + style + '>' + text + '</div>');
 };
 
 char.addtime = function (minutes) {
@@ -384,33 +614,29 @@ char.map = function () {
     }
     else if (g.roomID === 958) {
         if (g.map !== null)
-            room958.btnclick("displayMap");
+            invoker.invoke(958, "btnclick", "displayMap");
         return;
     }
 
     if (cArray.length > 0) {
         var ampm = gv.get("clock24") === "12";
-        $('#room_left_map').html('');
+        char.clearMapPanel();
         for (i = 0; i < cArray.length; i++) {
             ttop += 20;
-            $('#room_left_map').append('<div class="width-l resize-font killmap" style="color: #fff; position:absolute; font-size: ' + 20 * g.ratio + 'px; left: ' + 10 * g.ratio + 'px; top: ' + (ttop + 5) * g.ratio + 'px; " >' +
-                cArray[i].c +
-                '</div>');
+            char.addMapText(10, ttop, cArray[i].c, "#fff");
             ttop += 30;
             for (j = 0; j < cArray[i].t.subList.length; j++) {
                 if (cArray[i].t.subList[j].current) {
-                    $('#room_left_map').append('<div class="width-l resize-font killmap" style="color: #fdd; position:absolute; font-size: ' + 20 * g.ratio + 'px; left: ' + 15 * g.ratio + 'px; top: ' + (ttop + 5) * g.ratio + 'px; " >' +
+                    char.addMapText(15, ttop,
                         char.friendlyTime(cArray[i].t.subList[j].hstart, ampm) + " to " +
                         char.friendlyTime(cArray[i].t.subList[j].hend, ampm) + " - " +
-                        cArray[i].t.subList[j].room + " *" +
-                        '</div>');
+                        cArray[i].t.subList[j].room + " *", "#fdd");
                 }
                 else {
-                    $('#room_left_map').append('<div class="width-l resize-font killmap" style="color: #ccc; position:absolute; font-size: ' + 20 * g.ratio + 'px; left: ' + 15 * g.ratio + 'px; top: ' + (ttop + 5) * g.ratio + 'px; " >' +
+                    char.addMapText(15, ttop,
                         char.friendlyTime(cArray[i].t.subList[j].hstart, ampm) + " - " +
                         char.friendlyTime(cArray[i].t.subList[j].hend, ampm) + " - " +
-                        cArray[i].t.subList[j].room +
-                        '</div>');
+                        cArray[i].t.subList[j].room, "#ccc");
                 }
                 ttop += 25;
             }
@@ -419,15 +645,13 @@ char.map = function () {
     else {
         if (!(exRoom.includes(g.roomID))) {
             var tm = gv.get("map");
-            $('#room_left_map').html('');
+            char.clearMapPanel();
             for (i = 0; i < g.roomMap.length; i++) {
                 if (g.roomMap[i].map === tm) {
                     var newRatio = 45 / g.roomMap[i].height;
-                    var dayNight = g.roomMap[i].access ? '<img src="./images/general/day.png" class="resize" style="position:absolute; ' + g.makeCss(16, 16, ttop + 5, 260) + '"/>' : '';
-                    dayNight += g.roomMap[i].darkAccess ? '<img src="./images/general/night.png" class="resize" style="position:absolute; ' + g.makeCss(16, 16, ttop + 5, 280) + '"/>' : '';
-                    $('#room_left_map').append('<img src="./images/room/' + g.roomMap[i].img + '" class="width-l resize killmap" style="position:absolute; ' + g.makeCss(g.roomMap[i].height * newRatio, g.roomMap[i].width * newRatio, ttop, 10) + '" />');
-                    $('#room_left_map').append(dayNight);
-                    $('#room_left_map').append('<div class="width-l resize-font killmap" style="color: #fff; position:absolute; font-size: ' + 20 * g.ratio + 'px; left: ' + 100 * g.ratio + 'px; top: ' + (ttop + 5) * g.ratio + 'px; " >' + g.roomMap[i].display + '</div>');
+                    char.addMapImage("./images/room/" + g.roomMap[i].img, g.roomMap[i].height * newRatio, g.roomMap[i].width * newRatio, ttop, 10);
+                    $('#room_left_map').append(char.getMapDayNightIcons(g.roomMap[i], ttop));
+                    char.addMapText(100, ttop, g.roomMap[i].display, "#fff");
                     ttop += 50;
                 }
             }
@@ -454,21 +678,21 @@ char.friendlyTime = function (hour, ampm = null) {
 char.makeWalk = function () {
     $("#room_left_walk_sub").html("'<br/><br/>");
     if (g.pastSaves.length > 1) {
-        $("#room_left_walk_sub").append('<div class="resize-font"><br/><br/><br/><br/>Go back a room to: ' + g.pastSaves[g.pastSaves.length - 2].name + '</div>');
+        char.addWalkText('<br/><br/><br/><br/>Back to: ' + g.pastSaves[g.pastSaves.length - 2].name);
         if ($("#room_left_walk").is(":visible")) {
             $("#help_backButton").show();
         }
     }
     else {
-        $("#room_left_walk_sub").append('<div class="resize-font" style="font-size: ' + 20 * g.ratio + 'px"><br/><br/><br/><br/></div>');
+        char.addWalkText('<br/><br/><br/><br/>', 20);
         $("#help_backButton").hide();
     }
-    $("#room_left_walk_sub").append('<div class="resize-font" style="font-size: ' + 30 * g.ratio + 'px;"><br/>Popup History:</div>');
+    char.addWalkText('<br/>History:', 30);
     if (g.popArray.length === 0) {
-        $("#room_left_walk_sub").append('<div class="popUpHistory resize-font" style="font-size: ' + 20 * g.ratio + 'px">None</div>');
+        char.addWalkText('None', 20, "popUpHistory resize-font");
     }
     for (let i = 0; i < g.popArray.length; i++) {
-        $("#room_left_walk_sub").append('<div class="popUpHistory resize-font" style="font-size: ' + 20 * g.ratio + 'px">' + g.popArray[i] + '</div>');
+        char.addWalkText(g.popArray[i], 20, "popUpHistory resize-font");
     }
 };
 
@@ -579,7 +803,12 @@ char.room = function (roomID) {
 
     g.roomID = roomID;
     g.dt = char.addMinutes(g.dt, 2);
-    menu.makeSaves();
+    if (g.skipNextRoomSave) {
+        g.skipNextRoomSave = false;
+    }
+    else {
+        menu.makeSaves();
+    }
     nav.buildRoom();
     cl.cockDisplay();
     cl.energydisplay();
@@ -593,26 +822,12 @@ char.room = function (roomID) {
             char.changeMenu(g.prevview, false, true);
     }
     else if(!(g.roomID === 0 || g.roomID === 28))
-        g.prevview = $("#room_left_char").is(":visible") ? "body" : ($("#room_left_map").is(":visible") ? "map" : ($("#room_left_graph").is(":visible") ? "graph" : "hide"));
+        g.prevview = char.currentMenuPanel();
 
-    if (g.roomChange.includes(g.roomID)) 
-        $("#room-change").show();
-    else if (g.roomID === 354) {
-        if (sc.getMissionTask("landlord", "spermbank", 2).complete)
-            $("#room-change").show();
-        else
-            $("#room-change").hide();
-    }
-    else 
-        $("#room-change").hide();
-
-
-    if (g.passtime.includes(g.roomID))
-        $("#room-time").show();
-    else
-        $("#room-time").hide();
+    char.updateRoomActionButtons();
 
     phone.clear(true);
+    phone.preservedMenuOverlay = null;
 };
 
 char.addMinutes = function (date, minutes) {
@@ -716,63 +931,17 @@ menu.save = function (cookieName, saveToCookie) {
 menu.load = function (cookieName, btn, saveID) {
     fame.moanAnimateStop();
     if (g.newLoad) {
-        $('.room-left').show();
-        $('#room_footer').show();
-        $(".room-topper").show();
-        $('.menu-tab').show();
+        char.showGameShell();
     }
     g.newLoad = false;
 
     var tp = JSON.parse(localStorage[cookieName]);
-    var i;
-    let saveVersion = tp.version;
-    g.pass = tp.pass;
-    g.internal = tp.internal;
-    g.prevRoom = tp.prevRoom;
-    
-    g.load(tp.g);
-    inv.load(tp.inv);
-    cl.load(tp.cl);
-    sc.load(tp.sc);
-    //scc.load(tp.scc);
-    gv.load(tp.gv, saveVersion);
-    missy.load(tp.missy);
-    
-    try {
-        pic.load(tp.pic);
-    }
-    catch (err) {
-        console.log(err);
-    }
-    char.map();
-    cl.display();
-    char.room(g.roomID);
-    char.menu();
-    $('.hide-start').show();
-    if (g.roomID === 328) {
-        $("#room-inv").hide();
-    }
-    $('.menu-button[data-type="close"]').click();
-    $('.room-left').show();
-    $('#room_footer').show();
-    $(".room-topper").show();
-    $('.menu-tab').show();
-    if (g.roomChange.includes(g.roomID)) 
-        $("#room-change").show();
-    else 
-        $("#room-change").hide();
-
-    if (g.passtime.includes(g.roomID))
-        $("#room-time").show();
-    else
-        $("#room-time").hide();
-
-    if (tp.version < 22) {
-        sissy.st[7].ach = false;
-        sissy.st[8].ach = false;
-    }
-    $(".rl-change").show();
-    g.pastSaves = new Array();
+    let saveVersion = char.applyLoadedState(tp);
+    char.finishLoadedState(saveVersion, {
+        updateMap: true,
+        hideExportDialog: false,
+        resetPastSaves: true
+    });
 };
 
 menu.saveDel = function (cookieName) {
@@ -889,14 +1058,68 @@ char.menu = function () {
 char.export = function (saveID) {
     var cookieName = 'HatMP_' + saveID;
     var tp = localStorage[cookieName];
-    $("#room_export").slideDown();
-    $('#room_export_load').hide();
-    $('#room_export_load_file').hide();
-    $('#room_export_file').show();
-    $('#room_export_file').data('saveID', saveID);
-    $("#room_export_data").val(tp);
-    $('#room-export-text').show();
-    $('#room-import-text').hide();
+    char.showExportDialog({
+        data: tp,
+        saveID: saveID,
+        showLoad: false,
+        showLoadFile: false,
+        showSaveFile: true,
+        showExportText: true,
+        showImportText: false
+    });
+};
+
+char.applyLoadedState = function (tp) {
+    let saveVersion = tp.version;
+
+    g.pass = tp.pass;
+    g.internal = tp.internal;
+    g.prevRoom = tp.prevRoom;
+
+    g.load(tp.g);
+    inv.load(tp.inv);
+    cl.load(tp.cl);
+    sc.load(tp.sc);
+    gv.load(tp.gv, saveVersion);
+    missy.load(tp.missy);
+
+    try {
+        pic.load(tp.pic);
+    }
+    catch (err) {
+        console.log(err);
+    }
+
+    return saveVersion;
+};
+
+char.finishLoadedState = function (saveVersion, options) {
+    if (options.updateMap)
+        char.map();
+
+    cl.display();
+    char.room(g.roomID);
+    char.menu();
+
+    if (saveVersion < 22) {
+        sissy.st[7].ach = false;
+        sissy.st[8].ach = false;
+    }
+
+    $('.hide-start').show();
+    if (g.roomID === 328)
+        $("#room-inv").hide();
+
+    $('.menu-button[data-type="close"]').click();
+    char.showGameShell();
+    char.updateRoomActionButtons();
+    $(".rl-change").show();
+
+    if (options.hideExportDialog)
+        char.hideExportDialog();
+
+    if (options.resetPastSaves)
+        g.pastSaves = new Array();
 };
 
 char.import = function (importData) {
@@ -907,42 +1130,13 @@ char.import = function (importData) {
         tp = JSON.parse(importData);
 
     g.newLoad = false;
-    $('.room-left').show();
-    $('#room_footer').show();
-    $(".room-topper").show();
-    $('.menu-tab').show();
-    console.log("v: " + tp.version);
-    g.pass = tp.pass;
-    g.internal = tp.internal;
-    g.prevRoom = tp.prevRoom;
-    let saveVersion = tp.version;
-
-    g.load(tp.g);
-    inv.load(tp.inv);
-    cl.load(tp.cl);
-    sc.load(tp.sc);
-    gv.load(tp.gv, saveVersion);
-    missy.load(tp.missy);
-    try {
-        pic.load(tp.pic);
-    }
-    catch (err) {
-        console.log(err);
-    }
-    cl.display();
-    char.room(g.roomID);
-    char.menu();
-
-    if (tp.version < 22) {
-        sissy.st[7].ach = false;
-        sissy.st[8].ach = false;
-    }
-
-    $('.hide-start').show();
-    $('.menu-button[data-type="close"]').click();
-
-    $("#room_export").slideUp();
-    $(".rl-change").show();
+    char.showGameShell();
+    let saveVersion = char.applyLoadedState(tp);
+    char.finishLoadedState(saveVersion, {
+        updateMap: false,
+        hideExportDialog: true,
+        resetPastSaves: false
+    });
 };
 
 char.file_export = function (saveID) {

--- a/scripts/charisma.js
+++ b/scripts/charisma.js
@@ -21,8 +21,7 @@ charisma.getIntel = function (charismaLevel) {
     return { n: stat, txt: "[Intelligence Roll: " + stat + "%] ", baseRoll: baseRoll, rollNeeded: rollNeeded, myCharisma: myCharisma, appearance: 0 };
 };
 
-charisma.init = function (charismaLevel, btnPressWin, btnPressLost, roomID) {
-    var stat = charisma.getStats(charismaLevel);
+charisma.drawOverlayShell = function () {
     nav.button({
         "type": "img",
         "name": "quickfight",
@@ -50,7 +49,21 @@ charisma.init = function (charismaLevel, btnPressWin, btnPressLost, roomID) {
         "height": 100,
         "image": "1002_quickfight/roll.png"
     }, 1);
+};
 
+charisma.drawStatLine = function (row, text) {
+    nav.t({
+        type: "img",
+        name: "quickfight",
+        left: 1660,
+        top: 280 + (row * 50) + 12,
+        font: 20,
+        hex: "#ffffff",
+        text: text
+    }, 1);
+};
+
+charisma.drawRollSummary = function (title, stat, primaryLabel, secondaryLabel, totalLabel) {
     nav.t({
         type: "zimg",
         name: "quickfight",
@@ -58,62 +71,22 @@ charisma.init = function (charismaLevel, btnPressWin, btnPressLost, roomID) {
         top: 180,
         font: 30,
         hex: "#ffffff",
-        text: "Charisma"
+        text: title
     }, 1);
-    nav.t({
-        type: "img",
-        name: "quickfight",
-        left: 1660,
-        top: 280 + (0 * 50) + 12,
-        font: 20,
-        hex: "#ffffff",
-        text: "Your Charisma: " + stat.myCharisma
-    }, 1);
-    nav.t({
-        type: "img",
-        name: "quickfight",
-        left: 1660,
-        top: 280 + (1 * 50) + 12,
-        font: 20,
-        hex: "#ffffff",
-        text: "Sexy Bonus: " + stat.appearance
-    }, 1);
-    nav.t({
-        type: "img",
-        name: "quickfight",
-        left: 1660,
-        top: 280 + (2 * 50) + 12,
-        font: 20,
-        hex: "#ffffff",
-        text: "Total Charisma: " + (stat.myCharisma + stat.appearance)
-    }, 1);
-    nav.t({
-        type: "img",
-        name: "quickfight",
-        left: 1660,
-        top: 280 + (4 * 50) + 12,
-        font: 20,
-        hex: "#ffffff",
-        text: "Base Roll Needed : " + stat.baseRoll
-    }, 1);
-    nav.t({
-        type: "img",
-        name: "quickfight",
-        left: 1660,
-        top: 280 + (5 * 50) + 12,
-        font: 20,
-        hex: "#ffffff",
-        text: "Adjusted Roll Needed : " + stat.rollNeeded
-    }, 1);
-    nav.t({
-        type: "img",
-        name: "quickfight",
-        left: 1660,
-        top: 280 + (6 * 50) + 12,
-        font: 20,
-        hex: "#ffffff",
-        text: "Chance: " + stat.n + "%"
-    }, 1);
+    charisma.drawStatLine(0, primaryLabel + stat.myCharisma);
+    if (secondaryLabel !== null)
+        charisma.drawStatLine(1, secondaryLabel + stat.appearance);
+    if (totalLabel !== null)
+        charisma.drawStatLine(2, totalLabel + (stat.myCharisma + stat.appearance));
+    charisma.drawStatLine(4, "Base Roll Needed : " + stat.baseRoll);
+    charisma.drawStatLine(5, "Adjusted Roll Needed : " + stat.rollNeeded);
+    charisma.drawStatLine(6, "Chance: " + stat.n + "%");
+};
+
+charisma.init = function (charismaLevel, btnPressWin, btnPressLost, roomID) {
+    var stat = charisma.getStats(charismaLevel);
+    charisma.drawOverlayShell();
+    charisma.drawRollSummary("Charisma", stat, "Your Charisma: ", "Sexy Bonus: ", "Total Charisma: ");
     
 
     g.fight = {
@@ -253,86 +226,13 @@ charisma.complete = function () {
         name = g.fight.btnPressLost;
 
     g.fight = null;
-    window[g.room(roomId)]["btnclick"](name);
+    invoker.invoke(roomId, "btnclick", name);
 };
 
 charisma.itelInit = function (intelLevel, btnPressWin, btnPressLost, roomID) {
     let stat = charisma.getIntel(intelLevel);
-    nav.button({
-        "type": "img",
-        "name": "quickfight",
-        "left": 0,
-        "top": 0,
-        "width": 1920,
-        "height": 1080,
-        "image": "1002_quickfight/black20Alpha.png"
-    }, 1);
-    nav.button({
-        "type": "img",
-        "name": "quickfight",
-        "left": 1597,
-        "top": 147,
-        "width": 306,
-        "height": 712,
-        "image": "227_fight/menu.png"
-    }, 1);
-    nav.button({
-        "type": "btn",
-        "name": "charismaRoll",
-        "left": 760,
-        "top": 300,
-        "width": 400,
-        "height": 100,
-        "image": "1002_quickfight/roll.png"
-    }, 1);
-
-    nav.t({
-        type: "zimg",
-        name: "quickfight",
-        left: 1620,
-        top: 180,
-        font: 30,
-        hex: "#ffffff",
-        text: "Intelligence"
-    }, 1);
-    nav.t({
-        type: "img",
-        name: "quickfight",
-        left: 1660,
-        top: 280 + (0 * 50) + 12,
-        font: 20,
-        hex: "#ffffff",
-        text: "Your Intelligence: " + stat.myCharisma
-    }, 1);
-    
-    
-    nav.t({
-        type: "img",
-        name: "quickfight",
-        left: 1660,
-        top: 280 + (4 * 50) + 12,
-        font: 20,
-        hex: "#ffffff",
-        text: "Base Roll Needed : " + stat.baseRoll
-    }, 1);
-    nav.t({
-        type: "img",
-        name: "quickfight",
-        left: 1660,
-        top: 280 + (5 * 50) + 12,
-        font: 20,
-        hex: "#ffffff",
-        text: "Adjusted Roll Needed : " + stat.rollNeeded
-    }, 1);
-    nav.t({
-        type: "img",
-        name: "quickfight",
-        left: 1660,
-        top: 280 + (6 * 50) + 12,
-        font: 20,
-        hex: "#ffffff",
-        text: "Chance: " + stat.n + "%"
-    }, 1);
+    charisma.drawOverlayShell();
+    charisma.drawRollSummary("Intelligence", stat, "Your Intelligence: ", null, null);
 
 
     g.fight = {

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -1,9 +1,98 @@
 ﻿var privateChat = {};
 
+privateChat.resetButtons = function () {
+    $('.room-chatBtnClick').html('').hide().data('chatid', 0).data('roomid', 0).data('callback', '');
+};
+
+privateChat.hideOverlay = function () {
+    $('#room_chatOverlay').hide();
+    $('#room_footerSpeach').html("");
+    $('#room_chatSpeaker').html('');
+    $('#room_footer').show();
+};
+
+privateChat.close = function () {
+    privateChat.hideOverlay();
+    privateChat.resetButtons();
+    g.skipChat = false;
+};
+
+privateChat.setButton = function (index, text, chatID, roomID, callback) {
+    $('#room_chatBtn' + index)
+        .html(text)
+        .data('chatid', chatID)
+        .data('roomid', roomID)
+        .data('callback', callback)
+        .attr('title', 'Shortcut: ' + (index + 1))
+        .show();
+};
+
+privateChat.updateSkipButton = function (buttonCount) {
+    if (g.skipChat) {
+        setTimeout(function () {
+            privateChat.skipChat();
+        }, 100);
+    }
+    else if (buttonCount === 1)
+        $("#room_chatskip").show();
+    else
+        $("#room_chatskip").hide();
+};
+
+privateChat.visibleButtons = function () {
+    return $('.room-chatBtnClick:visible');
+};
+
+privateChat.selectButtonByIndex = function (index) {
+    var buttons = privateChat.visibleButtons();
+    if (index < 0 || index >= buttons.length)
+        return false;
+
+    buttons.eq(index).click();
+    return true;
+};
+
+privateChat.getShortcutIndexFromEvent = function (e) {
+    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)
+        return null;
+
+    if (e.which >= 49 && e.which <= 57)
+        return e.which - 49;
+
+    if (e.which >= 97 && e.which <= 105)
+        return e.which - 97;
+
+    if (e.code && e.code.startsWith("Digit")) {
+        var digitIndex = parseInt(e.code.replace("Digit", ""), 10) - 1;
+        return digitIndex >= 0 && digitIndex < 9 ? digitIndex : null;
+    }
+
+    if (e.code && e.code.startsWith("Numpad")) {
+        var numpadIndex = parseInt(e.code.replace("Numpad", ""), 10) - 1;
+        return numpadIndex >= 0 && numpadIndex < 9 ? numpadIndex : null;
+    }
+
+    return null;
+};
+
+privateChat.isTypingTarget = function (target) {
+    if (!target)
+        return false;
+
+    var tagName = target.tagName ? target.tagName.toLowerCase() : "";
+    return tagName === "input" || tagName === "textarea" || tagName === "select" || target.isContentEditable;
+};
+
+privateChat.canHandleSpace = function (target) {
+    return $('#room_chatOverlay').is(":visible") &&
+        !$('#room_export').is(":visible") &&
+        !privateChat.isTypingTarget(target);
+};
+
 function chat(chatID, roomID) {
 
     if (chatID !== -1) {
-        privateChat.makeChat(window[g.room(roomID)]["chat"](chatID), chatID, roomID);
+        privateChat.makeChat(invoker.invoke(roomID, "chat", chatID), chatID, roomID);
     }
     if (window.getSelection) {
         window.getSelection().removeAllRanges();
@@ -14,11 +103,8 @@ function chat(chatID, roomID) {
 }
 
 privateChat.kill = function(){
-    $('#room_chatOverlay').hide();
-    $('.room-chatBtnClick').html('').hide().data('chatid', 0).data('roomid', 0).data('callback', '');
-    $('#room_footerSpeach').html("");
-    $('#room_chatSpeaker').html('');
-    $('#room_footer').show();
+    privateChat.hideOverlay();
+    privateChat.resetButtons();
 };
 
 privateChat.makeChat = function (entry, chatID, roomID) {
@@ -30,32 +116,22 @@ privateChat.makeChat = function (entry, chatID, roomID) {
             //$('#char_charDisplay').hide();
         }
         var counter = 0;
-        $('.room-chatBtnClick').html('').hide().data('chatid', 0).data('roomid', 0).data('callback', '');
+        privateChat.resetButtons();
         $('#room_footerSpeach').html(entry.text);
         $('#room_chatSpeaker').html('<img src="' + thisSpeaker.img + '" /><br/>' + (thisSpeaker.name === "Random" ? "" : thisSpeaker.name));
         if (entry.button.length === 0) {
-            $('#room_chatBtn0').html('Close').show().data('chatid', -1).data('roomid', roomID).data('callback', '');
+            privateChat.setButton(0, 'Close', -1, roomID, '');
             counter = 1;
         }
         else {
             $.each(entry.button, function (i, v) {
-                $('#room_chatBtn' + i).html(v.text).data('chatid', v.chatID).data('roomid', roomID).data('callback', v.callback).show();
+                privateChat.setButton(i, v.text, v.chatID, roomID, v.callback);
                 counter++;
             });
         }
         counter = (counter === 0 ? counter = 1 : counter);
         $('.room-chatBtn').css('width', "calc(" + (100 / counter) + '% - ' + ((72 * g.ratio) / counter) + "px)");
-        if (g.skipChat) {
-            setTimeout(function () {
-                privateChat.skipChat();
-            }, 100);
-        }
-        else {
-            if(counter === 1)
-                $("#room_chatskip").show();
-            else
-                $("#room_chatskip").hide();
-        }
+        privateChat.updateSkipButton(counter);
     }
     else {
         g.error("chat", "chatID:" + chatID + " roomID: " + roomID);
@@ -112,22 +188,49 @@ privateChat.speakerInfo = function (charName) {
 };
 
 privateChat.skipChat = function () {
-    if (g.roomTimeout === null && g.roomTimeout2 === null) {
-        if ($('#room_chatBtn0').is(":visible")) {
-            if (!$('#room_chatBtn1').is(":visible") && !$('#room_chatBtn2').is(":visible")) {
-                $('#room_chatBtn0').click();
-            }
-            else {
-                g.skipChat = false;
-            }
-        }
+    var buttons = privateChat.visibleButtons();
+    if (buttons.length === 1) {
+        buttons.eq(0).click();
+    }
+    else if (buttons.length > 1) {
+        g.skipChat = false;
     }
 };
 
 $(document).ready(function () {
+    $(document).bind('keydown', function (e) {
+        if (e.which === 32) {//space bar
+            if (!privateChat.canHandleSpace(e.target))
+                return;
+
+            if (privateChat.visibleButtons().length === 1) {
+                g.suppressSpaceAdvanceKeyup = true;
+                e.preventDefault();
+                privateChat.skipChat();
+            }
+        }
+
+        var shortcutIndex = privateChat.getShortcutIndexFromEvent(e);
+        if (shortcutIndex === null)
+            return;
+        if (!privateChat.canHandleSpace(e.target))
+            return;
+
+        if (privateChat.selectButtonByIndex(shortcutIndex))
+            e.preventDefault();
+    });
+
     $(document).bind('keyup', function (e) {
         if (e.which === 32) {//space bar
-            privateChat.skipChat();
+            if (!privateChat.canHandleSpace(e.target))
+                return;
+
+            if (privateChat.visibleButtons().length === 1)
+                e.preventDefault();
+        }
+        else if (privateChat.getShortcutIndexFromEvent(e) !== null) {
+            if (privateChat.canHandleSpace(e.target))
+                e.preventDefault();
         }
         else if(e.which === 83){
             if ($("#room_chatskip").is(":visible")) {
@@ -153,18 +256,13 @@ $(document).ready(function () {
         var callback = $(this).data('callback');
 
         if (chatID < 0) {
-            $('#room_chatOverlay').hide();
-            $('.room-chatBtnClick').html('').hide().data('chatid', 0).data('roomid', 0).data('callback', '');
-            $('#room_footerSpeach').html("");
-            $('#room_chatSpeaker').html('');
-            $('#room_footer').show();
-            g.skipChat = false;
+            privateChat.close();
             //$('#char_charDisplay').show();
         }
         else
             chat(chatID, roomID);
         if (callback !== '')
-            window[g.room(roomID)]["chatcatch"](callback);
+            invoker.invoke(roomID, "chatcatch", callback);
 
     });
 });

--- a/scripts/clothes.js
+++ b/scripts/clothes.js
@@ -131,7 +131,7 @@ cl.init = function () {
         { type: "swimsuit", name: "p", display: "Pink Swimsuit", img: "swim_pink.png", sex: "f", inv: false, daring: 4, price: 80 },
 
         { type: "shoes", name: "w", display: "Workboots", img: "shoes_workboots.png", sex: "m", inv: true, daring: 0, price: -1 },
-        { type: "shoes", name: "d", display: "Dress Shoes", img: "shoes_black.png", sex: "m", inv: false, daring: 0, price: 60 },
+        { type: "shoes", name: "d", display: "Black Dress Shoes", img: "shoes_black.png", sex: "m", inv: false, daring: 0, price: 60 },
         { type: "shoes", name: "br", display: "Blue Running", img: "shoes_blueRun.png", sex: "m", inv: true, daring: 0, price: 75 },
         { type: "shoes", name: "nu", display: "Nurse shoes", img: "shoes_nurse.png", sex: "f", inv: false, daring: 1, price: -1 },
         { type: "shoes", name: "v", display: "Naked Beaver Shoes", img: "shoes_beaver.png", sex: "f", inv: false, daring: 1, price: -1 },
@@ -150,7 +150,7 @@ cl.init = function () {
         { type: "shoes", name: "bb", display: "Black Boots", img: "shoes_blackboots.png", sex: "f", inv: false, daring: 4, price: 127 },
 
         { type: "socks", name: "w", display: "Sweat Socks", img: "socks_white.png", sex: "m", inv: true, daring: 0, price: -1 },
-        { type: "socks", name: "b", display: "Dress Socks", img: "socks_black.png", sex: "m", inv: false, daring: 0, price: 15 },
+        { type: "socks", name: "b", display: "Black Dress Socks", img: "socks_black.png", sex: "m", inv: false, daring: 0, price: 15 },
         { type: "socks", name: "p", display: "Pink Stockings", img: "socks_pink.png", sex: "f", inv: false, daring: 1, price: 36 },
         { type: "socks", name: "s", display: "Little White Socks", img: "socks_shortWhite.png", sex: "f", inv: false, daring: 1, price: 24 },
         { type: "socks", name: "ss", display: "Sissy Socks", img: "socks_sissy.png", sex: "f", inv: false, daring: 2, price: -1 },
@@ -207,7 +207,7 @@ cl.init = function () {
         { type: "buttplug", name: "fr", display: "Rose", img: "plug_rose.png", sex: "f", inv: false, daring: 1, price: -1 },
         { type: "buttplug", name: "fd", display: "Daisy", img: "plug_daisy.png", sex: "f", inv: false, daring: 1, price: -1 },
         { type: "buttplug", name: "fp", display: "Pink flower", img: "plug_pinkFlower.png", sex: "f", inv: false, daring: 1, price: -1 },
-        { type: "buttplug", name: "t", display: "Tampon", img: "plug_tampon.png", sex: "f", inv: false, daring: 1, price: -1 },
+        { type: "buttplug", name: "t", display: "Tampon", img: "plug_small.png", sex: "f", inv: false, daring: 1, price: -1 },
         { type: "buttplug", name: "tail", display: "Tail", img: "plug_tail.png", sex: "f", inv: false, daring: 4, price: -1 },
         { type: "buttplug", name: "sh", display: "Shock", img: "plug_shock.png", sex: "f", inv: false, daring: 4, price: -1 },
         { type: "buttplug", name: "i", display: "Inflate", img: "plug_inflate.png", sex: "f", inv: false, daring: 4, price: -1 },
@@ -251,6 +251,28 @@ cl.cTemp = {
     shoes: null, socks: null, pants: null, panties: null, bra: null, shirt: null, dress: null, swimsuit: null, pj: null, buttplug: null
 };
 
+cl.tempClothingSlots = function () {
+    return ["shoes", "socks", "pants", "panties", "bra", "shirt", "dress", "swimsuit", "pj", "buttplug"];
+};
+
+cl.savedOutfitSlots = function () {
+    return ["shoes", "socks", "pants", "panties", "bra", "shirt", "dress", "swimsuit", "accessories", "pj"];
+};
+
+cl.copySlots = function (target, source, slots) {
+    $.each(slots, function (_, slot) {
+        target[slot] = source[slot];
+    });
+};
+
+cl.areSlotsEmpty = function (source, slots) {
+    for (var i = 0; i < slots.length; i++) {
+        if (source[slots[i]] !== null)
+            return false;
+    }
+    return true;
+};
+
 cl.pantiesTxt = function () {
     if (cl.c.panties !== null)
         return cl.list[cl.where("panties", cl.c.panties)].sex === "f" ? "panties" : "underwear";
@@ -267,137 +289,58 @@ cl.add = function (type, name) {
     }
 };
 
+cl.clearOutfitSlot = function (outfit, type, name) {
+    if (!Object.prototype.hasOwnProperty.call(outfit, type))
+        return false;
+
+    if (outfit[type] === name)
+        outfit[type] = null;
+    return true;
+};
+
+cl.clearCurrentSlot = function (type, name) {
+    var currentSlotMap = {
+        shoes: "shoes",
+        socks: "socks",
+        pants: "pants",
+        panties: "panties",
+        bra: "bra",
+        shirt: "shirt",
+        dress: "dress",
+        swimsuit: "swimsuit",
+        pj: "pj",
+        buttplug: "buttplug",
+        nipple: "nipplering",
+        ear: "earring",
+        nose: "nosering",
+        necklace: "necklace",
+        belly: "bellyring"
+    };
+    var slotName = currentSlotMap[type];
+    if (!slotName)
+        return false;
+
+    if (cl.c[slotName] === name)
+        cl.c[slotName] = null;
+    return true;
+};
+
 cl.remove = function (type, name) {
     var i;
     var clindex = cl.where(type, name);
     cl.list[clindex].inv = false;
     for (i = 0; i < 6; i++) {
-        switch (type) {
-            case "shoes":
-                if (cl.saveOutfit[i].shoes === name)
-                    cl.saveOutfit[i].shoes = null;
-                break;
-            case "socks":
-                if (cl.saveOutfit[i].socks === name)
-                    cl.saveOutfit[i].socks = null;
-                break;
-            case "pants":
-                if (cl.saveOutfit[i].pants === name)
-                    cl.saveOutfit[i].pants = null;
-                break;
-            case "panties":
-                if (cl.saveOutfit[i].panties === name)
-                    cl.saveOutfit[i].panties = null;
-                break;
-            case "bra":
-                if (cl.saveOutfit[i].bra === name)
-                    cl.saveOutfit[i].bra = null;
-                break;
-            case "shirt":
-                if (cl.saveOutfit[i].shirt === name)
-                    cl.saveOutfit[i].shirt = null;
-                break;
-            case "dress":
-                if (cl.saveOutfit[i].dress === name)
-                    cl.saveOutfit[i].dress = null;
-                break;
-            case "swimsuit":
-                if (cl.saveOutfit[i].swimsuit === name)
-                    cl.saveOutfit[i].swimsuit = null;
-                break;
-            case "pj":
-                if (cl.saveOutfit[i].pj === name)
-                    cl.saveOutfit[i].pj = null;
-                break;
-            case "accessories":
-                if (cl.saveOutfit[i].accessories === name)
-                    cl.saveOutfit[i].accessories = null;
-                break;
-            default:
-                console.log("missing: " + type + ", " + name);
-                break;
-        }
-    }
-    switch (type) {
-        case "shoes":
-            if (cl.c.shoes === name)
-                cl.c.shoes = null;
-            break;
-        case "socks":
-            if (cl.c.socks === name)
-                cl.c.socks = null;
-            break;
-        case "pants":
-            if (cl.c.pants === name)
-                cl.c.pants = null;
-            break;
-        case "panties":
-            if (cl.c.panties === name)
-                cl.c.panties = null;
-            break;
-        case "bra":
-            if (cl.c.bra === name)
-                cl.c.bra = null;
-            break;
-        case "shirt":
-            if (cl.c.shirt === name)
-                cl.c.shirt = null;
-            break;
-        case "dress":
-            if (cl.c.dress === name)
-                cl.c.dress = null;
-            break;
-        case "swimsuit":
-            if (cl.c.swimsuit === name)
-                cl.c.swimsuit = null;
-            break;
-        case "pj":
-            if (cl.c.pj === name)
-                cl.c.pj = null;
-            break;
-        case "buttplug":
-            if (cl.c.butthole === name)
-                cl.c.buttplug = null;
-            break;
-        case "nipple":
-            if (cl.c.nipplering === name)
-                cl.c.nipplering = null;
-            break;
-        case "ear":
-            if (cl.c.earring === name)
-                cl.c.earring = null;
-            break;
-        case "nose":
-            if (cl.c.nosering === name)
-                cl.c.nosering = null;
-            break;
-        case "necklace":
-            if (cl.c.necklace === name)
-                cl.c.necklace = null;
-            break;
-        case "belly":
-            if (cl.c.bellyring === name)
-                cl.c.bellyring = null;
-            break;
-        default:
+        if (!cl.clearOutfitSlot(cl.saveOutfit[i], type, name))
             console.log("missing: " + type + ", " + name);
-            break;
     }
+    if (!cl.clearCurrentSlot(type, name))
+        console.log("missing: " + type + ", " + name);
     cl.display();
     g.popUpNotice("You lost your " + cl.list[clindex].display + ". ");
 };
 
 cl.showdick = function () {
-    cl.cTemp.shoes = cl.c.shoes;
-    cl.cTemp.socks = cl.c.socks;
-    cl.cTemp.pants = cl.c.pants;
-    cl.cTemp.panties = cl.c.panties;
-    cl.cTemp.bra = cl.c.bra;
-    cl.cTemp.shirt = cl.c.shirt;
-    cl.cTemp.dress = cl.c.dress;
-    cl.cTemp.swimsuit = cl.c.swimsuit;
-    cl.cTemp.pj = cl.c.pj;
-    cl.cTemp.buttplug = cl.c.buttplug;
+    cl.saveTempClothing();
 
     cl.c.pants = null;
     cl.c.panties = null;
@@ -408,16 +351,7 @@ cl.showdick = function () {
 };
 
 cl.nude = function () {
-    cl.cTemp.shoes = cl.c.shoes;
-    cl.cTemp.socks = cl.c.socks;
-    cl.cTemp.pants = cl.c.pants;
-    cl.cTemp.panties = cl.c.panties;
-    cl.cTemp.bra = cl.c.bra;
-    cl.cTemp.shirt = cl.c.shirt;
-    cl.cTemp.dress = cl.c.dress;
-    cl.cTemp.swimsuit = cl.c.swimsuit;
-    cl.cTemp.pj = cl.c.pj;
-    cl.cTemp.buttplug = cl.c.buttplug;
+    cl.saveTempClothing();
 
     cl.c.shoes = null;
     cl.c.socks = null;
@@ -432,45 +366,24 @@ cl.nude = function () {
 };
 
 cl.changeClothingSave = function () {
-    cl.cTemp.shoes = cl.c.shoes;
-    cl.cTemp.socks = cl.c.socks;
-    cl.cTemp.pants = cl.c.pants;
-    cl.cTemp.panties = cl.c.panties;
-    cl.cTemp.bra = cl.c.bra;
-    cl.cTemp.shirt = cl.c.shirt;
-    cl.cTemp.dress = cl.c.dress;
-    cl.cTemp.swimsuit = cl.c.swimsuit;
-    cl.cTemp.pj = cl.c.pj;
-    cl.cTemp.buttplug = cl.c.buttplug;
+    cl.saveTempClothing();
+};
+
+cl.saveTempClothing = function () {
+    cl.copySlots(cl.cTemp, cl.c, cl.tempClothingSlots());
 };
 
 cl.changeClothing = function (p) {
-    cl.c.shoes = cl.cTemp.shoes;
-    cl.c.socks = cl.cTemp.socks;
-    cl.c.pants = cl.cTemp.pants;
-    cl.c.panties = cl.cTemp.panties;
-    cl.c.bra = cl.cTemp.bra;
-    cl.c.shirt = cl.cTemp.shirt;
-    cl.c.dress = cl.cTemp.dress;
-    cl.c.swimsuit = cl.cTemp.swimsuit;
-    cl.c.pj = cl.cTemp.pj;
+    cl.restoreTempClothing();
     cl.display();
 };
 
+cl.restoreTempClothing = function () {
+    cl.copySlots(cl.c, cl.cTemp, cl.tempClothingSlots());
+};
+
 cl.checkTemp = function () {
-    let nude = false;
-    if (
-        cl.cTemp.shoes === null &&
-        cl.cTemp.socks === null &&
-        cl.cTemp.pants === null &&
-        cl.cTemp.panties === null &&
-        cl.cTemp.bra === null &&
-        cl.cTemp.shirt === null &&
-        cl.cTemp.dress === null &&
-        cl.cTemp.swimsuit === null &&
-        cl.cTemp.pj === null)
-        nude = true;
-    return { nude: nude };
+    return { nude: cl.areSlotsEmpty(cl.cTemp, cl.tempClothingSlots().filter(function (slot) { return slot !== "buttplug"; })) };
 };
 
 cl.undo = function(){
@@ -536,16 +449,7 @@ cl.where = function (type, name) {
 };
 
 cl.wearSavedOutfit = function (entry) {
-    cl.c.shoes = cl.saveOutfit[entry].shoes;
-    cl.c.socks = cl.saveOutfit[entry].socks;
-    cl.c.pants = cl.saveOutfit[entry].pants;
-    cl.c.panties = cl.saveOutfit[entry].panties;
-    cl.c.bra = cl.saveOutfit[entry].bra;
-    cl.c.shirt = cl.saveOutfit[entry].shirt;
-    cl.c.dress = cl.saveOutfit[entry].dress;
-    cl.c.swimsuit = cl.saveOutfit[entry].swimsuit;
-    cl.c.accessories = cl.saveOutfit[entry].accessories;
-    cl.c.pj = cl.saveOutfit[entry].pj;
+    cl.copySlots(cl.c, cl.saveOutfit[entry], cl.savedOutfitSlots());
     cl.display();
 };
 
@@ -2965,7 +2869,20 @@ cl.stretchButt = function (invItem, sizeItem) {
     alert("remove this - cl.stretchButt");
 }; 
 
+cl.markAvailableClothing = function (clothes, item) {
+    if (!item.inv)
+        return true;
+
+    if (!Object.prototype.hasOwnProperty.call(clothes, item.type))
+        return false;
+
+    clothes[item.type].has = true;
+    clothes[item.type].gender = item.sex;
+    return true;
+};
+
 cl.checkAllClothing = function () {
+    var i;
     var clothes = {
         necklace: { has: false, gender: null, type: "necklace" },
         panties: { has: false, gender: null, type: "panties" },
@@ -2985,131 +2902,9 @@ cl.checkAllClothing = function () {
         chastity: { has: false, gender: null, type: "chastity" },
         buttplug: { has: false, gender: null, type: "buttplug" }
     };
-    for (i = 0; i < cl.list.length; i++)
-        switch (cl.list[i].type) {
-            case "necklace":
-                if (cl.list[i].inv) {
-                    if (cl.list[i].gender !== "f") {
-                        clothes.necklace.has = true;
-                        clothes.necklace.gender = cl.list[i].sex;
-                    }
-                    else {
-                        clothes.necklace.has = true;
-                        clothes.necklace.gender = cl.list[i].sex;
-                    }
-                }
-                break;
-        case "shoes":
-                if (cl.list[i].inv) {
-                    if (cl.list[i].gender !== "f") {
-                        clothes.shoes.has = true;
-                        clothes.shoes.gender = cl.list[i].sex;
-                    }
-                    else {
-                        clothes.shoes.has = true;
-                        clothes.shoes.gender = cl.list[i].sex;
-                    }
-                }
-            break;
-        case "socks":
-                if (cl.list[i].inv) {
-                    if (cl.list[i].gender !== "f") {
-                        clothes.socks.has = true;
-                        clothes.socks.gender = cl.list[i].sex;
-                    }
-                    else {
-                        clothes.socks.has = true;
-                        clothes.socks.gender = cl.list[i].sex;
-                    }
-                }
-            break;
-        case "pants":
-                if (cl.list[i].inv) {
-                    if (cl.list[i].gender !== "f") {
-                        clothes.pants.has = true;
-                        clothes.pants.gender = cl.list[i].sex;
-                    }
-                    else {
-                        clothes.pants.has = true;
-                        clothes.pants.gender = cl.list[i].sex;
-                    }
-                }
-            break;
-        case "panties":
-                if (cl.list[i].inv) {
-                    if (cl.list[i].gender !== "f") {
-                        clothes.panties.has = true;
-                        clothes.panties.gender = cl.list[i].sex;
-                    }
-                    else {
-                        clothes.panties.has = true;
-                        clothes.panties.gender = cl.list[i].sex;
-                    }
-                }
-            break;
-        case "bra":
-                if (cl.list[i].inv) {
-                    if (cl.list[i].gender !== "f") {
-                        clothes.bra.has = true;
-                        clothes.bra.gender = cl.list[i].sex;
-                    }
-                    else {
-                        clothes.bra.has = true;
-                        clothes.bra.gender = cl.list[i].sex;
-                    }
-                }
-            break;
-        case "shirt":
-                if (cl.list[i].inv) {
-                    if (cl.list[i].gender !== "f") {
-                        clothes.shirt.has = true;
-                        clothes.shirt.gender = cl.list[i].sex;
-                    }
-                    else {
-                        clothes.shirt.has = true;
-                        clothes.shirt.gender = cl.list[i].sex;
-                    }
-                }
-            break;
-        case "dress":
-                if (cl.list[i].inv) {
-                    if (cl.list[i].gender !== "f") {
-                        clothes.dress.has = true;
-                        clothes.dress.gender = cl.list[i].sex;
-                    }
-                    else {
-                        clothes.dress.has = true;
-                        clothes.dress.gender = cl.list[i].sex;
-                    }
-                }
-            break;
-        case "swimsuit":
-                if (cl.list[i].inv) {
-                    if (cl.list[i].gender !== "f") {
-                        clothes.swimsuit.has = true;
-                        clothes.swimsuit.gender = cl.list[i].sex;
-                    }
-                    else {
-                        clothes.swimsuit.has = true;
-                        clothes.swimsuit.gender = cl.list[i].sex;
-                    }
-                }
-            break;
-        case "pj":
-                if (cl.list[i].inv) {
-                    if (cl.list[i].gender !== "f") {
-                        clothes.pj.has = true;
-                        clothes.pj.gender = cl.list[i].sex;
-                    }
-                    else {
-                        clothes.pj.has = true;
-                        clothes.pj.gender = cl.list[i].sex;
-                    }
-                }
-            break;
-        default:
+    for (i = 0; i < cl.list.length; i++) {
+        if (!cl.markAvailableClothing(clothes, cl.list[i]))
             console.log("missing: " + cl.list[i].type);
-            break;
-        }
+    }
     return clothes;
 };

--- a/scripts/clothes_zcl.js
+++ b/scripts/clothes_zcl.js
@@ -430,12 +430,7 @@ cl.displayMainWhere = function (thisArray, entry, top, left, ratio, dback) {
 
 zcl.displayMainSub = function (thisImage, top, left, ratio) {
     if (thisImage !== null) {
-        var btnWidth, btnHeight;
-        btnWidth = 2075 * ratio * g.ratio;
-        btnWidth = 4200 * ratio * g.ratio;
-        top = top * g.ratio;
-        left = left * g.ratio;
-        $('#room-buttons').append('<img src="./images/mainChar/' + thisImage + '" class="room-img" data-name="zzz-clothing-kill" style="width:' + btnWidth + 'px; top:' + top + 'px; left:' + left + 'px;" />');
+        zcl.renderImage("./images/mainChar/" + thisImage, top, left, 4200 * ratio * g.ratio, null, false);
     }
 };
 
@@ -1132,12 +1127,7 @@ zcl.assup = function (top, left, ratio, mod) {
 };
 
 cl.assupSub = function (thisImage, top, left, ratio) {
-    var btnWidth, btnHeight;
-    btnWidth = 2716 * ratio * g.ratio;
-    btnWidth = 1352 * ratio * g.ratio;
-    top = top * g.ratio;
-    left = left * g.ratio;
-    $('#room-buttons').append('<img src="./images/mainChar/assup/' + thisImage + '" class="room-img" data-name="zzz-clothing-kill" style="width:' + btnWidth + 'px; height:' + btnHeight + 'px; top:' + top + 'px; left:' + left + 'px;" />');
+    zcl.renderImage("./images/mainChar/assup/" + thisImage, top, left, 1352 * ratio * g.ratio, null, false);
 };
 
 
@@ -1173,10 +1163,14 @@ zcl.bent = function (top, left, ratio, mod, reverse = false) {
 
 
 zcl.subDisplay = function (thisImage, top, left, ratio, reverse, w, h, f) {
-    var btnWidth, btnHeight;
-    btnWidth = w * ratio * g.ratio;
-    btnHeight = h * ratio * g.ratio;
+    zcl.renderImage("./images/mainChar/" + f + "/" + thisImage, top, left, w * ratio * g.ratio, h * ratio * g.ratio, reverse);
+};
+
+zcl.renderImage = function (src, top, left, width, height, reverse) {
     top = top * g.ratio;
     left = left * g.ratio;
-    $('#room-buttons').append('<img src="./images/mainChar/' + f + '/' + thisImage + '" class="room-img" data-name="zzz-clothing-kill" style="width:' + btnWidth + 'px; height:' + btnHeight + 'px; top:' + top + 'px; left:' + left + 'px; ' + (reverse ? ' transform: scaleX(-1); ' : '') + '" />');
+    $('#room-buttons').append('<img src="' + src + '" class="room-img" data-name="zzz-clothing-kill" style="width:' + width + 'px;' +
+        (height === null ? '' : ' height:' + height + 'px;') +
+        ' top:' + top + 'px; left:' + left + 'px;' +
+        (reverse ? ' transform: scaleX(-1);' : '') + '" />');
 };

--- a/scripts/gamevariables.js
+++ b/scripts/gamevariables.js
@@ -52,6 +52,10 @@ gv.init = function () {
         { n: "dildoanal", t: 0, q: "int" },
         { n: "fingeranal", t: 0, q: "int" },
         { n: "dildooral", t: 0, q: "int" },
+        { n: "receiveOralMale", t: 0, q: "int" },
+        { n: "receiveOralFemale", t: 0, q: "int" },
+        { n: "receiveAnalMale", t: 0, q: "int" },
+        { n: "receiveAnalFemale", t: 0, q: "int" },
         { n: "beer", t: 0, q: "zero" },
         { n: "sissySchoolDream", t: false, q: "bool" },
         { n: "playWithPussy", t: false, q: "bool" },
@@ -740,6 +744,11 @@ gv.mod = function (name, amount) {
     var i, index, type;
     index = gv.i(name);
 
+    if (index === -1 && levels.i(name) > -1) {
+        levels.mod(name, amount);
+        return;
+    }
+
     if (index > -1) {
         type = gv.st[index].q;
         switch (type) {
@@ -831,47 +840,20 @@ gv.mod = function (name, amount) {
 };
 
 gv.getButtCum = function () {
-    var pig, horse, dog, human, cumType;
-    cumType = null;
-    pig = horse = dog = human = 0;
-    counter = 0;
+    var buttCum = gv.emptyCumTotals();
     for (i = 0; i < gv.st.length; i++) {
-        if (gv.st[i].n === "analCum") {
-            if (gv.st[i].t > 0) {
-                human = gv.st[i].t;
-                cumType = "cumjar";
-            }
-        }
-        else if (gv.st[i].n === "analCumDog") {
-            if (gv.st[i].t > 0) {
-                dog = gv.st[i].t;
-                cumType = "dogcumjar";
-            }
-        }
-        else if (gv.st[i].n === "analCumHorse") {
-            if (gv.st[i].t > 0) {
-                horse = gv.st[i].t;
-                cumType = "horsecumjar";
-            }
-        }
-        else if (gv.st[i].n === "analCumPig") {
-            if (gv.st[i].t > 0) {
-                pig = gv.st[i].t;
-                cumType = "pigcumjar";
+        for (let j = 0; j < gv.buttCumKeys.length; j++) {
+            if (gv.st[i].n === gv.buttCumKeys[j].stat && gv.st[i].t > 0) {
+                buttCum[gv.buttCumKeys[j].key] = gv.st[i].t;
+                buttCum.cumType = gv.buttCumKeys[j].cumType;
             }
         }
     }
-    return {
-        human: human,
-        dog: dog,
-        horse: horse,
-        pig: pig,
-        cumType: cumType,
-        total: human + dog + horse + pig
-    };
+    buttCum.total = buttCum.human + buttCum.dog + buttCum.horse + buttCum.pig;
+    return buttCum;
 };
 
-gv.getPussyCum = function () {
+gv.emptyCumTotals = function () {
     return {
         human: 0,
         dog: 0,
@@ -880,21 +862,26 @@ gv.getPussyCum = function () {
         cumType: null,
         total: 0
     };
-}
+};
+
+gv.buttCumKeys = [
+    { stat: "analCum", key: "human", cumType: "cumjar" },
+    { stat: "analCumDog", key: "dog", cumType: "dogcumjar" },
+    { stat: "analCumHorse", key: "horse", cumType: "horsecumjar" },
+    { stat: "analCumPig", key: "pig", cumType: "pigcumjar" }
+];
+
+gv.getPussyCum = function () {
+    return gv.emptyCumTotals();
+};
 
 gv.clearButtCum = function () {
     for (i = 0; i < gv.st.length; i++) {
-        if (gv.st[i].n === "analCum") {
-            gv.st[i].t = 0;
-        }
-        else if (gv.st[i].n === "analCumDog") {
-            gv.st[i].t = 0;
-        }
-        else if (gv.st[i].n === "analCumHorse") {
-            gv.st[i].t = 0;
-        }
-        else if (gv.st[i].n === "analCumPig") {
-            gv.st[i].t = 0;
+        for (let j = 0; j < gv.buttCumKeys.length; j++) {
+            if (gv.st[i].n === gv.buttCumKeys[j].stat) {
+                gv.st[i].t = 0;
+                break;
+            }
         }
     }
     cl.display();

--- a/scripts/gender.js
+++ b/scripts/gender.js
@@ -110,133 +110,135 @@ gender.cIndex = function (name) {
     return -1;
 }
 
+gender.entry = function (name) {
+    return gender.changes[gender.cIndex(name)];
+};
+
+gender.currentValue = function (cType) {
+    switch (cType) {
+        case "xdress": return cl.isCrossdressing();
+        case "panties": return cl.pantiesTxt() === "panties";
+        case "chest": return cl.c.chest;
+        case "leg": return cl.c.leg;
+        case "hairLength": return cl.c.hairLength;
+        case "hairColor": return cl.c.hairColor;
+        case "cock": return cl.c.cock;
+        case "chastity": return cl.c.chastity !== null;
+        default: console.log("gender.currentValue cType not found: " + cType); break;
+    }
+};
+
+gender.syncChangeField = function (entry, changes, field, currentValue) {
+    if (entry[field] === null) {
+        entry[field] = currentValue;
+    }
+    else if (entry[field] !== currentValue) {
+        changes[field] = true;
+        entry[field] = currentValue;
+    }
+};
+
 gender.changesGetSet = function (name, characterCanSeeCock) {
     var changes = {
         anyChanges: false,
         xdress: false,
+        panties: false,
         chest: false,
         leg: false,
-        hair: false,
-        haircolor: false,
+        hairLength: false,
+        hairColor: false,
         cock: false,
         chastity: false
     };
-    var i = gender.cIndex(name);
+    var entry = gender.entry(name);
     //xdress
-    if (!gender.changes[i].xdress && cl.isCrossdressing()) {
+    if (!entry.xdress && cl.isCrossdressing()) {
         changes.xdress = true;
-        gender.changes[i].xdress = true;
+        entry.xdress = true;
     }
 
     //panties
 
-    if (!gender.changes[i].panties && cl.pantiesTxt() === "panties") {
+    if (!entry.panties && cl.pantiesTxt() === "panties") {
         changes.panties = true;
-        gender.changes[i].panties = true;
+        entry.panties = true;
     }
 
-    //chest
-    if (gender.changes[i].chest === null) {
-        gender.changes[i].chest = cl.c.chest;
-    }
-    else if (cl.c.chest !== gender.changes[i].chest) {
-        changes.chest = true;
-        gender.changes[i].chest = cl.c.chest;
-    }
+    gender.syncChangeField(entry, changes, "chest", cl.c.chest);
+    gender.syncChangeField(entry, changes, "leg", cl.c.leg);
+    gender.syncChangeField(entry, changes, "hairLength", cl.c.hairLength);
+    gender.syncChangeField(entry, changes, "hairColor", cl.c.hairColor);
 
-    //leg (butt)
-    if (gender.changes[i].leg === null) {
-        gender.changes[i].leg = cl.c.leg;
+    if (entry.cock === null) {
+        entry.cock = cl.c.cock;
     }
-    else if (cl.c.leg !== gender.changes[i].leg) {
-        changes.leg = true;
-        gender.changes[i].leg = cl.c.leg;
-    }
-
-    //hair length
-    if (gender.changes[i].hairLength === null) {
-        gender.changes[i].hairLength = cl.c.hairLength;
-    }
-    else if (cl.c.hairLength !== gender.changes[i].hairLength) {
-        changes.hairLength = true;
-        gender.changes[i].hairLength = cl.c.hairLength;
-    }
-
-    //hair color
-    if (gender.changes[i].hairColor === null) {
-        gender.changes[i].hairColor = cl.c.hairColor;
-    }
-    else if (cl.c.hairColor !== gender.changes[i].hairColor) {
-        changes.hairColor = true;
-        gender.changes[i].hairColor = cl.c.hairColor;
-    }
-
-    if (gender.changes[i].cock === null) {
-        gender.changes[i].cock = cl.c.cock;
-    }
-    else if (cl.c.cock !== gender.changes[i].cock && characterCanSeeCock) {
+    else if (cl.c.cock !== entry.cock && characterCanSeeCock) {
         changes.cock = true;
-        gender.changes[i].cock = cl.c.cock;
+        entry.cock = cl.c.cock;
     }
 
-    if (cl.c.chastity !== null && characterCanSeeCock && !gender.changes[i].chastity) {
+    if (cl.c.chastity !== null && characterCanSeeCock && !entry.chastity) {
         changes.chastity = true;
-        gender.changes[i].cock = true;
+        entry.chastity = true;
     }
 
-    changes.anyChanges = (changes.xdress || changes.panties || changes.chest || changes.leg || changes.hairLength || changes.haircolor || changes.cock || changes.chastity);
+    changes.anyChanges = (changes.xdress || changes.panties || changes.chest || changes.leg || changes.hairLength || changes.hairColor || changes.cock || changes.chastity);
     return changes;
 };
 
 gender.setChanges = function (name, cType) {
-    var i = gender.cIndex(name);
+    var entry = gender.entry(name);
 
     switch (cType) {
-        case "xdress": gender.changes[i].xdress = cl.isCrossdressing(); break;
+        case "xdress": entry.xdress = cl.isCrossdressing(); break;
         case "panties":
             if (cl.pantiesTxt() === "panties")
-                gender.changes[i].panties = true;
+                entry.panties = true;
             break;
-        case "chest": gender.changes[i].chest = cl.c.chest; break;
-        case "leg": gender.changes[i].leg = cl.c.leg; break;
-        case "hairLength": gender.changes[i].hairLength = cl.c.hairLength; break;
-        case "hairColor": gender.changes[i].hairColor = cl.c.hairColor; break;
-        case "cock": gender.changes[i].cock = cl.c.cock; break;
+        case "chest":
+        case "leg":
+        case "hairLength":
+        case "hairColor":
+        case "cock":
+            entry[cType] = gender.currentValue(cType);
+            break;
         case "chastity":
             if (cl.c.chastity !== null)
-                gender.changes[i].chastity = true;
+                entry.chastity = true;
             break;
         default: console.log("gender.setChanges cType not found: " + cType); break;
     }
 };
 
 gender.getChange = function (name, cType) {
-    var i = gender.cIndex(name);
+    var entry = gender.entry(name);
 
     switch (cType) {
-        case "xdress": return gender.changes[i].xdress; 
-        case "panties": return gender.changes[i].panties; 
-        case "chest": return gender.changes[i].chest !== cl.c.chest; 
-        case "leg": return gender.changes[i].leg !== cl.c.leg; 
-        case "hairLength": return gender.changes[i].hairLength !== cl.c.hairLength; 
-        case "hairColor": return gender.changes[i].hairColor !== cl.c.hairColor; 
-        case "cock": return gender.changes[i].cock !== cl.c.cock; 
-        case "chastity": return gender.changes[i].chastity
+        case "xdress": return entry.xdress; 
+        case "panties": return entry.panties; 
+        case "chastity": return entry.chastity;
+        case "chest":
+        case "leg":
+        case "hairLength":
+        case "hairColor":
+        case "cock":
+            return entry[cType] !== gender.currentValue(cType);
         default: console.log("gender.setChanges cType not found: " + cType); break;
     }
 };
 
 gender.get = function (name, cType) {
-    var i = gender.cIndex(name);
+    var entry = gender.entry(name);
     switch (cType) {
-        case "xdress": return gender.changes[i].xdress;
-        case "panties": return gender.changes[i].panties;
-        case "chest": return gender.changes[i].chest;
-        case "leg": return gender.changes[i].leg;
-        case "hairLength": return gender.changes[i].hairLength;
-        case "hairColor": return gender.changes[i].hairColor;
-        case "cock": return gender.changes[i].cock;
-        case "chastity": return gender.changes[i].chastity
+        case "xdress":
+        case "panties":
+        case "chest":
+        case "leg":
+        case "hairLength":
+        case "hairColor":
+        case "cock":
+        case "chastity":
+            return entry[cType];
         default: console.log("gender.setChanges cType not found: " + cType); break;
     }
 };
@@ -251,13 +253,19 @@ gender.load = function (ra) {
     gender.init();
 
     $.each(ra, function (i, v) {
+        var entry = gender.entry(ra[i].name);
+        if (entry === undefined)
+            return;
         saveloop: for (j = 0; j < gender.changes.length; j++) {
             if (ra[i].name === gender.changes[j].name) {
                 gender.changes[j].xdress = ra[i].xdress;
+                gender.changes[j].panties = ra[i].panties !== undefined ? ra[i].panties : gender.changes[j].panties;
                 gender.changes[j].chest = ra[i].chest;
                 gender.changes[j].leg = ra[i].leg;
-                gender.changes[j].hair = ra[i].hair;
+                gender.changes[j].hairLength = ra[i].hairLength !== undefined ? ra[i].hairLength : ra[i].hair;
+                gender.changes[j].hairColor = ra[i].hairColor !== undefined ? ra[i].hairColor : gender.changes[j].hairColor;
                 gender.changes[j].cock = ra[i].cock;
+                gender.changes[j].chastity = ra[i].chastity !== undefined ? ra[i].chastity : gender.changes[j].chastity;
                 break saveloop;
             }
         }

--- a/scripts/global.js
+++ b/scripts/global.js
@@ -30,8 +30,11 @@ g.st = new Array();
 g.fmap;
 g.nextRoomId = 0;
 g.pastSaves = new Array();
+g.skipNextRoomSave = false;
 g.skipChat = false;
 g.saveAlert = false;
+g.noticeQueues = {};
+g.noticeCounter = 0;
 g.gt = function (first, second) {
     return gv.get(first) > gv.get(second);
 };
@@ -94,32 +97,76 @@ g.checkPop = function (name, amount) {
     }
 };
 
-g.popUpNotice = function (notice) {
+g.renderNoticeQueue = function (config) {
+    var element = $(config.selector);
+    var queue = g.noticeQueues[config.selector] || [];
 
-    if ($('#char_alert').is(":visible")) {
-        $('#char_alert').append("<hr />" + notice);
+    if (queue.length === 0) {
+        element.stop(true, true).fadeOut(config.fadeOut);
+        return;
     }
-    else {
-        $('#char_alert').html(notice).fadeIn(1000, function () {
-            $('#char_alert').fadeOut(3000);
-        });
+
+    var html = "";
+    for (var i = 0; i < queue.length; i++) {
+        if (i > 0)
+            html += "<hr />";
+        html += queue[i].notice;
     }
-    g.popupNoticeHistory(notice);
+
+    if (element.is(":visible"))
+        element.stop(true, true).html(html).show();
+    else
+        element.stop(true, true).html(html).fadeIn(config.fadeIn);
+};
+
+g.showNotice = function (config) {
+    if (!Object.prototype.hasOwnProperty.call(g.noticeQueues, config.selector))
+        g.noticeQueues[config.selector] = [];
+
+    var queue = g.noticeQueues[config.selector];
+    var noticeId = ++g.noticeCounter;
+    queue.push({ id: noticeId, notice: config.notice });
+    if (queue.length > 3)
+        queue.shift();
+
+    g.renderNoticeQueue(config);
+
+    setTimeout(function () {
+        var currentQueue = g.noticeQueues[config.selector] || [];
+        for (var i = 0; i < currentQueue.length; i++) {
+            if (currentQueue[i].id === noticeId) {
+                currentQueue.splice(i, 1);
+                break;
+            }
+        }
+        g.renderNoticeQueue(config);
+    }, config.delay > 0 ? config.delay : config.fadeOut);
+
+    g.popupNoticeHistory(config.notice);
+};
+
+g.popUpNotice = function (notice) {
+    g.showNotice({
+        selector: '#char_alert',
+        notice: notice,
+        fadeIn: 1000,
+        fadeOut: 3000,
+        delay: 0
+    });
 };
 
 g.popUpNoticeBottom = function (notice) {
-    if ($('#char_alert_bottom').is(":visible")) {
-        $('#char_alert_bottom').append("<hr />" + notice);
-    }
-    else {
-        $('#char_alert_bottom').html(notice).fadeIn(200, function () {
-            setTimeout(function () {
-                $('#char_alert_bottom').fadeOut(1000);
-            }, 2000 );
-            
-        });
-    }
-    g.popupNoticeHistory(notice);
+    var selector = $('.room-btn[data-room="1003"]:visible, .room-img[data-room="1003"]:visible').length > 0
+        ? '#char_alert'
+        : '#char_alert_bottom';
+
+    g.showNotice({
+        selector: selector,
+        notice: notice,
+        fadeIn: 200,
+        fadeOut: 1000,
+        delay: 2000
+    });
 };
 
 g.popupNoticeHistory = function (notice) {
@@ -162,7 +209,7 @@ g.rooms = [
     { roomID: 19, name: "On Bed", image: "19_layInBed/bg52.jpg", nightImage: "19_layInBed/bg52.jpg", houseID: 16, btn: "roomBtn_19.png" },
     { roomID: 20, name: "Dishes", image: "20_dishes/20_dishes.png", nightImage: "20_dishes/20_dishes.png", houseID: 16, btn: "roomBtn_20.png" },
     { roomID: 21, name: "Mother's Room Spanking", image: "21_motherSpank/021_spankBG.jpg", nightImage: "21_motherSpank/021_spankBG.jpg", houseID: 16, btn: "roomBtn_21.png" },
-    { roomID: 22, name: "Toilet", image: "22_toilet/12.jpg", nightImage: "22_toilet/12.jpg", houseID: 10, btn: "roomBtn_22.png" },
+    { roomID: 22, name: "Toilet", image: "22_toilet/a_12.jpg", nightImage: "22_toilet/a_12.jpg", houseID: 10, btn: "roomBtn_22.png" },
     { roomID: 23, name: "Truth or Dare", image: "24_spinTheBottle/013_spinBG.jpg", nightImage: "24_spinTheBottle/013_spinBG.jpg", houseID: 16, btn: "roomBtn_23.png" },
     { roomID: 24, name: "Spin the bottle", image: "24_spinTheBottle/013_spinBG.jpg", nightImage: "24_spinTheBottle/013_spinBG.jpg", houseID: 16, btn: "roomBtn_24.png" },
     { roomID: 25, name: "Dining Room", image: "25_dining/025_diningRoom.jpg", nightImage: "25_dining/025_diningRoomNight.jpg", houseID: 16, btn: "roomBtn_25.png" },
@@ -201,7 +248,7 @@ g.rooms = [
 
     { roomID: 125, name: "Jimmy's House", image: "125_poker/basement.jpg", nightImage: "125_poker/basement_night.jpg", houseID: 125, btn: "roomBtn_125.png" },
 
-    { roomID: 150, name: "Jones Home", image: "150_jones/frontdoor.jpg", nightImage: "150_jones/frontdoorNight.jpg", houseID: 150, btn: "roomBtn_150.png" },
+    { roomID: 150, name: "Jones Home", image: "150_jones/day.jpg", nightImage: "150_jones/night.jpg", houseID: 150, btn: "roomBtn_150.png" },
     { roomID: 151, name: "Jones Ent", image: "151_jones/bg.jpg", nightImage: "151_jones/bg.jpg", houseID: 150, btn: "roomBtn_151.png" },
     { roomID: 152, name: "Jones Sitting", image: "152_sittingRoom/bg.jpg", nightImage: "152_sittingRoom/bg.jpg", houseID: 150, btn: "roomBtn_152.png" },
     { roomID: 153, name: "Jones Bathroom", image: "153_bathroom/bg.jpg", nightImage: "153_bathroom/bg.jpg", houseID: 150, btn: "roomBtn_153.png" },
@@ -251,7 +298,7 @@ g.rooms = [
     { roomID: 215, name: "Whore Hallway", image: "215_pinkroom/bg.jpg", nightImage: "215_pinkroom/bg.jpg", houseID: 203, btn: "roomBtn_215.png" },
     { roomID: 216, name: "Glory Hole", image: "216_pinkglory/bg.jpg", nightImage: "216_pinkglory/bg.jpg", houseID: 203, btn: "roomBtn_216.png" },
     { roomID: 217, name: "Punishment", image: "217_punish/punish1.jpg", nightImage: "217_punish/punish1.jpg", houseID: 203, btn: "roomBtn_217.png" },
-    { roomID: 218, name: "masturbate", image: "218_masturbate/punish1.jpg", nightImage: "217_punish/punish1.jpg", houseID: 203, btn: "roomBtn_217.png" },
+    { roomID: 218, name: "masturbate", image: "218_masturbate/desk.jpg", nightImage: "218_masturbate/desk.jpg", houseID: 203, btn: "roomBtn_217.png" },
     { roomID: 219, name: "Data Entry", image: "219_dataEntry/bg.jpg", nightImage: "219_dataEntry/bg.jpg", houseID: 203, btn: "roomBtn_219.png" },
     { roomID: 220, name: "Clean Bathroom", image: "201_bathroom/bg0.jpg", nightImage: "201_bathroom/bg0.jpg", houseID: 203, btn: "roomBtn_201.png" },
     { roomID: 221, name: "Reception", image: "221_recip/bg.jpg", nightImage: "221_recip/bg.jpg", houseID: 203, btn: "roomBtn_203.png" },
@@ -268,7 +315,7 @@ g.rooms = [
 
     { roomID: 250, name: "Naked Beaver Diner", image: "250_beaver/250_beaver.jpg", nightImage: "250_beaver/250_beaver.jpg", houseID: 250, btn: "roomBtn_250.png" },
     { roomID: 251, name: "Back Office", image: "251_office/office.jpg", nightImage: "251_office/office.jpg", houseID: 250, btn: "roomBtn_251.png" },
-    { roomID: 252, name: "Naked Beaver Diner", image: "252_beaver/250_beaver.jpg", nightImage: "250_beaver/250_beaver.jpg", houseID: 250, btn: "roomBtn_250.png" },
+    { roomID: 252, name: "Naked Beaver Diner", image: "252_waitress/250_beaver.jpg", nightImage: "252_waitress/250_beaver.jpg", houseID: 250, btn: "roomBtn_250.png" },
 
     { roomID: 300, name: "First Floor", image: "300_apartment/bg.jpg", nightImage: "300_apartment/bg.jpg", houseID: 300, btn: "roomBtn_300.png" },
     { roomID: 301, name: "Living Room", image: "301_living/bg.jpg", nightImage: "301_living/bg.jpg", houseID: 300, btn: "roomBtn_301.png" },
@@ -353,7 +400,7 @@ g.rooms = [
     { roomID: 550, name: "Gym Front Desm", image: "550_gymFront/entrance.jpg", nightImage: "550_gymFront/entrance.jpg", houseID: 550, btn: "roomBtn_550.png" },
     { roomID: 551, name: "Gym", image: "551_gymInside/551_gym.jpg", nightImage: "551_gymInside/551_gym.jpg", houseID: 550, btn: "roomBtn_551.png" },
     { roomID: 552, name: "Boys Locker", image: "552_boy/lockeroom.jpg", nightImage: "552_boy/lockeroom.jpg", houseID: 550, btn: "roomBtn_552.png" },
-    { roomID: 553, name: "Girls Locker", image: "553_girl/553_girl.jpg", nightImage: "552_running/553_girl.jpg", houseID: 550, btn: "roomBtn_553.png" },
+    { roomID: 553, name: "Girls Locker", image: "553_girl/553_girl.jpg", nightImage: "553_girl/553_girl.jpg", houseID: 550, btn: "roomBtn_553.png" },
     { roomID: 554, name: "Gym Shower", image: "554_shower/552_shower.jpg", nightImage: "554_shower/552_shower.jpg", houseID: 550, btn: "roomBtn_554.png" },
     { roomID: 555, name: "Back Gym", image: "555_backgym/gym.jpg", nightImage: "555_backgym/gym.jpg", houseID: 550, btn: "roomBtn_555.png" },
     { roomID: 556, name: "Spar Training", image: "555_backgym/ring.jpg", nightImage: "555_backgym/ring.jpg", houseID: 550, btn: "roomBtn_555.png" },
@@ -706,7 +753,8 @@ g.save = function () {
         roomMap: new Array(),
         roomID: g.roomID,
         dt: g.dt,// g.dtstring() //timezone share bug fix
-        map: $.extend(true, {}, g.map)
+        map: $.extend(true, {}, g.map),
+        popArray: g.popArray.slice()
     };
 
     for (i = 0; i < g.roomMap.length; i++) {
@@ -737,6 +785,10 @@ g.load = function (rma) {
 
     if(rma.map !== undefined)
         g.map = $.extend(true, {}, rma.map);
+    if (rma.popArray !== undefined)
+        g.popArray = rma.popArray.slice();
+    else
+        g.popArray = new Array();
 
     g.roomMapInit();
 

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -16,6 +16,9 @@ var pic = {};
 //r = room painting
 inv.isFooter = true;
 inv.leftMenu = true;
+inv.prevPanel = "hide";
+inv.hadPanelOpen = false;
+inv.isOpen = false;
 inv.page = 0;
 inv.master = new Array();
 pic.master = new Array();
@@ -154,7 +157,7 @@ inv.init = function () {
         { type: "g", name: "chisel", display: "Chisel", entry: false, count: null, cost: -1, buy: 5, image: "chisel.png", n: false, desc: "Used to break out of prison. " },
         { type: "g", name: "pizza", display: "Frozen Pizza", entry: false, count: 0, cost: 24, buy: 3, image: "pizza.png", n: false, desc: "Frozen pizza for date night. " },
         { type: "g", name: "peanutbutter", display: "Peanut Butter", entry: false, count: 0, cost: 12, buy: 3, image: "peanutbutter.png", n: false, desc: "Jar of Peanut Butter. " },
-        { type: "g", name: "pickles", display: "Pickles", entry: false, count: 0, cost: 12, buy: 3, image: "pickles.png", n: false, desc: "Jar of Peanut Butter. " },
+        { type: "g", name: "pickles", display: "Pickles", entry: false, count: 0, cost: 12, buy: 3, image: "pickles.png", n: false, desc: "Jar of Pickles. " },
         { type: "g", name: "sleepingpills", display: "Sleeping pills", entry: false, count: 0, cost: -1, buy: null, image: "sleepingpills.png", n: false, desc: "Sleeping pills for you know who" },
 
         { type: "n", name: "magman", display: "Men's Magazine", entry: false, count: 0, cost: 20, buy: 2, image: "magman.png", n: false, desc: "For the Fashionable Male" },
@@ -301,16 +304,26 @@ pic.load = function (picList) {
 inv.backpack = "backpack";
 inv.phone = "phoneBasic";
 
+inv.canOpenMain = function () {
+    return ![401, 405].includes(g.roomID);
+};
+
+inv.openMain = function () {
+    if (!inv.canOpenMain()) {
+        g.popUpNotice("Inventory not accessable");
+        return false;
+    }
+
+    phone.clear(true);
+    inv.page = 0;
+    inv.isOpen = false;
+    inv.display();
+    return true;
+};
+
 $(document).ready(function () {
     $('#room-inv').click(function () {
-        let ignoreList = [401, 405];
-        if (ignoreList.includes(g.roomID))
-            g.popUpNotice("Inventory not accessable");
-        else {
-            phone.clear(true);
-            inv.page = 0;
-            inv.display();
-        }
+        inv.openMain();
     });
 });
 
@@ -320,6 +333,20 @@ inv.hide = function () {
 
 inv.show = function () {
     $("#room-inv").show();
+};
+
+inv.hideShellPanels = function () {
+    inv.prevPanel = char.currentMenuPanel();
+    inv.hadPanelOpen = inv.prevPanel !== "hide";
+    char.hideMenuPanels();
+};
+
+inv.restoreShellPanels = function () {
+    var panel = inv.prevPanel !== "hide" ? inv.prevPanel : g.prevview;
+    if (inv.hadPanelOpen && panel && panel !== "hide")
+        setTimeout(function () {
+            char.changeMenu(panel, false, true);
+        }, 0);
 };
 
 inv.getPhoneAsBackground = function () {
@@ -333,6 +360,77 @@ inv.gett = function (t) {
             return inv.t[i].n;
     }
     return "NOT FOUND";
+};
+
+inv.displayName = function (item) {
+    if (item.display !== undefined && item.display !== null && item.display.trim() !== "")
+        return item.display;
+    if (item.type === "3") {
+        var posterMatch = item.name.match(/_(\d+)$/);
+        if (posterMatch !== null)
+            return "Poster " + posterMatch[1];
+    }
+    return inv.gett(item.type);
+};
+
+inv.isSinglePurchase = function (item) {
+    return item.count === null || ["r", "0", "1", "2", "3"].includes(item.type);
+};
+
+inv.configureActionButton = function (selector, itemType, itemName, actionType, label) {
+    $(selector).attr("data-itype", actionType);
+    $(selector).attr("data-type", itemType);
+    $(selector).attr("data-name", itemName);
+    $(selector).html(label);
+    $(selector).show();
+};
+
+inv.setPrimaryAction = function (item, actionType, label) {
+    inv.configureActionButton("#menu_displayAction", item.type, item.name, actionType, label);
+};
+
+inv.setSecondaryAction = function (item, actionType, label) {
+    inv.configureActionButton("#menu_displayAction2", item.type, item.name, actionType, label);
+};
+
+inv.hideActions = function (hideCountLine) {
+    $("#menu_displayAction").hide();
+    if (hideCountLine)
+        $("#menu_displayCountLine").hide();
+};
+
+inv.setDisplayInfo = function (text) {
+    $("#menu_displayInfo").html(text);
+};
+
+inv.markPurchased = function (hideCountLine) {
+    inv.hideActions(hideCountLine);
+    inv.setDisplayInfo("PURCHASED");
+};
+
+inv.markUpdated = function () {
+    inv.hideActions(false);
+    inv.setDisplayInfo("UPDATED");
+};
+
+inv.refreshCurrentPurchaseRoom = function () {
+    if (g.roomID === 401)
+        invoker.invokeCurrent("main");
+};
+
+inv.redrawBedroomIfVisible = function () {
+    if (g.roomID === 10)
+        invoker.invoke(10, "btnclick", "drawRoom");
+};
+
+inv.selectGroupTypes = function (groupKey) {
+    if (groupKey === "q")
+        return null;
+    if (groupKey === "r")
+        return ["r", "1", "2", "3"];
+    if (groupKey === "d")
+        return ["d"];
+    return [groupKey];
 };
 
 inv.get = function (name) {
@@ -371,7 +469,7 @@ inv.add = function (name) {
             inv.master[i].entry = true;
             if (inv.master[i].count !== null)
                 inv.master[i].count = inv.master[i].count + 1;
-            g.popUpNotice(inv.master[i].display + " added to inventory. ");
+            g.popUpNotice(inv.displayName(inv.master[i]) + " added to inventory. ");
             i = 9999999;
         }
     }
@@ -384,10 +482,10 @@ inv.addMulti = function (name, count) {
             inv.master[i].entry = true;
             if (inv.master[i].count !== null) {
                 inv.master[i].count = inv.master[i].count + count;
-                g.popUpNotice("You receved " + count + " " + inv.master[i].display);
+                g.popUpNotice("You receved " + count + " " + inv.displayName(inv.master[i]));
             }
             else
-                g.popUpNotice(inv.master[i].display + " added to inventory. ");
+                g.popUpNotice(inv.displayName(inv.master[i]) + " added to inventory. ");
             i = 9999999;
         }
     }
@@ -461,20 +559,60 @@ inv.phoneIcon = function () {
     }
 };
 
+inv.renderInventoryEntry = function (counter, item) {
+    $('#menu-bg_' + counter).html('<img src="./images/inv/' + item.image + '" class="menu-select" data-inv="' + item.name + '" title="' + item.display + '">');
+    if (item.n)
+        $('#menu-bg_' + counter).append('<img src="./images/inv/new.png" title="New Inventory" class="display-top3 click-thru" title="' + item.display + '">');
+    if (item.count !== null)
+        $('#menu-bg_' + counter).append('<div class="menu-popup-count" data-name="' + item.name + '">' + item.count + '</div>');
+};
+
+inv.filterButtons = function () {
+    return [
+        { value: "q", label: "View All", top: 100 },
+        { value: "e", label: "Energy Snack", top: 200 },
+        { value: "b", label: "Purse", top: 260 },
+        { value: "p", label: "Phone Case", top: 320 },
+        { value: "r", label: "Room Decor", top: 380 },
+        { value: "m", label: "Makeup", top: 440 },
+        { value: "a", label: "Gifts", top: 500 },
+        { value: "d", label: "Dildos", top: 560 },
+        { value: "o", label: "Keys", top: 620 },
+        { value: "n", label: "Magazine", top: 680 }
+    ];
+};
+
+inv.renderFilterButton = function (button) {
+    $('.room-main').append('<button class="menu_inventory_grouping" data-val="' + button.value + '" style="' +
+        g.cssText(12) + '; ' + g.makeCss(50, 260, button.top, 90) + '; position:absolute; z-index:2;">' + button.label + '</button>');
+};
+
+inv.clothingPreviewSlots = function () {
+    return ["shoes", "socks", "pants", "panties", "bra", "shirt", "dress", "swimsuit"];
+};
+
+inv.getClothingPreviewSource = function (entry) {
+    return entry < 0 ? cl.cTemp : cl.saveOutfit[entry];
+};
+
+inv.renderClothingPreviewSlot = function (preview, slot, entry) {
+    var clothingName = preview[slot];
+    if (clothingName !== null)
+        return inv.displayClothesSub(cl.list[cl.where(slot, clothingName)].img, entry);
+
+    return "";
+};
+
 inv.display = function (typeArray = null) {
     inv.createElements(true);
     var counter = 0;
     var totalCounter = 0;
-    var i, prevI;
+    var i;
     if (typeArray === null) {
         for (i = 0; i < inv.master.length; i++) {
             if (inv.master[i].entry) {
                 if (totalCounter >= inv.page && counter < 31) {
-                    $('#menu-bg_' + counter).html('<img src="./images/inv/' + inv.master[i].image + '" class="menu-select" data-inv="' + inv.master[i].name + '" title="' + inv.master[i].display + '">');
-                    if (inv.master[i].n)
-                        $('#menu-bg_' + counter).append('<img src="./images/inv/new.png" title="New Inventory" class="display-top3 click-thru" title="' + inv.master[i].display + '">');
-                    if (inv.master[i].count !== null)
-                        $('#menu-bg_' + counter).append('<div class="menu-popup-count" data-name="' + inv.master[i].name + '">' + inv.master[i].count + '</div>');
+                    inv.renderInventoryEntry(counter, inv.master[i]);
                     counter++;
                 }
                 totalCounter++;
@@ -487,11 +625,7 @@ inv.display = function (typeArray = null) {
         for (i = 0; i < inv.master.length; i++) {
             if (inv.master[i].entry  && typeArray.includes(inv.master[i].type)) {
                 if (counter < 31) {
-                    $('#menu-bg_' + counter).html('<img src="./images/inv/' + inv.master[i].image + '" class="menu-select" data-inv="' + inv.master[i].name + '" title="' + inv.master[i].display + '">');
-                    if (inv.master[i].n)
-                        $('#menu-bg_' + counter).append('<img src="./images/inv/new.png" title="New Inventory" class="display-top3 click-thru" title="' + inv.master[i].display + '">');
-                    if (inv.master[i].count !== null)
-                        $('#menu-bg_' + counter).append('<div class="menu-popup-count" data-name="' + inv.master[i].name + '">' + inv.master[i].count + '</div>');
+                    inv.renderInventoryEntry(counter, inv.master[i]);
                     counter++;
                 }
                 totalCounter++;
@@ -501,8 +635,12 @@ inv.display = function (typeArray = null) {
     }
     counter++;
 
-    inv.isFooter = $('#room_footer').is(":visible");
-    if (inv.isFooter) { $('#room_footer').hide(); }
+    if (!inv.isOpen) {
+        inv.isFooter = $('#room_footer').is(":visible");
+        if (inv.isFooter) { $('#room_footer').hide(); }
+        inv.hideShellPanels();
+        inv.isOpen = true;
+    }
     $('.kill-invNew').remove();
 
     $('.menu-select').click(function () {
@@ -521,88 +659,45 @@ inv.display = function (typeArray = null) {
         $("#menu_displayCount").html("1");
         $("#menu_displayUp").attr("data-price", thisItem.cost);
         $("#menu_displayDown").attr("data-price", thisItem.cost);
+        $("#menu_displayAction2").hide();
 
         switch (thisItem.type) {
             case "b"://backpack
-                $("#menu_displayAction").attr("data-itype", "bag");
-                $("#menu_displayAction").attr("data-type", thisItem.type);
-                $("#menu_displayAction").attr("data-name", thisItem.name);
-                $("#menu_displayAction").html("Change Bag");
-                $("#menu_displayAction").show();
+                inv.setPrimaryAction(thisItem, "bag", "Change Bag");
                 break;
             case "e"://energy snack
-                $("#menu_displayAction").attr("data-itype", "bag");
-                $("#menu_displayAction").attr("data-type", thisItem.type);
-                $("#menu_displayAction").attr("data-name", thisItem.name);
-                $("#menu_displayAction").html("Snack Attack");
+                inv.setPrimaryAction(thisItem, "bag", "Snack Attack");
                 $("#menu_displayDesc").append(" - Max Energy: " + gv.get("maxenergy"));
-                $("#menu_displayAction").show();
                 break;
             case "n"://magazine
-                $("#menu_displayAction").attr("data-itype", "magazine");
-                $("#menu_displayAction").attr("data-type", thisItem.type);
-                $("#menu_displayAction").attr("data-name", thisItem.name);
-                $("#menu_displayAction").html("Read Magazine");
-                $("#menu_displayAction").show();
+                inv.setPrimaryAction(thisItem, "magazine", "Read Magazine");
                 break;
             case "p"://phone case
-                $("#menu_displayAction").attr("data-itype", "bag");
-                $("#menu_displayAction").attr("data-type", thisItem.type);
-                $("#menu_displayAction").attr("data-name", thisItem.name);
-                $("#menu_displayAction").html("Change Phone Case");
-                $("#menu_displayAction").show();
+                inv.setPrimaryAction(thisItem, "bag", "Change Phone Case");
                 break;
             case "r"://room decoration
-                $("#menu_displayAction").attr("data-itype", "bag");
-                $("#menu_displayAction").attr("data-type", thisItem.type);
-                $("#menu_displayAction").attr("data-name", thisItem.name);
-                $("#menu_displayAction").html("Change Apartment Picture");
-                $("#menu_displayAction").show();
+                inv.setPrimaryAction(thisItem, "bag", "Change Apartment Picture");
                 break;
             case "0"://room decoration
             case "1"://room decoration
             case "2"://room decoration
-                $("#menu_displayAction").attr("data-itype", "bag");
-                $("#menu_displayAction").attr("data-type", thisItem.type);
-                $("#menu_displayAction").attr("data-name", thisItem.name);
-                $("#menu_displayAction").html("Change Room Decoration");
-                $("#menu_displayAction").show();
+                inv.setPrimaryAction(thisItem, "bag", "Change Room Decoration");
                 break;
             case "3":
-                $("#menu_displayAction").attr("data-itype", "bag");
-                $("#menu_displayAction2").attr("data-itype", "bag");
-                $("#menu_displayAction").attr("data-type", thisItem.type);
-                $("#menu_displayAction").attr("data-name", thisItem.name);
-                $("#menu_displayAction2").attr("data-type", thisItem.type);
-                $("#menu_displayAction2").attr("data-name", thisItem.name);
-                $("#menu_displayAction").html("Change Left Poster");
-                $("#menu_displayAction2").html("Change Right Poster");
-                $("#menu_displayAction").show();
-                $("#menu_displayAction2").show();
+                inv.setPrimaryAction(thisItem, "bag", "Change Left Poster");
+                inv.setSecondaryAction(thisItem, "bag", "Change Right Poster");
                 break;
             case "h":
                 var xh = gv.get("autohormone");
 
                 if (xh) {
-                    $("#menu_displayAction").attr("data-itype", "bag");
-                    $("#menu_displayAction").attr("data-type", thisItem.type);
-                    $("#menu_displayAction").attr("data-name", thisItem.name);
-                    $("#menu_displayAction").html("Stop Auto Taking Pill");
-                    $("#menu_displayAction").show();
+                    inv.setPrimaryAction(thisItem, "bag", "Stop Auto Taking Pill");
                 }
                 else if (!daily.get("tookHormonePill")) {
-                    $("#menu_displayAction").attr("data-itype", "bag");
-                    $("#menu_displayAction").attr("data-type", thisItem.type);
-                    $("#menu_displayAction").attr("data-name", thisItem.name);
-                    $("#menu_displayAction").html("Take Your Pill");
-                    $("#menu_displayAction").show();
+                    inv.setPrimaryAction(thisItem, "bag", "Take Your Pill");
                 }
                 else {
-                    $("#menu_displayAction").attr("data-itype", "bag");
-                    $("#menu_displayAction").attr("data-type", thisItem.type);
-                    $("#menu_displayAction").attr("data-name", thisItem.name);
-                    $("#menu_displayAction").html("Auto Take Pill<br/>When Hormone < 90");
-                    $("#menu_displayAction").show();
+                    inv.setPrimaryAction(thisItem, "bag", "Auto Take Pill<br/>When Hormone < 90");
                 }
                 break;
             default:
@@ -636,29 +731,12 @@ inv.display = function (typeArray = null) {
 };
 
 inv.displayClothes = function (e) {
-    var t;
     var displayString = "";
-    if (e < 0)
-        t = cl.cTemp;
-    else
-        t = cl.saveOutfit[e];
-    
-    if (t.shoes !== null)
-        displayString += inv.displayClothesSub(cl.list[cl.where("shoes", t.shoes)].img, e);
-    if (t.socks !== null)
-        displayString += inv.displayClothesSub(cl.list[cl.where("socks", t.socks)].img, e);
-    if (t.pants !== null)
-        displayString += inv.displayClothesSub(cl.list[cl.where("pants", t.pants)].img, e);
-    if (t.panties !== null)
-        displayString += inv.displayClothesSub(cl.list[cl.where("panties", t.panties)].img, e);
-    if (t.bra !== null)
-        displayString += inv.displayClothesSub(cl.list[cl.where("bra", t.bra)].img, e);
-    if (t.shirt !== null)
-        displayString += inv.displayClothesSub(cl.list[cl.where("shirt", t.shirt)].img, e);
-    if (t.dress !== null)
-        displayString += inv.displayClothesSub(cl.list[cl.where("dress", t.dress)].img, e);
-    if (t.swimsuit !== null)
-        displayString += inv.displayClothesSub(cl.list[cl.where("swimsuit", t.swimsuit)].img, e);
+    var preview = inv.getClothingPreviewSource(e);
+
+    $.each(inv.clothingPreviewSlots(), function (_, slot) {
+        displayString += inv.renderClothingPreviewSlot(preview, slot, e);
+    });
     //if (t.accessories !== null)
     //    displayString += inv.displayClothesSub(cl.where("swimsuit", t.accessories).img);
 
@@ -669,11 +747,18 @@ inv.displayClothesSub = function (img, e) {
     return '<img src="./images/mainChar/icons/inv/' + img + '" class="inv-clothingChange" data-num="' + e + '"/>';
 };
 
-inv.close = function () {
+inv.close = function (preserveShell) {
     $('#room-menuButtons').html('').hide();
     $(".menu_inventory_grouping").remove();
-    if (inv.isFooter)
-        $('#room_footer').show();
+    if (!preserveShell) {
+        if (inv.isFooter || !$('#room_footer').is(":visible")) {
+            $('#room_footer').show();
+            char.updateRoomActionButtons();
+        }
+        inv.restoreShellPanels();
+        inv.isOpen = false;
+        inv.hadPanelOpen = false;
+    }
 };
 
 inv.createElements = function (showFilter = true) {
@@ -716,17 +801,9 @@ inv.createElements = function (showFilter = true) {
     $('#menu_displayAction2').hide();
 
     if (showFilter) {
-        $('.room-main').append('<button class="menu_inventory_grouping" data-val="q" style="' + g.cssText(12) + '; ' + g.makeCss(50, 260, 100, 90) + '; position:absolute; z-index:2;">View All</button>');
-        $('.room-main').append('<button class="menu_inventory_grouping" data-val="e" style="' + g.cssText(12) + '; ' + g.makeCss(50, 260, 200, 90) + '; position:absolute; z-index:2;">Energy Snack</button>');
-        $('.room-main').append('<button class="menu_inventory_grouping" data-val="b" style="' + g.cssText(12) + '; ' + g.makeCss(50, 260, 260, 90) + '; position:absolute; z-index:2;">Purse</button>');
-        $('.room-main').append('<button class="menu_inventory_grouping" data-val="p" style="' + g.cssText(12) + '; ' + g.makeCss(50, 260, 320, 90) + '; position:absolute; z-index:2;">Phone Case</button>');
-        $('.room-main').append('<button class="menu_inventory_grouping" data-val="r" style="' + g.cssText(12) + '; ' + g.makeCss(50, 260, 380, 90) + '; position:absolute; z-index:2;">Room Decor</button>');
-        $('.room-main').append('<button class="menu_inventory_grouping" data-val="m" style="' + g.cssText(12) + '; ' + g.makeCss(50, 260, 440, 90) + '; position:absolute; z-index:2;">Makeup</button>');
-        $('.room-main').append('<button class="menu_inventory_grouping" data-val="a" style="' + g.cssText(12) + '; ' + g.makeCss(50, 260, 500, 90) + '; position:absolute; z-index:2;">Gifts</button>');
-        $('.room-main').append('<button class="menu_inventory_grouping" data-val="d" style="' + g.cssText(12) + '; ' + g.makeCss(50, 260, 560, 90) + '; position:absolute; z-index:2;">Dildos</button>');
-        $('.room-main').append('<button class="menu_inventory_grouping" data-val="o" style="' + g.cssText(12) + '; ' + g.makeCss(50, 260, 620, 90) + '; position:absolute; z-index:2;">Keys</button>');
-        $('.room-main').append('<button class="menu_inventory_grouping" data-val="n" style="' + g.cssText(12) + '; ' + g.makeCss(50, 260, 680, 90) + '; position:absolute; z-index:2;">Magazine</button>');
-
+        $.each(inv.filterButtons(), function (_, button) {
+            inv.renderFilterButton(button);
+        });
     }
 
 
@@ -751,25 +828,18 @@ inv.createElements = function (showFilter = true) {
     $("#menu_displayAction2").click(function () {
         let thisName2 = $(this).attr("data-name");
         gv.set("mr_poster_r", thisName2);
-        if (g.roomID === 10) {
-            room10.btnclick("drawRoom");
-        }
+        inv.redrawBedroomIfVisible();
     });
 
     $('.menu_inventory_grouping').click(function () {
         let t = $(this).attr("data-val");
+        let typeArray;
         inv.page = 0;
-        if (t === "q") {
+        typeArray = inv.selectGroupTypes(t);
+        if (typeArray === null) {
             inv.display();
             return;
         }
-        let typeArray = [];
-        if (t === "r")
-            typeArray = ["r", "1", "2", "3"];
-        else if (t === "d")
-            typeArray = ["d"];
-        else
-            typeArray = [t];
 
         inv.display(typeArray);
     });
@@ -789,11 +859,12 @@ inv.createElements = function (showFilter = true) {
                     inv.master[ti].n = true;
                     inv.backpackIcon();
                 }
-                if (thisInv.count === null) {
-                    inv.add(thisName);
+                if (inv.isSinglePurchase(thisInv)) {
+                    thisInv.entry = true;
                     gv.mod("money", (-1 * thisInv.cost));
-                    $("#menu_displayAction").hide();
-                    $('#menu_displayInfo').html("PURCHASED");
+                    g.popUpNotice(inv.displayName(thisInv) + " added to inventory. ");
+                    inv.markPurchased(false);
+                    inv.refreshCurrentPurchaseRoom();
                 }
                 else {
                     var thisCount = parseInt($("#menu_displayCount").html());
@@ -806,10 +877,13 @@ inv.createElements = function (showFilter = true) {
                         inv.master[ti].count += thisCount;
                     inv.master[ti].entry = true;
                     gv.mod("money", totalMoney);
-                    $("#menu_displayAction").hide();
-                    $("#menu_displayCountLine").hide();
-                    $('#menu_displayInfo').html("PURCHASED");
-                    $("#menu_displayAdditional").html("In Inventory: " + inv.master[ti].count); 
+                    if (thisCount > 1)
+                        g.popUpNotice("You receved " + thisCount + " " + inv.displayName(thisInv));
+                    else
+                        g.popUpNotice(inv.displayName(thisInv) + " added to inventory. ");
+                    inv.markPurchased(true);
+                    $("#menu_displayAdditional").html("In Inventory: " + inv.master[ti].count);
+                    inv.refreshCurrentPurchaseRoom();
                 }
             }
             else
@@ -820,23 +894,21 @@ inv.createElements = function (showFilter = true) {
             
             if (tic !== null) {
                 if (cl.list[tic].inv) {
-                    $('#menu_displayInfo').html("Already Purchased");
-                    $("#menu_displayAction").hide();
-                    $("#menu_displayCountLine").hide();
+                    inv.setDisplayInfo("Already Purchased");
+                    inv.hideActions(true);
                 }
                 else {
                     var thisMoney = gv.get("money");
                     if (cl.list[tic].price > thisMoney) {
-                        $('#menu_displayInfo').html("Can't Afford");
-                        $("#menu_displayAction").hide();
-                        $("#menu_displayCountLine").hide();
+                        inv.setDisplayInfo("Can't Afford");
+                        inv.hideActions(true);
                     }
                     else {
                         cl.list[tic].inv = true;
                         gv.mod("money", -1 * cl.list[tic].price);
-                        $("#menu_displayAction").hide();
-                        $("#menu_displayCountLine").hide();
-                        $('#menu_displayInfo').html("PURCHASED");
+                        g.popUpNotice(cl.list[tic].display + " added to inventory. ");
+                        inv.markPurchased(true);
+                        inv.refreshCurrentPurchaseRoom();
                         if (cl.list[tic].type === "ear") {
                             cl.c.earring = cl.list[tic].name;
                             cl.display();
@@ -862,8 +934,7 @@ inv.createElements = function (showFilter = true) {
                 case "b"://backpack
                     inv.backpack = thisName;
                     inv.backpackIcon();
-                    $("#menu_displayInfo").html("UPDATED");
-                    $("#menu_displayAction").hide();
+                    inv.markUpdated();
                     inv.close();
                     break;
                 case "e"://energy snack
@@ -945,33 +1016,24 @@ inv.createElements = function (showFilter = true) {
                                 "image": "52_myroom/" + thisName + ".png",
                             }, 52);
                     }
-                    $("#menu_displayInfo").html("UPDATED");
-                    $("#menu_displayAction").hide();
+                    inv.markUpdated();
                     inv.close();
                     break;
                 case "0":
                     gv.set("mr_paint", thisName);
-                    if (g.roomID === 10) {
-                        room10.btnclick("drawRoom");
-                    }
+                    inv.redrawBedroomIfVisible();
                     break;
                 case "1":
                     gv.set("mr_bed", thisName);
-                    if (g.roomID === 10) {
-                        room10.btnclick("drawRoom");
-                    }
+                    inv.redrawBedroomIfVisible();
                     break;
                 case "2":
                     gv.set("mr_rug", thisName);
-                    if (g.roomID === 10) {
-                        room10.btnclick("drawRoom");
-                    }
+                    inv.redrawBedroomIfVisible();
                     break;
                 case "3":
                     gv.set("mr_poster_l", thisName);
-                    if (g.roomID === 10) {
-                        room10.btnclick("drawRoom");
-                    }
+                    inv.redrawBedroomIfVisible();
                     break;
                 case "h":
                     var xh = gv.get("autohormone");
@@ -1068,7 +1130,7 @@ inv.createElements = function (showFilter = true) {
 
 inv.paging = function (pageSize) {
     inv.page += pageSize;
-    inv.close();
+    inv.close(true);
     inv.display();
 }
 

--- a/scripts/invoker.js
+++ b/scripts/invoker.js
@@ -1,0 +1,102 @@
+var invoker = {
+    rooms: {},
+    fallbackHits: {},
+    fallbackWarnings: true,
+    fallbackMode: "warn"
+};
+
+invoker.roomName = function (roomID) {
+    return "room" + roomID.toString();
+};
+
+invoker.registerRoom = function (roomID, handlers) {
+    invoker.rooms[roomID] = handlers;
+    return handlers;
+};
+
+invoker.setFallbackMode = function (mode) {
+    var allowed = ["allow", "warn", "strict"];
+    if (allowed.indexOf(mode) === -1)
+        throw new Error("Invoker error: invalid fallback mode [" + mode + "]");
+
+    invoker.fallbackMode = mode;
+};
+
+invoker.trackFallback = function (roomID, roomName) {
+    var key = roomID.toString();
+    if (!Object.prototype.hasOwnProperty.call(invoker.fallbackHits, key)) {
+        invoker.fallbackHits[key] = {
+            roomID: roomID,
+            roomName: roomName,
+            count: 0
+        };
+    }
+
+    invoker.fallbackHits[key].count++;
+
+    if (invoker.fallbackMode === "warn" && invoker.fallbackWarnings && invoker.fallbackHits[key].count === 1 && typeof console !== "undefined" && typeof console.warn === "function")
+        console.warn("Invoker fallback used for " + roomName + " [roomID=" + roomID + "]");
+};
+
+invoker.getFallbackReport = function () {
+    var report = [];
+    for (var key in invoker.fallbackHits) {
+        if (Object.prototype.hasOwnProperty.call(invoker.fallbackHits, key)) {
+            report.push({
+                roomID: invoker.fallbackHits[key].roomID,
+                roomName: invoker.fallbackHits[key].roomName,
+                count: invoker.fallbackHits[key].count
+            });
+        }
+    }
+    report.sort(function (a, b) { return a.roomID - b.roomID; });
+    return report;
+};
+
+invoker.resetFallbackReport = function () {
+    invoker.fallbackHits = {};
+};
+
+invoker.error = function (roomID, commandName, message) {
+    var text = "Invoker error: " + message + " [roomID=" + roomID + ", command=" + commandName + "]";
+    if (typeof g !== "undefined" && typeof g.error === "function")
+        g.error("invoker", text);
+    throw new Error(text);
+};
+
+invoker.resolveRoom = function (roomID) {
+    if (Object.prototype.hasOwnProperty.call(invoker.rooms, roomID))
+        return invoker.rooms[roomID];
+
+    var roomName = invoker.roomName(roomID);
+    if (typeof window[roomName] !== "undefined") {
+        if (invoker.fallbackMode === "strict")
+            invoker.error(roomID, "resolveRoom", "fallback disabled for unregistered room");
+
+        invoker.trackFallback(roomID, roomName);
+        invoker.rooms[roomID] = window[roomName];
+        return window[roomName];
+    }
+
+    return null;
+};
+
+invoker.invoke = function (roomID, commandName) {
+    var room = invoker.resolveRoom(roomID);
+    var args = Array.prototype.slice.call(arguments, 2);
+
+    if (room === null)
+        invoker.error(roomID, commandName, "room not found");
+
+    if (typeof room[commandName] !== "function")
+        invoker.error(roomID, commandName, "command not found");
+
+    return room[commandName].apply(room, args);
+};
+
+invoker.invokeCurrent = function (commandName) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    args.unshift(commandName);
+    args.unshift(g.roomID);
+    return invoker.invoke.apply(invoker, args);
+};

--- a/scripts/lockpick.js
+++ b/scripts/lockpick.js
@@ -1,5 +1,62 @@
-﻿lockpick = {};
+lockpick = {};
 var room1003 = {};
+
+lockpick.clearTimer = function () {
+    if (g.roomTimeout2 !== null) {
+        clearTimeout(g.roomTimeout2);
+        g.roomTimeout2 = null;
+    }
+};
+
+lockpick.scheduleTick = function () {
+    g.roomTimeout2 = setTimeout(function () {
+        invoker.invoke(1003, "btnclick", "tick");
+    }, 1000);
+};
+
+lockpick.showTimer = function () {
+    nav.t({
+        type: "img",
+        name: "lockpickq_timer",
+        left: 1020,
+        top: 420,
+        font: 30,
+        hex: "#000000",
+        text: "Time left: " + g.fight.timer
+    }, 1003);
+};
+
+lockpick.showResult = function (name, image) {
+    nav.button({
+        "type": "img",
+        "name": "lockpickq_kill",
+        "left": 0,
+        "top": 0,
+        "width": 1920,
+        "height": 1080,
+        "image": "1001_rand/black_25.png"
+    }, 1003);
+
+    nav.button({
+        "type": "btn",
+        "name": name,
+        "left": 915,
+        "top": 360,
+        "width": 400,
+        "height": 100,
+        "image": image
+    }, 1003);
+};
+
+lockpick.finish = function (buttonName, giveReward) {
+    lockpick.clearTimer();
+    if (giveReward)
+        levels.mod("pi", 25);
+    nav.killbuttonStartsWith("lockpickq_");
+    $('#room_footer').show();
+    invoker.invoke(g.fight.roomID, "btnclick", buttonName);
+};
+
 //difficulty: 1, 2, 3, 4 (number of key slots)
 lockpick.init = function (difficulty, btnPressWin, btnPressLost, timer, roomID) {
     $('#room_footer').hide();
@@ -98,15 +155,14 @@ lockpick.init = function (difficulty, btnPressWin, btnPressLost, timer, roomID) 
         }
     }
 
-    nav.t({
-        type: "img",
-        name: "lockpickq_timer",
-        left: 1020,
-        top: 420,
-        font: 30,
-        hex: "#000000",
-        text: "Time left: " + timer
-    }, 1003);
+    g.fight = {
+        btnPressWin: btnPressWin,
+        btnPressLost: btnPressLost,
+        roomID: roomID,
+        timer: timer
+    };
+
+    lockpick.showTimer();
 
     nav.button({
         "type": "img",
@@ -135,16 +191,8 @@ lockpick.init = function (difficulty, btnPressWin, btnPressLost, timer, roomID) 
             "image": "1003_lockpick/" + (i + 1) + "_" + thisKey + "x.png"
         }, 1003);
     }
-    g.fight = {
-        btnPressWin: btnPressWin,
-        btnPressLost: btnPressLost,
-        roomID: roomID,
-        timer: timer
-    };
 
-    g.roomTimeout2 = setTimeout(function () {
-        room1003.btnclick("tick");
-    }, 1000);
+    lockpick.scheduleTick();
 };
 
 room1003.btnclick = function (callback) {
@@ -152,75 +200,22 @@ room1003.btnclick = function (callback) {
         nav.killbutton("lockpickq_timer");
         g.fight.timer--;
         if (g.fight.timer < 1) {
-            nav.button({
-                "type": "img",
-                "name": "lockpickq_kill",
-                "left": 0,
-                "top": 0,
-                "width": 1920,
-                "height": 1080,
-                "image": "1001_rand/black_25.png"
-            }, 1003);
-
-            nav.button({
-                "type": "btn",
-                "name": "lockpickq_fail",
-                "left": 915,
-                "top": 360,
-                "width": 400,
-                "height": 100,
-                "image": "1003_lockpick/time.png"
-            }, 1003);
+            lockpick.showResult("lockpickq_fail", "1003_lockpick/time.png");
         }
         else {
-            nav.t({
-                type: "img",
-                name: "lockpickq_timer",
-                left: 1020,
-                top: 420,
-                font: 30,
-                hex: "#000000",
-                text: "Time left: " + g.fight.timer
-            }, 1003);
-            g.roomTimeout2 = setTimeout(function () {
-                room1003.btnclick("tick");
-            }, 1000);
+            lockpick.showTimer();
+            lockpick.scheduleTick();
         }
     }
     else if (callback === "lockpickq_winner") {
-        clearTimeout(g.roomTimeout2);
-        nav.button({
-            "type": "img",
-            "name": "lockpickq_kill",
-            "left": 0,
-            "top": 0,
-            "width": 1920,
-            "height": 1080,
-            "image": "1001_rand/black_25.png"
-        }, 1003);
-
-        nav.button({
-            "type": "btn",
-            "name": "lockpickq_success",
-            "left": 915,
-            "top": 360,
-            "width": 400,
-            "height": 100,
-            "image": "1003_lockpick/success.png"
-        }, 1003);
+        lockpick.clearTimer();
+        lockpick.showResult("lockpickq_success", "1003_lockpick/success.png");
     }
     else if (callback === "lockpickq_success") {
-        clearTimeout(g.roomTimeout2);
-        levels.mod("pi", 25);
-        nav.killbuttonStartsWith("lockpickq_");
-        $('#room_footer').show();
-        window[g.room(g.fight.roomID)]["btnclick"](g.fight.btnPressWin);
+        lockpick.finish(g.fight.btnPressWin, true);
     }
     else if (callback === "lockpickq_fail") {
-        clearTimeout(g.roomTimeout2);
-        nav.killbuttonStartsWith("lockpickq_");
-        $('#room_footer').show();
-        window[g.room(g.fight.roomID)]["btnclick"](g.fight.btnPressLost);
+        lockpick.finish(g.fight.btnPressLost, false);
     }
     else {
         nav.killbutton(callback);
@@ -249,3 +244,5 @@ room1003.btnclick = function (callback) {
         //}
     }
 };
+
+invoker.registerRoom(1003, room1003);

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -2,6 +2,53 @@
 m.fmap = null;
 m.row = 80;
 m.col = 20;
+m.directionConfig = {
+    north: { title: "North", glyph: "dn", suffix: "_n", webpLeft: 840, webpTop: 200 },
+    south: { title: "South", glyph: "ds", suffix: "_s", webpLeft: 840, webpTop: 880 },
+    west: { title: "West", glyph: "dw", suffix: "_w", webpLeft: 300, webpTop: 460 },
+    east: { title: "East", glyph: "de", suffix: "_e", webpLeft: 1600, webpTop: 460 }
+};
+
+m.pushWebpDirectionButton = function (buttons, direction) {
+    var cfg = m.directionConfig[direction];
+    buttons.push({
+        "type": "btn",
+        "name": direction,
+        "title": cfg.title,
+        "left": cfg.webpLeft,
+        "top": cfg.webpTop,
+        "width": 225,
+        "height": 75,
+        "image": "475_fight/" + cfg.glyph + ".png"
+    });
+};
+
+m.drawBlockedWebpDirection = function (bg, direction) {
+    var cfg = m.directionConfig[direction];
+    nav.button({
+        "type": "img",
+        "name": direction,
+        "title": cfg.title,
+        "left": 0,
+        "top": 0,
+        "width": 1920,
+        "height": 1080,
+        "image": "475_fight/" + bg + cfg.suffix + ".webp"
+    }, 475);
+};
+
+m.drawVisitButton = function () {
+    nav.button({
+        "type": "zbtn",
+        "name": "visit",
+        "title": "Visit",
+        "left": 450,
+        "top": 100,
+        "width": 225,
+        "height": 75,
+        "image": "475_fight/visit.png"
+    }, 475);
+};
 
 //m -> path
 //i -> forest queen
@@ -95,29 +142,11 @@ m.drawBackground = function (row, col) {
         if (row > 0) {
             if (webplogic) {
                 if (m.fmap[row - 1][col].used !== 'x') {
-                    webpbuttons.push({
-                        "type": "btn",
-                        "name": "north",
-                        "title": "North",
-                        "left": 840,
-                        "top": 200,
-                        "width": 225,
-                        "height": 75,
-                        "image": "475_fight/dn.png"
-                    });
+                    m.pushWebpDirectionButton(webpbuttons, "north");
                     pathCounter++;
                 }
                 else {
-                    nav.button({
-                        "type": "img",
-                        "name": "north",
-                        "title": "North",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "475_fight/" + bg + "_n.webp"
-                    }, 475);
+                    m.drawBlockedWebpDirection(bg, "north");
                 }
             }
             else if (m.fmap[row - 1][col].used !== 'x') {
@@ -147,29 +176,11 @@ m.drawBackground = function (row, col) {
         if (row < m.row - 1) {
             if (webplogic) {
                 if (m.fmap[row + 1][col].used !== 'x') {
-                    webpbuttons.push({
-                        "type": "btn",
-                        "name": "south",
-                        "title": "South",
-                        "left": 840,
-                        "top": 880,
-                        "width": 225,
-                        "height": 75,
-                        "image": "475_fight/ds.png"
-                    });
+                    m.pushWebpDirectionButton(webpbuttons, "south");
                     pathCounter++;
                 }
                 else {
-                    nav.button({
-                        "type": "img",
-                        "name": "south",
-                        "title": "South",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "475_fight/" + bg + "_s.webp"
-                    }, 475);
+                    m.drawBlockedWebpDirection(bg, "south");
                 }
             }
             else if (m.fmap[row + 1][col].used !== 'x') {
@@ -199,29 +210,11 @@ m.drawBackground = function (row, col) {
         if (col > 0) {
             if (webplogic) {
                 if (m.fmap[row][col - 1].used !== 'x') {
-                    webpbuttons.push({
-                        "type": "btn",
-                        "name": "west",
-                        "title": "West",
-                        "left": 300,
-                        "top": 460,
-                        "width": 225,
-                        "height": 75,
-                        "image": "475_fight/dw.png"
-                    });
+                    m.pushWebpDirectionButton(webpbuttons, "west");
                     pathCounter++;
                 }
                 else {
-                    nav.button({
-                        "type": "img",
-                        "name": "west",
-                        "title": "West",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "475_fight/" + bg + "_w.webp"
-                    }, 475);
+                    m.drawBlockedWebpDirection(bg, "west");
                 }
             }
             else if (m.fmap[row][col - 1].used !== 'x') {
@@ -252,29 +245,11 @@ m.drawBackground = function (row, col) {
         if (col < m.col - 1) {
             if (webplogic) {
                 if (m.fmap[row][col + 1].used !== 'x') {
-                    webpbuttons.push({
-                        "type": "btn",
-                        "name": "east",
-                        "title": "East",
-                        "left": 1600,
-                        "top": 460,
-                        "width": 225,
-                        "height": 75,
-                        "image": "475_fight/de.png"
-                    });
+                    m.pushWebpDirectionButton(webpbuttons, "east");
                     pathCounter++;
                 }
                 else {
-                    nav.button({
-                        "type": "img",
-                        "name": "east",
-                        "title": "East",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "475_fight/" + bg + "_e.webp"
-                    }, 475);
+                    m.drawBlockedWebpDirection(bg, "east");
                 }
             }
             else if (m.fmap[row][col + 1].used !== 'x') {
@@ -371,16 +346,7 @@ m.drawBackground = function (row, col) {
                 pathCounter++;
             }
         }
-        nav.button({
-            "type": "zbtn",
-            "name": "visit",
-            "title": "Visit",
-            "left": 450,
-            "top": 100,
-            "width": 225,
-            "height": 75,
-            "image": "475_fight/visit.png"
-        }, 475);
+        m.drawVisitButton();
     }
     else {
         nav.bg("475_fight/z" + m.fmap[row][col].used + "1.jpg", "475_fight/z" + m.fmap[row][col].used + "1_n.jpg");
@@ -488,16 +454,7 @@ m.drawBackground = function (row, col) {
                 pathCounter++;
             }
         }
-        nav.button({
-            "type": "zbtn",
-            "name": "visit",
-            "title": "Visit",
-            "left": 450,
-            "top": 100,
-            "width": 225,
-            "height": 75,
-            "image": "475_fight/visit.png"
-        }, 475);
+        m.drawVisitButton();
     }
     for (let i = 0; i < webpbuttons.length; i++) {
         nav.button(webpbuttons[i], 475);

--- a/scripts/missyHelper.js
+++ b/scripts/missyHelper.js
@@ -184,6 +184,16 @@ missy.didJob = function (jobId, payMulti, payOverride) {
         missy.mod("weeklyPay", payOverride);
 };
 
+missy.buildCaseEntry = function (caseId, active, notReadyTxt, callback) {
+    return {
+        caseId: caseId,
+        active: active,
+        icon: "case" + caseId.toString() + (active ? "" : "_no") + ".png",
+        notReadyTxt: notReadyTxt,
+        callback: callback
+    };
+};
+
 missy.getcases = function () {
     var i;
     var caseList = new Array();
@@ -205,13 +215,7 @@ missy.getcases = function () {
     //must do first case (Has explaination)
     if (completeCounter === 0) {
         canDoCase = cl.c.chest > 0;
-        caseList.push({
-            caseId: 4,
-            active: canDoCase,
-            icon: "case4" + (canDoCase ? "" : "_no") + ".png",
-            notReadyTxt: "Need to get in shape first piggy. oink oink!",
-            callback: missy.cases[4].name
-        });
+        caseList.push(missy.buildCaseEntry(4, canDoCase, "Need to get in shape first piggy. oink oink!", missy.cases[4].name));
     } //list all cases
     else {
         for (i = 0; i < missy.cases.length; i++) {
@@ -219,184 +223,88 @@ missy.getcases = function () {
                 switch (missy.cases[i].name) {
                     case "case_booth":
                         canDoCase = piLevel > 0;
-                        caseList.push({
-                            caseId: i,
-                            active: canDoCase,
-                            icon: "case" + i.toString() + (canDoCase ? "" : "_no") + ".png",
-                            notReadyTxt: "Need to increase improve your Invistation expertise (Level 1).",
-                            callback: missy.cases[i].name
-                        });
+                        caseList.push(missy.buildCaseEntry(i, canDoCase, "Need to increase improve your Invistation expertise (Level 1).", missy.cases[i].name));
                         break;
                     case "case_lostgirl":
                         canDoCase = piLevel > 1;
-                        caseList.push({
-                            caseId: i,
-                            active: canDoCase,
-                            icon: "case" + i.toString() + (canDoCase ? "" : "_no") + ".png",
-                            notReadyTxt: "Need to increase improve your Invistation expertise (Level 2).",
-                            callback: missy.cases[i].name
-                        });
+                        caseList.push(missy.buildCaseEntry(i, canDoCase, "Need to increase improve your Invistation expertise (Level 2).", missy.cases[i].name));
                         break;
                     case "case_trash":
                         if (completeCounter > 1) {
                             canDoCase = piLevel > 2;
-                            caseList.push({
-                                caseId: i,
-                                active: canDoCase,
-                                icon: "case" + i.toString() + (canDoCase ? "" : "_no") + ".png",
-                                notReadyTxt: "Need to increase improve your Invistation expertise (Level 3).",
-                                callback: missy.cases[i].name
-                            });
+                            caseList.push(missy.buildCaseEntry(i, canDoCase, "Need to increase improve your Invistation expertise (Level 3).", missy.cases[i].name));
                         }
                         break;
                     case "case_goth":
                         canDoCase = piLevel > 1;
-                        caseList.push({
-                            caseId: i,
-                            active: canDoCase,
-                            icon: "case" + i.toString() + (canDoCase ? "" : "_no") + ".png",
-                            notReadyTxt: "Need to increase improve your Invistation expertise (Level 2).",
-                            callback: missy.cases[i].name
-                        });
+                        caseList.push(missy.buildCaseEntry(i, canDoCase, "Need to increase improve your Invistation expertise (Level 2).", missy.cases[i].name));
                         break;
                     case "case_shopping":
                         if (qdress.st[1].ach) {
                             canDoCase = qdress.st[3].ach;
-                            caseList.push({
-                                caseId: i,
-                                active: canDoCase,
-                                icon: "case" + i.toString() + (canDoCase ? "" : "_no") + ".png",
-                                notReadyTxt: "Find it in yourself to wear women's clothing. [Unlock Women's clothing in your dreams]",
-                                callback: missy.cases[i].name
-                            });
+                            caseList.push(missy.buildCaseEntry(i, canDoCase, "Find it in yourself to wear women's clothing. [Unlock Women's clothing in your dreams]", missy.cases[i].name));
                         }
                         break;
                     case "case_bimbopanties":
                         if (levels.get("pi").l > 2) {
                             canDoCase = inv.has("lockpick");
-                            caseList.push({
-                                caseId: i,
-                                active: canDoCase,
-                                icon: "case" + i.toString() + (canDoCase ? "" : "_no") + ".png",
-                                notReadyTxt: "Work everyday till Missy decides you're worthy of the lock picking class Intelligence Level 4. ",
-                                callback: missy.cases[i].name
-                            });
+                            caseList.push(missy.buildCaseEntry(i, canDoCase, "Work everyday till Missy decides you're worthy of the lock picking class Intelligence Level 4. ", missy.cases[i].name));
                         }
                         break;
                     case "case_elijah_origin": 
                         if (levels.get("pi").l > 2) {
                             canDoCase = piLevel > 3;
-                            caseList.push({
-                                caseId: i,
-                                active: canDoCase,
-                                icon: "case" + i.toString() + (canDoCase ? "" : "_no") + ".png",
-                                notReadyTxt: "Raise your PI Level. ",
-                                callback: missy.cases[i].name
-                            });
+                            caseList.push(missy.buildCaseEntry(i, canDoCase, "Raise your PI Level. ", missy.cases[i].name));
                         }
                         break;
                     case "case_elijah":
                         if (qdress.st[3].ach && sissy.st[10].ach && missy.cases[15].success) {
                             canDoCase = true;
-                            caseList.push({
-                                caseId: i,
-                                active: canDoCase,
-                                icon: "case" + i.toString() + (canDoCase ? "" : "_no") + ".png",
-                                notReadyTxt: "Raise your PI Level. ",
-                                callback: missy.cases[i].name
-                            });
+                            caseList.push(missy.buildCaseEntry(i, canDoCase, "Raise your PI Level. ", missy.cases[i].name));
                         }
                         break;
                     case "case_elijah_boyfriend":
                         if (missy.cases[13].success && future.get("case_elijah_complete") === -1) {
                             canDoCase = true;
-                            caseList.push({
-                                caseId: i,
-                                active: true,
-                                icon: "case" + i.toString() + (canDoCase ? "" : "_no") + ".png",
-                                notReadyTxt: "Raise your PI Level. ",
-                                callback: missy.cases[i].name
-                            });
+                            caseList.push(missy.buildCaseEntry(i, true, "Raise your PI Level. ", missy.cases[i].name));
                         }
                         break;
                     case "case_beaver":
                         if (missy.get("uniform") > 0) {
                             canDoCase = piLevel > 2;
-                            caseList.push({
-                                caseId: i,
-                                active: canDoCase,
-                                icon: "case" + i.toString() + (canDoCase ? "" : "_no") + ".png",
-                                notReadyTxt: "Raise your PI Level. ",
-                                callback: missy.cases[i].name
-                            });
+                            caseList.push(missy.buildCaseEntry(i, canDoCase, "Raise your PI Level. ", missy.cases[i].name));
                         }
                         break;
                     case "case_saveralph":
                         if (sissy.st[10].ach) {
                             canDoCase = true;
-                            caseList.push({
-                                caseId: i,
-                                active: canDoCase,
-                                icon: "case" + i.toString() + (canDoCase ? "" : "_no") + ".png",
-                                notReadyTxt: "...",
-                                callback: missy.cases[i].name
-                            });
+                            caseList.push(missy.buildCaseEntry(i, canDoCase, "...", missy.cases[i].name));
                         }
                         break;
                     case "case_damselle":
                         if (cl.pantiesTxt() === "panties" && cl.c.chest > 0 && g.dt.getDay() < 4)  {
                             canDoCase = piLevel > 2;
-                            caseList.push({
-                                caseId: i,
-                                active: canDoCase,
-                                icon: "case" + i.toString() + (canDoCase ? "" : "_no") + ".png",
-                                notReadyTxt: "Raise your PI Level. ",
-                                callback: missy.cases[i].name
-                            });
+                            caseList.push(missy.buildCaseEntry(i, canDoCase, "Raise your PI Level. ", missy.cases[i].name));
                         }
                         break;
                     case "case_carnival":
                         if (sissy.st[21].ach) {
-                            caseList.push({
-                                caseId: i,
-                                active: true,
-                                icon: "case" + i.toString() + ".png",
-                                notReadyTxt: "Raise your PI Level. ",
-                                callback: missy.cases[i].name
-                            });
+                            caseList.push(missy.buildCaseEntry(i, true, "Raise your PI Level. ", missy.cases[i].name));
                         }
                         break;
                     case "case_farm":
                         if (missy.cases[18].complete) {
-                            caseList.push({
-                                caseId: i,
-                                active: true,
-                                icon: "case" + i.toString() + ".png",
-                                notReadyTxt: "N/A. ",
-                                callback: missy.cases[i].name
-                            });
+                            caseList.push(missy.buildCaseEntry(i, true, "N/A. ", missy.cases[i].name));
                         }
                         break;
                     case "case_sewer":
                         if (missy.cases[18].complete) {
-                            caseList.push({
-                                caseId: i,
-                                active: true,
-                                icon: "case" + i.toString() + ".png",
-                                notReadyTxt: "N/A. ",
-                                callback: missy.cases[i].name
-                            });
+                            caseList.push(missy.buildCaseEntry(i, true, "N/A. ", missy.cases[i].name));
                         }
                         break;
                     case "case_cult": 
                         if (missy.cases[20].complete) {
-                            caseList.push({
-                                caseId: i,
-                                active: true,
-                                icon: "case" + i.toString() + ".png",
-                                notReadyTxt: "N/A. ",
-                                callback: missy.cases[i].name
-                            });
+                            caseList.push(missy.buildCaseEntry(i, true, "N/A. ", missy.cases[i].name));
                         }
                         break;
                 }
@@ -437,10 +345,10 @@ missy.save = function () {
 missy.load = function (saveData) {
     var i;
     missy.init();
-    for (i = 0; i < saveData.st.length; i++) {
+    for (i = 0; i < saveData.st.length && i < missy.st.length; i++) {
         missy.st[i].c = saveData.st[i];
     }
-    for (i = 0; i < saveData.cases.length; i++) {
+    for (i = 0; i < saveData.cases.length && i < missy.cases.length; i++) {
         missy.cases[i].complete = saveData.cases[i].complete;
         missy.cases[i].success = saveData.cases[i].success;
     }

--- a/scripts/nav.js
+++ b/scripts/nav.js
@@ -1,5 +1,41 @@
 ﻿var nav = {};
 
+nav.clearRoomTimeouts = function () {
+    if (g.roomTimeout !== null) {
+        clearTimeout(g.roomTimeout);
+        g.roomTimeout = null;
+    }
+    if (g.roomTimeout2 !== null) {
+        clearTimeout(g.roomTimeout2);
+        g.roomTimeout2 = null;
+    }
+};
+
+nav.getButtonClasses = function (type) {
+    switch (type) {
+        case "dark": return "room-img img-dark";
+        case "btn": return "room-btn rom-event";
+        case "btnNoHover": return "room-btnNoHover rom-event";
+        case "kiss": return "room-btn-lips rom-event";
+        case "tongue": return "room-btn-tongue rom-event";
+        case "ztongue": return "room-btn-tongue rom-event room-zindex";
+        case "dick": return "room-btn-dick rom-event";
+        case "brush": return "room-btn-brush rom-event";
+        case "hand": return "room-btn-hand rom-event";
+        case "zhand": return "room-btn-hand rom-event room-zindex";
+        case "grab": return "room-btn-grab rom-event";
+        case "vib": return "room-btn-vib rom-event";
+        case "btnflat": return "room-btnflat room-btn rom-event";
+        case "zimg": return "room-img room-zindex";
+        case "zbtn": return "room-btn rom-event room-zindex";
+        case "btnhover": return "room-btn rom-event fight-hover";
+        case "imghover": return "room-img fight-hover-element";
+        case "clickthrough": return "room-img click-thru";
+        case "zclickthrough": return "room-img click-thru room-zindex";
+        default: return "room-img";
+    }
+};
+
 nav.setRatio = function () {
     var width = $(window).width();
     var height = $(window).height();
@@ -11,14 +47,7 @@ nav.buildRoom = function () {
     nav.killvideo();
     var vList = null;
 
-    if (g.roomTimeout !== null) {
-        clearTimeout(g.roomTimeout);
-        g.roomTimeout = null;
-    }
-    if (g.roomTimeout2 !== null) {
-        clearTimeout(g.roomTimeout2);
-        g.roomTimeout2 = null;
-    }
+    nav.clearRoomTimeouts();
     $('#room-animationFront').html('');
     $('#room-animationStandby').html('');
 
@@ -36,7 +65,7 @@ nav.buildRoom = function () {
         $('#room-buttons').html("");
         $('#room_footer').html('');
         try {
-            window[g.room(vList.roomID)]["main"]();
+            invoker.invoke(vList.roomID, "main");
         }
         catch (ex) {
             console.log(ex);
@@ -49,33 +78,62 @@ nav.buildRoom = function () {
 };
 
 nav.killall = function () {
-    if (g.roomTimeout !== null) {
-        clearTimeout(g.roomTimeout);
-        g.roomTimeout = null;
-    }
-    if (g.roomTimeout2 !== null) {
-        clearTimeout(g.roomTimeout2);
-        g.roomTimeout2 = null;
-    }
+    nav.clearRoomTimeouts();
     $('#room-buttons').html("");
     $('#room_footer').html("");
 };
 
 nav.kill = function () {
-    if (g.roomTimeout !== null) {
-        clearTimeout(g.roomTimeout);
-        g.roomTimeout = null;
-    }
-    if (g.roomTimeout2 !== null) {
-        clearTimeout(g.roomTimeout2);
-        g.roomTimeout2 = null;
-    }
+    nav.clearRoomTimeouts();
     $('#room-buttons').html("");
 };
 
-nav.bg = function (image, night) {
+nav.resolveMapCloseFallback = function (image, night) {
+    var match = /map\/(\d+)_close(?:night)?\.jpg$/.exec(image);
+    if (match === null) {
+        return null;
+    }
+
+    var roomId = parseInt(match[1], 10);
+    var roomMeta = null;
+    $.each(g.rooms, function (i, room) {
+        if (room.roomID === roomId) {
+            roomMeta = room;
+            return false;
+        }
+    });
+
+    if (roomMeta === null) {
+        return null;
+    }
+
+    return {
+        image: roomMeta.image,
+        night: roomMeta.nightImage === undefined ? roomMeta.image : roomMeta.nightImage
+    };
+};
+
+nav.buildBgTag = function (src, gameWidth, gameHeight, fallbackSrc) {
+    var onError = fallbackSrc === undefined || fallbackSrc === null
+        ? ""
+        : ' onerror="this.onerror=null;this.src=\'./images/room/' + fallbackSrc + '\';"';
+    return '<img src="./images/room/' + src + '" style="width:' + gameWidth + 'px; height:' + gameHeight + ';"' + onError + '/>';
+};
+
+nav.bg = function (image, night, fallbackImage, fallbackNight) {
     if (night === undefined)
         night = image;
+    if (fallbackNight === undefined)
+        fallbackNight = fallbackImage;
+
+    if (fallbackImage === undefined) {
+        var mapCloseFallback = nav.resolveMapCloseFallback(image, night);
+        if (mapCloseFallback !== null) {
+            fallbackImage = mapCloseFallback.image;
+            fallbackNight = mapCloseFallback.night;
+        }
+    }
+
     var gameWidth = 1920 * g.ratio;
     var gameHeight = 1080 * g.ratio;
     if (image.endsWith(".mp4")) {
@@ -85,9 +143,9 @@ nav.bg = function (image, night) {
             '</video>');
     }
     else if (g.isNight())
-        $('#room-background').html('<img src="./images/room/' + night + '" style="width:' + gameWidth + 'px; height:' + gameHeight + ';"/>');
+        $('#room-background').html(nav.buildBgTag(night, gameWidth, gameHeight, fallbackNight));
     else
-        $('#room-background').html('<img src="./images/room/' + image + '" style="width:' + gameWidth + 'px; height:' + gameHeight + ';"/>');
+        $('#room-background').html(nav.buildBgTag(image, gameWidth, gameHeight, fallbackImage));
 };
 
 nav.button = function (btn, roomNum) {
@@ -104,55 +162,15 @@ nav.button = function (btn, roomNum) {
         $("#room-video")[0].load();
     }
     else {
-        var classes = "room-img";
+        var classes = nav.getButtonClasses(btn.type);
         var charAttr = "";
+        var spaceAdvanceAttr = btn.spaceAdvance ? ' data-space-advance="true"' : "";
         var thisImage = btn.image;
         if (g.isNight() && (typeof btn.night !== "undefined"))
             thisImage = btn.night;
-
-        if (btn.type === "dark")
-            classes = "room-img img-dark";
-        else if (btn.type === "btn")
-            classes = "room-btn rom-event";
-        else if (btn.type === "btnNoHover")
-            classes = "room-btnNoHover rom-event";
-        else if (btn.type === "kiss")
-            classes = "room-btn-lips rom-event";
-        else if (btn.type === "tongue")
-            classes = "room-btn-tongue rom-event";
-        else if (btn.type === "ztongue")
-            classes = "room-btn-tongue rom-event room-zindex";
-        else if (btn.type === "dick")
-            classes = "room-btn-dick rom-event";
-        else if (btn.type === "brush")
-            classes = "room-btn-brush rom-event";
-        else if (btn.type === "hand")
-            classes = "room-btn-hand rom-event";
-        else if (btn.type === "zhand")
-            classes = "room-btn-hand rom-event room-zindex";
-        else if (btn.type === "grab")
-            classes = "room-btn-grab rom-event";
-        else if (btn.type === "vib")
-            classes = "room-btn-vib rom-event";
-        else if (btn.type === "btnflat")
-            classes = "room-btnflat room-btn rom-event";
-        else if (btn.type === "zimg")
-            classes = "room-img room-zindex";
-        else if (btn.type === "zbtn")
-            classes = "room-btn rom-event room-zindex";
-        else if (btn.type === "btnhover")
-            classes = "room-btn rom-event fight-hover";
-        else if (btn.type === "imghover")
-            classes = "room-img fight-hover-element";
-        else if (btn.type === "clickthrough") {
-            classes = "room-img click-thru";
-        }
-        else if (btn.type === "zclickthrough") {
-            classes = "room-img click-thru room-zindex";
-        }
         if ("char" in btn)
             charAttr = ' data-char="' + btn.char + ' "';
-        line = '<img src="./images/room/' + thisImage + '" class="' + classes + '" data-name="' + btn.name + '" data-room="' + roomNum + '" title="' + (("title" in btn) ? btn.title : "") + charAttr + '" style="width:' + btnWidth + 'px; height:' + btnHeight + 'px; top:' + top + 'px; left:' + left + 'px;" />';
+        line = '<img src="./images/room/' + thisImage + '" class="' + classes + '" data-name="' + btn.name + '" data-room="' + roomNum + '"' + spaceAdvanceAttr + ' title="' + (("title" in btn) ? btn.title : "") + charAttr + '" style="width:' + btnWidth + 'px; height:' + btnHeight + 'px; top:' + top + 'px; left:' + left + 'px;" />';
         $('#room-buttons').append(line);
     }
     $('img').on('dragstart', function (event) { event.preventDefault(); });
@@ -171,31 +189,10 @@ nav.t = function (btn, roomNum) {
     var top = btn.top * g.ratio;
     var left = btn.left * g.ratio;
 
-    var classes = "room-img";
+    var classes = nav.getButtonClasses(btn.type);
     var thisHex = "#000000";
     if (g.isNight() && (typeof btn.night !== "undefined"))
         thisImage = btn.night;
-
-    if (btn.type === "btn")
-        classes = "room-btn rom-event";
-    else if (btn.type === "kiss")
-        classes = "room-btn-lips rom-event";
-    else if (btn.type === "tongue")
-        classes = "room-btn-tongue rom-event";
-    else if (btn.type === "hand")
-        classes = "room-btn-hand rom-event";
-    else if (btn.type === "grab")
-        classes = "room-btn-grab rom-event";
-    else if (btn.type === "btnflat")
-        classes = "room-btnflat room-btn rom-event";
-    else if (btn.type === "zimg")
-        classes = "room-img room-zindex";
-    else if (btn.type === "zbtn")
-        classes = "room-btn rom-event room-zindex";
-    else if(btn.type === "btnhover")
-        classes = "room-btn rom-event fight-hover";
-    else if (btn.type === "clickthrough")
-        classes = "room-img click-thru";
 
     if (btn.font === 12)
         classes += " char-12 ";
@@ -225,38 +222,11 @@ nav.inputbox = function (btn, roomNum) {
     var left = btn.left * g.ratio;
     var btnWidth = btn.width * g.ratio;
     var btnHeight = btn.height * g.ratio;
-    var classes = "room-img";
+    var classes = nav.getButtonClasses(btn.type);
     var charAttr = "";
     var thisImage = btn.image;
     if (g.isNight() && (typeof btn.night !== "undefined"))
         thisImage = btn.night;
-
-    if (btn.type === "dark")
-        classes = "room-img img-dark";
-    else if (btn.type === "btn")
-        classes = "room-btn rom-event";
-    else if (btn.type === "btnNoHover")
-        classes = "room-btnNoHover rom-event";
-    else if (btn.type === "kiss")
-        classes = "room-btn-lips rom-event";
-    else if (btn.type === "tongue")
-        classes = "room-btn-tongue rom-event";
-    else if (btn.type === "brush")
-        classes = "room-btn-brush rom-event";
-    else if (btn.type === "hand")
-        classes = "room-btn-hand rom-event";
-    else if (btn.type === "grab")
-        classes = "room-btn-grab rom-event";
-    else if (btn.type === "btnflat")
-        classes = "room-btnflat room-btn rom-event";
-    else if (btn.type === "zimg")
-        classes = "room-img room-zindex";
-    else if (btn.type === "zbtn")
-        classes = "room-btn rom-event room-zindex";
-    else if (btn.type === "btnhover")
-        classes = "room-btn rom-event fight-hover";
-    else if (btn.type === "imghover")
-        classes = "room-img fight-hover-element";
 
     line = '<input type="text" class="resize-font ' + classes + '" data-name="' + btn.name + '" data-room="' + roomNum + '" value="' + (("title" in btn) ? btn.title : "") + charAttr + '" style="width:' + btnWidth + 'px; height:' + btnHeight + 'px; top:' + top + 'px; left:' + left + 'px;" />';
 
@@ -264,30 +234,16 @@ nav.inputbox = function (btn, roomNum) {
 };
 
 nav.modbutton = function (name, newImage, newName, newType) {
+    var element = nav.getButtonElement(name);
     if (newName === null)
         newName = name;
     if(newImage !== null)
-        $('img[data-name="' + name + '"]').attr("src", "./images/room/" + newImage).attr("data-name", newName);
+        element.attr("src", "./images/room/" + newImage).attr("data-name", newName);
     else
-        $('img[data-name="' + name + '"]').attr("data-name", newName);
+        element.attr("data-name", newName);
 
-    if (newType !== null) {
-        $('img[data-name="' + name + '"]')
-            .removeClass("room-btn")
-            .removeClass("room-btn-grab")
-            .removeClass("rom-event")
-            .removeClass("rom-tongue")
-            .removeClass("room-btn-lips");
-
-        if (newType === "img")
-            $('img[data-name="' + name + '"]').addClass("room-img");
-        else if (newType === "btn")
-            $('img[data-name="' + name + '"]').addClass("room-btn rom-event");
-        else if (newType === "kiss")
-            $('img[data-name="' + name + '"]').addClass("room-btn-lips rom-event");
-        else if (newType === "tongue")
-            $('img[data-name="' + name + '"]').addClass("room-btn-tongue rom-event");
-    }
+    if (newType !== null)
+        nav.applyModButtonType(element, newType);
 };
 
 nav.flash = function (thisImage, length) {
@@ -314,6 +270,28 @@ nav.killbutton = function (name) {
 nav.killbuttonStartsWith = function (name) {
     $('[data-name^="' + name + '"]').remove();
 
+};
+
+nav.getButtonElement = function (name) {
+    return $('img[data-name="' + name + '"]');
+};
+
+nav.applyModButtonType = function (element, newType) {
+    element
+        .removeClass("room-btn")
+        .removeClass("room-btn-grab")
+        .removeClass("rom-event")
+        .removeClass("rom-tongue")
+        .removeClass("room-btn-lips");
+
+    if (newType === "img")
+        element.addClass("room-img");
+    else if (newType === "btn")
+        element.addClass("room-btn rom-event");
+    else if (newType === "kiss")
+        element.addClass("room-btn-lips rom-event");
+    else if (newType === "tongue")
+        element.addClass("room-btn-tongue rom-event");
 };
 
 nav.buildnav = function (roomIDList, rebuild = false) {
@@ -384,7 +362,7 @@ nav.progressBar = function (btn, roomId) {
     let maxVal = btn.maxVal;
     let val = btn.val;
     let bgColor, fgColor;
-    let classes = "room-img";
+    let classes = nav.getButtonClasses(btn.type);
     if (val > maxVal)
         val = maxVal;
     if (val < 0)
@@ -436,39 +414,6 @@ nav.progressBar = function (btn, roomId) {
             break;
     }
 
-    if (btn.type === "dark")
-        classes = "room-img img-dark";
-    else if (btn.type === "btn")
-        classes = "room-btn rom-event";
-    else if (btn.type === "btnNoHover")
-        classes = "room-btnNoHover rom-event";
-    else if (btn.type === "kiss")
-        classes = "room-btn-lips rom-event";
-    else if (btn.type === "tongue")
-        classes = "room-btn-tongue rom-event";
-    else if (btn.type === "dick")
-        classes = "room-btn-dick rom-event";
-    else if (btn.type === "brush")
-        classes = "room-btn-brush rom-event";
-    else if (btn.type === "hand")
-        classes = "room-btn-hand rom-event";
-    else if (btn.type === "grab")
-        classes = "room-btn-grab rom-event";
-    else if (btn.type === "vib")
-        classes = "room-btn-vib rom-event";
-    else if (btn.type === "btnflat")
-        classes = "room-btnflat room-btn rom-event";
-    else if (btn.type === "zimg")
-        classes = "room-img room-zindex";
-    else if (btn.type === "zbtn")
-        classes = "room-btn rom-event room-zindex";
-    else if (btn.type === "btnhover")
-        classes = "room-btn rom-event fight-hover";
-    else if (btn.type === "imghover")
-        classes = "room-img fight-hover-element";
-    else if (btn.type === "clickthrough") {
-        classes = "room-img click-thru";
-    }
     nav.killbutton(btn.name);
     $('#room-buttons').append('<div class="resize ' + classes + '" data-name="' + btn.name + '" data-room="' + roomId + '" style=" ' + bgCss + '  background: ' + bgColor + '; border-radius:100px;" ></div>');
     $('#room-buttons').append('<div class="resize ' + classes + '" data-name="' + btn.name + '" data-room="' + roomId + '" style=" ' + fgCss + '  background: ' + fgColor + '; border-radius:100px;" ></div>');
@@ -572,7 +517,16 @@ nav.close = function (btnClickName, sroomid = null) {
 };
 
 nav.next = function (btnClickName, sroomid = null) {
-    nav.drawButton("1001_rand/next.png", btnClickName, sroomid);
+    nav.button({
+        "type": "zbtn",
+        "name": btnClickName,
+        "left": 1695,
+        "top": 920,
+        "width": 225,
+        "height": 75,
+        "image": "1001_rand/next.png",
+        "spaceAdvance": true
+    }, sroomid === null ? g.roomID : sroomid);
 };
 
 nav.back = function (btnClickName, sroomid = null) {

--- a/scripts/phone.js
+++ b/scripts/phone.js
@@ -1,28 +1,495 @@
 ﻿var phone = {};
 var room9999 = {};
 phone.charPointer = 0;
+phone.preservedMenuOverlay = null;
 //var pic = {};
 
-phone.build = function (selection = null) {
-    phone.clear(true);
-    inv.close();
-    var btnList = [
+phone.mainButtons = function () {
+    return [
         { n: "phone_save", img: "bSave", x: 0, y: 0 },
         { n: "phone_rel", img: "bRelationships", x: 1, y: 0 },
         { n: "phone_contacts", img: "bContacts", x: 2, y: 0 },
         { n: "phone_pic", img: "bPic", x: 3, y: 0 },
-        
-        //{ n: "phone_stats", img: "bStats", x: 0, y: 1 },
         { n: "phone_time", img: "bTime", x: 0, y: 1 },
         { n: "phone_purity", img: "bPurity", x: 1, y: 1 },
         { n: "phone_ach", img: "bAch", x: 2, y: 1 },
         { n: "phone_settings", img: "bSettings", x: 3, y: 1 },
-
         { n: "phone_cheat", img: "bCheat", x: 0, y: 2 },
         { n: "phone_help", img: "bHelp", x: 1, y: 2 },
         { n: "phone_patron", img: "bPatron", x: 2, y: 2 },
         { n: "phone_thankyou", img: "bPatreon", x: 3, y: 2 }
     ];
+};
+
+phone.findMainButton = function (name) {
+    return phone.mainButtons().find(function (button) {
+        return button.n === name;
+    }) || null;
+};
+
+phone.getAchievementGroups = function (index) {
+    switch (index) {
+        case 0: return ["panties", "bra"];
+        case 1: return ["oral", "anal", "vaginal"];
+        case 2: return ["fuck"];
+        case 3: return ["event", "school", "pinkroom"];
+        case 4: return ["end"];
+        default: return [];
+    }
+};
+
+phone.showAchievementGroup = function (index) {
+    phone.charPointer = index;
+    invoker.invoke(9999, "btnclick", "phone_ach_draw");
+};
+
+phone.isOpen = function () {
+    return $('[data-name="phonex_reserve"]:visible').length > 0;
+};
+
+phone.close = function () {
+    if (!phone.isOpen())
+        return false;
+
+    phone.clear(true);
+    phone.restoreMenuOverlay();
+    return true;
+};
+
+phone.handleSaveMenuAction = function (name) {
+    let slotId;
+
+    if (name === "phone_save_load_cancel") {
+        phone.saveMenu();
+        return true;
+    }
+
+    if (name.startsWith("phone_save_replace_verify_")) {
+        slotId = name.replace("phone_save_replace_verify_", "");
+        menu.saveDel('HatMP_' + slotId);
+        menu.save('HatMP_' + slotId, true);
+        phone.saveMenu();
+        return true;
+    }
+
+    if (name.startsWith("phone_save_replace_")) {
+        slotId = name.replace("phone_save_replace_", "");
+        phone.showSaveConfirmDialog({
+            overlayName: "phone_replace_verify",
+            promptLeft: 650,
+            promptText: "Are you sure you wish to overwrite save: ",
+            slotId: slotId,
+            confirmName: "phone_save_replace_verify_" + slotId,
+            confirmImage: "999_phone/save.png",
+            cancelImage: "999_phone/cancel_grey.png"
+        });
+        return true;
+    }
+
+    if (name.startsWith("phone_save_load_verify_")) {
+        slotId = name.replace("phone_save_load_verify_", "");
+        chat(-1, 0);
+        menu.load('HatMP_' + slotId);
+        return true;
+    }
+
+    if (name.startsWith("phone_save_load_")) {
+        slotId = name.replace("phone_save_load_", "");
+        if (g.newLoad) {
+            chat(-1, 0);
+            menu.load('HatMP_' + slotId);
+        }
+        else {
+            phone.showSaveConfirmDialog({
+                overlayName: "phone_load_verify",
+                promptLeft: 750,
+                promptText: "Are you sure you wish to load: ",
+                slotId: slotId,
+                confirmName: "phone_save_load_verify_" + slotId,
+                confirmImage: "999_phone/load.png",
+                cancelImage: "999_phone/cancel.png"
+            });
+        }
+        return true;
+    }
+
+    if (name.startsWith("phone_save_delete_verify_")) {
+        slotId = name.replace("phone_save_delete_verify_", "");
+        menu.saveDel('HatMP_' + slotId);
+        phone.saveMenu();
+        return true;
+    }
+
+    if (name.startsWith("phone_save_delete_")) {
+        slotId = name.replace("phone_save_delete_", "");
+        phone.showSaveConfirmDialog({
+            overlayName: "phone_load_verify",
+            promptLeft: 750,
+            promptText: "Are you sure you wish to delete: ",
+            slotId: slotId,
+            confirmName: "phone_save_delete_verify_" + slotId,
+            confirmImage: "999_phone/delete.png",
+            cancelImage: "999_phone/cancel_grey.png"
+        });
+        return true;
+    }
+
+    if (name.startsWith("phone_save_export_")) {
+        slotId = name.replace("phone_save_export_", "");
+        char.export(slotId);
+        return true;
+    }
+
+    if (name.startsWith("phone_save_save_")) {
+        slotId = name.replace("phone_save_save_", "");
+        menu.save('HatMP_' + slotId, true);
+        phone.saveMenu();
+        return true;
+    }
+
+    return false;
+};
+
+phone.handleSettingsAction = function (name) {
+    if (name.startsWith("phone_setting_diff")) {
+        gv.set("difficulty", parseInt(name.replace("phone_setting_diff", "")));
+        phone.settings();
+        return true;
+    }
+
+    if (name.startsWith("phone_setting_clock")) {
+        gv.set("clock24", name.replace("phone_setting_clock", ""));
+        nav.buildclock();
+        phone.settings();
+        return true;
+    }
+
+    if (name === "phone_setting_encM" || name === "phone_setting_encF" ||
+        name === "phone_setting_encBeast" || name === "phone_setting_encMyth") {
+        gv.set(name.replace("phone_setting_", ""), !gv.get(name.replace("phone_setting_", "")));
+        phone.settings();
+        return true;
+    }
+
+    if (name === "phone_setting_d_on") {
+        gv.set("transformation", "voluntary");
+        phone.settings();
+        return true;
+    }
+
+    if (name === "phone_setting_d_off") {
+        gv.set("transformation", "voluntaryoff");
+        phone.settings();
+        return true;
+    }
+
+    if (name === "phone_setting_d_auto") {
+        gv.set("transformation", "forced");
+        phone.settings();
+        return true;
+    }
+
+    if (name === "phone_setting_m" || name === "phone_setting_f" || name === "phone_setting_a") {
+        gv.set("pronouns", name.replace("phone_setting_", ""));
+        phone.settings();
+        return true;
+    }
+
+    return false;
+};
+
+phone.handlePrefixAction = function (name) {
+    if (name.startsWith("phone_photo_")) {
+        phone.clear(false);
+        var imgName = name.replace("phone_photo_", "");
+        for (var i = 0; i < pic.master.length; i++) {
+            if (pic.master[i].name === imgName) {
+                nav.button({
+                    "type": "zimg",
+                    "name": "phone_photo_",
+                    "left": 451,
+                    "top": 155,
+                    "width": 1185,
+                    "height": 815,
+                    "image": "999_phone/pic/" + pic.master[i].image,
+                }, 9999);
+            }
+            phone.backbutton("phone_pic");
+        }
+        return true;
+    }
+
+    if (name.startsWith("phone_charselect_")) {
+        phone.characterSelect(name.replace("phone_charselect_", ""));
+        return true;
+    }
+
+    if (name.startsWith("phone_modtime")) {
+        var modTime = name.replace("phone_modtime_", "");
+        if (modTime === "x") {
+            char.addtime(58);
+            char.room(g.roomID);
+        }
+        else {
+            var timeHour = parseInt(modTime);
+            if (timeHour === 0)
+                g.dt.setDate(g.dt.getDate() + 1);
+            char.settime(parseInt(modTime), 0);
+            char.room(g.roomID);
+        }
+        return true;
+    }
+
+    if (name.startsWith("phone_charsel_")) {
+        nav.killbuttonStartsWith("phone_charsel_");
+        var charstep1 = name.replace("phone_charsel_", "");
+        var varstep2 = charstep1.split("_");
+        var ch = sc.getMission(varstep2[0], varstep2[1]);
+        var roomList = "";
+        nav.t({
+            type: "zimg",
+            name: "phone_charsel_" + sc.charMission[ch.i].name + "_" + sc.charMission[ch.i].mission[ch.j].missionName,
+            "left": 850,
+            "top": 250,
+            font: 30,
+            hex: "#ffffff",
+            text: sc.charMission[ch.i].mission[ch.j].title + " [" + sc.mStatus(sc.charMission[ch.i].mission[ch.j].mStatus) + "]"
+        }, 9999);
+        nav.t({
+            type: "zimg",
+            name: "phone_charsel_",
+            "left": 900,
+            "top": 300,
+            font: 20,
+            hex: "#ffffff",
+            text: sc.charMission[ch.i].mission[ch.j].desc
+        }, 1);
+        nav.button({
+            "type": "zbtn",
+            "name": "phone_charselect_" + varstep2[0],
+            "left": 800,
+            "top": 250,
+            "width": 40,
+            "height": 40,
+            "image": "999_phone/char_down.png",
+        }, 9999);
+        let taskcounter = 0;
+        for (i = 0; i < sc.charMission[ch.i].mission[ch.j].task.length; i++) {
+            if (sc.charMission[ch.i].mission[ch.j].task[i].show) {
+                roomList = " @: " + (g.getRooms(sc.charMission[ch.i].mission[ch.j].task[i].roomId).name ?? "");
+                var tcolor = "#ffffff";
+                var mstatus;
+                switch (sc.mStatus(sc.charMission[ch.i].mission[ch.j].task[i].mStatus)) {
+                    case "Failed": tcolor = "#cc3333"; mstatus = " ✘ "; break;
+                    case "Completed": tcolor = "#33cc33"; mstatus = " ☑ "; break;
+                    case "Not Started": tcolor = "#999999"; mstatus = " ☐ "; break;
+                    default: tcolor = "#ffffff"; mstatus = " ";
+                }
+                nav.t({
+                    type: "zimg",
+                    name: "phone_charsel_",
+                    "left": 910,
+                    "top": 350 + (taskcounter * 40),
+                    font: 24,
+                    hex: tcolor,
+                    text: mstatus + sc.charMission[ch.i].mission[ch.j].task[i].txt + roomList
+                }, 1);
+                taskcounter++;
+            }
+        }
+        return true;
+    }
+
+    if (name.startsWith("phone_cheatmod")) {
+        if (name === "phone_cheatmod_money") {
+            gv.mod("money", 100);
+            phone.cheat();
+            $('#char_alert').hide();
+        }
+        else if (name === "phone_cheatmod_on") {
+            gv.set("cheatMode", true);
+            phone.cheat();
+        }
+        else {
+            var cheatLevel = name.replace("phone_cheatmod_level_", "");
+            levels.mod(cheatLevel, 100);
+            phone.cheat();
+            $('#char_alert').hide();
+        }
+        return true;
+    }
+
+    if (name.startsWith("phone_charRename_")) {
+        var charrename = name.replace("phone_charRename_", "");
+        sc.setcharname(charrename, $(".room-img[data-name='phone_charRenameDisplay']").val());
+        g.popUpNoticeBottom(sc.n(charrename) + " has been renamed.");
+        return true;
+    }
+
+    if (name.startsWith("phone_purity_")) {
+        let purid = parseInt(name.replace("phone_purity_", ""));
+        nav.killbuttonStartsWith("phone_purity");
+        phone.backbutton("phone_purity");
+        phone.showPanel("999_phone/purity_bg.jpg", "phone_purity");
+        phone.addPurityText({
+            left: 500,
+            top: 200,
+            font: 60,
+            hex: "#000000",
+            text: sex.st[purid].d,
+            zindex: 1
+        });
+        phone.addPurityDetailRow(300, "Boys: ", sex.st[purid].ent[0], 1);
+        phone.addPurityDetailRow(350, "Girls: ", sex.st[purid].ent[1], 1);
+        phone.addPurityDetailRow(400, "Non-binary: ", sex.st[purid].ent[2], 1);
+        phone.addPurityNamesColumnHeaders();
+        phone.addPurityNames(sex.st[purid], 1);
+        return true;
+    }
+
+    return false;
+};
+
+phone.changeCharacterPage = function (delta) {
+    phone.charPointer += delta;
+    phone.characters();
+};
+
+phone.openExternal = function (url) {
+    window.open(url, "_blank");
+};
+
+phone.help = function () {
+    phone.clear(false);
+    $('#room-buttons').append('<div class="room-img resize" data-name="phone_help_bg" style="position:absolute; z-index:2; ' +
+        g.makeCss(815, 1185, 155, 451) + ' background:#111114;"></div>');
+    $('#room-buttons').append('<div class="room-img resize" data-name="phone_help_inner" style="position:absolute; z-index:2; ' +
+        g.makeCss(735, 1095, 195, 496) + ' background:#19191d; border:2px solid #2f3140; border-radius:18px;"></div>');
+
+    nav.t({
+        type: "zimg",
+        name: "phone_help",
+        left: 550,
+        top: 225,
+        font: 42,
+        hex: "#ffffff",
+        text: "Keyboard Shortcuts"
+    }, 9999);
+
+    nav.t({
+        type: "zimg",
+        name: "phone_help",
+        left: 550,
+        top: 325,
+        font: 26,
+        hex: "#ffffff",
+        text: "I  -  Open or close inventory"
+    }, 9999);
+    nav.t({
+        type: "zimg",
+        name: "phone_help",
+        left: 550,
+        top: 385,
+        font: 26,
+        hex: "#ffffff",
+        text: "Space  -  Advance single-step dialog or Next scenes"
+    }, 9999);
+    nav.t({
+        type: "zimg",
+        name: "phone_help",
+        left: 550,
+        top: 445,
+        font: 26,
+        hex: "#ffffff",
+        text: "S  -  Toggle chat auto-skip when available"
+    }, 9999);
+    nav.t({
+        type: "zimg",
+        name: "phone_help",
+        left: 550,
+        top: 505,
+        font: 26,
+        hex: "#ffffff",
+        text: "1-9  -  Pick visible chat choices by order"
+    }, 9999);
+    nav.t({
+        type: "zimg",
+        name: "phone_help",
+        left: 550,
+        top: 565,
+        font: 26,
+        hex: "#ffffff",
+        text: "Middle Click Phone  -  Open save menu"
+    }, 9999);
+    nav.t({
+        type: "zimg",
+        name: "phone_help",
+        left: 550,
+        top: 625,
+        font: 26,
+        hex: "#ffffff",
+        text: "Esc  -  Close phone"
+    }, 9999);
+    nav.t({
+        type: "zimg",
+        name: "phone_help",
+        left: 550,
+        top: 695,
+        font: 22,
+        hex: "#ffd7f5",
+        text: "Some scenes still require direct clicks."
+    }, 9999);
+
+    $('#room-buttons').append('<div class="room-img resize" data-name="phone_help_site" style="position:absolute; z-index:2; ' +
+        g.makeCss(68, 360, 735, 550) + ' background:#1f3a8a; border:2px solid #ffffff; border-radius:12px;"></div>');
+    nav.button({
+        "type": "zbtn",
+        "name": "phone_help_site",
+        "left": 550,
+        "top": 735,
+        "width": 360,
+        "height": 68,
+        "image": "1002_quickfight/black20Alpha.png",
+    }, 9999);
+    nav.tcenter({
+        type: "zbtn",
+        name: "phone_help_site",
+        left: 550,
+        width: 360,
+        top: 755,
+        font: 26,
+        hex: "#ffffff",
+        text: "Open Support Site"
+    }, 9999);
+};
+
+phone.drawAchievements = function () {
+    phone.clear(false);
+    var groups = phone.getAchievementGroups(phone.charPointer);
+    phone.showPanel("999_phone/Achievements_bg.jpg");
+    phone.drawAchievementTabs();
+
+    let newAchList = trophy.st
+        .filter(item => groups.includes(item.group))
+        .sort((a, b) => {
+            const indexA = groups.indexOf(a.group);
+            const indexB = groups.indexOf(b.group);
+
+            if (indexA !== indexB)
+                return indexA - indexB;
+
+            return a.o - b.o;
+        });
+
+    for (let i = 0; i < newAchList.length; i++)
+        phone.addAchievementCard(newAchList[i], i);
+};
+
+phone.build = function (selection = null) {
+    phone.clear(true);
+    phone.captureMenuOverlay();
+    inv.close(phone.preservedMenuOverlay !== null);
+    var btnList = phone.mainButtons();
 
     nav.button({
         "type": "zimg",
@@ -65,18 +532,48 @@ phone.build = function (selection = null) {
 
     if (selection !== null) {
         if (selection === "save") {
-            room9999.btnclick("phone_save");
+            invoker.invoke(9999, "btnclick", "phone_save");
             nav.killbutton("phonex_menu");
         }
         else if (selection === "time") {
-            room9999.btnclick("phone_time");
+            invoker.invoke(9999, "btnclick", "phone_time");
             nav.killbutton("phonex_menu");
         }
         else {
-            room9999.btnclick(selection);
+            invoker.invoke(9999, "btnclick", selection);
             nav.killbutton("phonex_menu");
         }
     }
+};
+
+phone.captureMenuOverlay = function () {
+    var overlay = $('#room-menuButtons');
+
+    if (inv.isOpen || !overlay.is(":visible") || overlay.children().length === 0) {
+        phone.preservedMenuOverlay = null;
+        return;
+    }
+
+    phone.preservedMenuOverlay = {
+        background: overlay.css('background'),
+        children: overlay.children().detach()
+    };
+    overlay.hide().html('');
+};
+
+phone.restoreMenuOverlay = function () {
+    var overlay = $('#room-menuButtons');
+
+    if (phone.preservedMenuOverlay === null)
+        return false;
+
+    overlay.html('');
+    if (phone.preservedMenuOverlay.background)
+        overlay.css('background', phone.preservedMenuOverlay.background);
+    overlay.append(phone.preservedMenuOverlay.children);
+    overlay.show();
+    phone.preservedMenuOverlay = null;
+    return true;
 };
 
 phone.clear = function (clearAll) {
@@ -86,35 +583,311 @@ phone.clear = function (clearAll) {
 };
 
 phone.backbutton = function (icon) {
-    var btnList = [
-        { n: "phone_save", img: "bSave", x: 0, y: 0 },
-        { n: "phone_rel", img: "bRelationships", x: 1, y: 0 },
-        { n: "phone_contacts", img: "bContacts", x: 2, y: 0 },
-        { n: "phone_pic", img: "bPic", x: 3, y: 0 },
+    var button = phone.findMainButton(icon);
+    if (button !== null) {
+        nav.button({
+            "type": "zbtn",
+            "name": button.n,
+            "left": 1662,
+            "top": 525,
+            "width": 90,
+            "height": 112,
+            "image": "999_phone/" + button.img + ".png",
+        }, 9999);
+    }
+};
 
-        //{ n: "phone_stats", img: "bStats", x: 0, y: 1 },
-        { n: "phone_time", img: "bTime", x: 0, y: 1 },
-        { n: "phone_ach", img: "bAch", x: 2, y: 1 },
-        { n: "phone_settings", img: "bSettings", x: 3, y: 1 },
+phone.showSaveConfirmDialog = function (config) {
+    nav.button({
+        "type": "zimg",
+        "name": config.overlayName,
+        "left": 0,
+        "top": 0,
+        "width": 1920,
+        "height": 1080,
+        "image": "999_phone/verify.png",
+    }, 9999);
 
-        { n: "phone_help", img: "bHelp", x: 0, y: 2 },
-        { n: "phone_patron", img: "bPatron", x: 2, y: 2 },
-        { n: "phone_thankyou", img: "bPatreon", x: 3, y: 2 },
-        { n: "phone_purity", img: "bPurity", x: 1, y: 1 }
-    ];
-    for (i = 0; i < btnList.length; i++) {
-        if (icon === btnList[i].n) {
-            nav.button({
-                "type": "zbtn",
-                "name": btnList[i].n,
-                "left": 1662,
-                "top": 525,
-                "width": 90,
-                "height": 112,
-                "image": "999_phone/" + btnList[i].img + ".png",
-            }, 9999);
+    nav.t({
+        type: "zimg",
+        name: "phone_",
+        left: config.promptLeft,
+        top: 400,
+        font: 30,
+        hex: "#ffffff",
+        text: config.promptText
+    }, 1);
+    nav.t({
+        type: "zimg",
+        name: "phone_",
+        left: 650,
+        top: 450,
+        font: 30,
+        hex: "#ffffff",
+        text: $("[data-name='phone_save_load_name_" + config.slotId + "']").text()
+    }, 1);
+    nav.button({
+        "type": "zbtn",
+        "name": config.confirmName,
+        "left": 650,
+        "top": 600,
+        "width": 250,
+        "height": 100,
+        "image": config.confirmImage,
+    }, 9999);
+    nav.button({
+        "type": "zbtn",
+        "name": "phone_save_load_cancel",
+        "left": 1030,
+        "top": 600,
+        "width": 250,
+        "height": 100,
+        "image": config.cancelImage,
+    }, 9999);
+};
+
+phone.showPanel = function (image, name = "phone_") {
+    nav.button({
+        "type": "zimg",
+        "name": name,
+        "left": 451,
+        "top": 155,
+        "width": 1185,
+        "height": 815,
+        "image": image,
+    }, 9999);
+};
+
+phone.addCharacterCard = function (character, row, column) {
+    const top = 180 + (row * 220);
+    const left = 485 + (column * 190);
+
+    $('#room-buttons').append('<div class="room-img resize" data-name="phone_char_bg" ' +
+        'style="position: absolute; background: ' + character.hex + '; z-index:2; ' +
+        g.makeCss(150, 150, top, left) + '">' +
+        '</div>');
+
+    nav.button({
+        "type": "zbtn",
+        "name": "phone_charselect_" + character.name,
+        "left": left,
+        "top": top,
+        "width": 150,
+        "height": 150,
+        "image": "../speaker/" + character.image,
+    }, 9999);
+
+    nav.t({
+        type: "zimg",
+        name: "phone_char_",
+        "left": left,
+        "top": top + 150,
+        font: character.display.length < 20 ? 20 : 12,
+        hex: "#ffffff",
+        text: character.display,
+    }, 1);
+
+    $('#room-buttons').append('<div class="resize room-img" data-name="phone_char_" data-room="999" style=" ' +
+        g.makeCss(5, (character.l * 15), top + 180, left) +
+        '  background: #00ff00; border-radius:100px; z-index:2" ></div>');
+
+    nav.t({
+        type: "zimg",
+        name: "phone_char_",
+        "left": left,
+        "top": top + 185,
+        font: 20,
+        hex: "#ffc2ff",
+        text: character.secret > 99 ? "They know" : (character.secret === 0 ? "" : "Suspicious"),
+    }, 1);
+};
+
+phone.addStatBar = function (config) {
+    nav.t({
+        type: "zimg",
+        name: config.name || "phone_",
+        "left": config.left,
+        "top": config.top,
+        font: config.font || 30,
+        hex: config.hex || "#ffffff",
+        text: config.label
+    }, 1);
+
+    $('#room-buttons').append('<div class="room-img" data-name="phone_charbar" style="position: absolute; bottom: 1%; background: #2d2d40; ' +
+        g.makeCss(config.height || 10, config.width, config.top + (config.barOffsetTop || 20), config.left) + ' z-index:2;">' +
+        '<div style="background: ' + config.barColor + '; border-radius: 20px; height: ' + g.ratio * (config.height || 10) + 'px; width: ' + config.value + '%;" class="resize-height rl-bar"></div>' +
+        '</div>');
+};
+
+phone.addPurityText = function (config) {
+    nav.t({
+        type: config.type || "zimg",
+        name: config.name || "phone_purity",
+        left: config.left,
+        top: config.top,
+        font: config.font || 24,
+        hex: config.hex || "#ffffff",
+        text: config.text
+    }, config.zindex || 9999);
+};
+
+phone.addPurityColumnHeaders = function (left, top, hex, labels) {
+    for (let i = 0; i < labels.length; i++) {
+        phone.addPurityText({
+            left: left + (i * 50),
+            top: top,
+            hex: hex,
+            text: labels[i]
+        });
+    }
+};
+
+phone.addPurityNamesColumnHeaders = function () {
+    const labels = ["Boys: ", "Girls: ", "Non-binary: "];
+    for (let i = 0; i < labels.length; i++) {
+        phone.addPurityText({
+            left: 1100 + (i * 150),
+            top: 180,
+            hex: "#ffffff",
+            text: labels[i]
+        });
+    }
+};
+
+phone.addPurityFirstTime = function (left, top, day, hex, zindex = 9999) {
+    phone.addPurityText({
+        left: left,
+        top: top,
+        hex: hex,
+        text: day === null ? "" : "First time: Day " + day,
+        zindex: zindex
+    });
+};
+
+phone.addPurityDetailRow = function (top, label, entry, zindex = 9999) {
+    phone.addPurityText({
+        left: 500,
+        top: top,
+        hex: "#000000",
+        text: label,
+        zindex: zindex
+    });
+    phone.addPurityText({
+        left: 650,
+        top: top,
+        hex: "#000000",
+        text: entry.c,
+        zindex: zindex
+    });
+    phone.addPurityFirstTime(750, top, entry.day, "#000000", zindex);
+};
+
+phone.addPurityNames = function (purity, zindex = 9999) {
+    for (let i = 0; i < 3; i++) {
+        for (let j = 0; j < purity.ent[i].names.length; j++) {
+            phone.addPurityText({
+                left: 1100 + (i * 150),
+                top: 210 + (j * 25),
+                font: 20,
+                text: g.trunc(purity.ent[i].names[j], 15),
+                zindex: zindex
+            });
         }
     }
+};
+
+phone.addPurityOverviewRow = function (purity, top, color, labelLeft, countLefts) {
+    phone.addPurityText({
+        type: "zbtn",
+        name: "phone_purity_" + purity.id,
+        left: labelLeft,
+        top: top,
+        hex: color,
+        text: purity.d
+    });
+    for (let i = 0; i < 3; i++) {
+        phone.addPurityText({
+            type: "zbtn",
+            name: "phone_purity_" + purity.id,
+            left: countLefts[i],
+            top: top,
+            hex: color,
+            text: purity.ent[i].c
+        });
+    }
+};
+
+phone.addPuritySummaryLine = function (top, text) {
+    phone.addPurityText({
+        left: 750,
+        top: top,
+        text: text
+    });
+};
+
+phone.addPurityStatLine = function (top, text) {
+    phone.addPurityText({
+        type: "zbtn",
+        left: 1100,
+        top: top,
+        text: text
+    });
+};
+
+phone.addAchievementTab = function (name, left, text) {
+    nav.t({
+        type: "zbtn",
+        name: name,
+        left: left,
+        top: 800,
+        font: 30,
+        hex: "#ffffff",
+        text: text
+    }, 9999);
+};
+
+phone.drawAchievementTabs = function () {
+    phone.addAchievementTab("phone_ach", 550, "Clothing");
+    phone.addAchievementTab("phone_ach1", 750, "Sex");
+    phone.addAchievementTab("phone_ach2", 950, "Events");
+    phone.addAchievementTab("phone_ach3", 1150, "Other");
+    phone.addAchievementTab("phone_ach4", 1350, "Endings");
+};
+
+phone.addAchievementCard = function (achievement, index) {
+    const left = (index % 3 * 380) + 485;
+    const top = 200 + (Math.floor(index / 3) * 100);
+    const achieved = achievement.ach;
+
+    nav.button({
+        "type": "zimg",
+        "name": "phone_",
+        "left": left,
+        "top": top,
+        "width": 350,
+        "height": 84,
+        "image": achieved ? "999_phone/ach/" + achievement.img : "999_phone/ach/x.webp",
+    }, 9999);
+
+    nav.t({
+        type: "zimg",
+        name: "phone_",
+        "left": left + 95,
+        "top": top + 50,
+        font: 16,
+        hex: "#cccccc",
+        text: achieved ? sc.replace(achievement.display) : "Not Achieved"
+    }, 9999);
+
+    nav.t({
+        type: "zimg",
+        name: "phone_",
+        "left": left + 95,
+        "top": top + 10,
+        font: 20,
+        hex: "#ffffff",
+        text: sc.replace(achievement.title)
+    }, 9999);
 };
 
 phone.saveMenu = function () {
@@ -123,15 +896,7 @@ phone.saveMenu = function () {
     let mostRecentRow = null;
     let saveByOrder = new Array();
     phone.clear(false);
-    nav.button({
-        "type": "zimg",
-        "name": "phone_",
-        "left": 451,
-        "top": 155,
-        "width": 1185,
-        "height": 815,
-        "image": "999_phone/save_bg.jpg",
-    }, 9999);
+    phone.showPanel("999_phone/save_bg.jpg");
     let newestSave = new Date(1900, 0, 0);
     let newestSaveId = -1;
     let savedt;
@@ -276,15 +1041,7 @@ phone.settings = function () {
     let transformation = gv.get("transformation");
     let pronouns = gv.get("pronouns");
 
-    nav.button({
-        "type": "zimg",
-        "name": "phone_",
-        "left": 451,
-        "top": 155,
-        "width": 1185,
-        "height": 815,
-        "image": "999_phone/settingbg.jpg",
-    }, 9999);
+    phone.showPanel("999_phone/settingbg.jpg");
     var settings = [
         { y: 0, x: 0, b: 3, n: "diff0", i: "diffEasy", active: difficulty === 0 },
         { y: 0, x: 1, b: 3, n: "diff1", i: "diffNormal", active: difficulty === 1 },
@@ -317,16 +1074,8 @@ phone.settings = function () {
 
 phone.pictures = function () {
     phone.clear(false);
-    
-    nav.button({
-        "type": "zimg",
-        "name": "phone_",
-        "left": 451,
-        "top": 155,
-        "width": 1185,
-        "height": 815,
-        "image": "999_phone/pics_bg.jpg",
-    }, 9999);
+
+    phone.showPanel("999_phone/pics_bg.jpg");
     var c = 0;
     for (var i = 0; i < pic.master.length; i++) {
         if (pic.master[i].entry) {
@@ -346,15 +1095,7 @@ phone.pictures = function () {
 
 phone.characters = function () {
     phone.clear(false);
-    nav.button({
-        "type": "zimg",
-        "name": "phone_",
-        "left": 451,
-        "top": 155,
-        "width": 1185,
-        "height": 815,
-        "image": "999_phone/rel_bg.jpg",
-    }, 9999);
+    phone.showPanel("999_phone/rel_bg.jpg");
     
     let j = 0;
     let i;
@@ -362,51 +1103,7 @@ phone.characters = function () {
     for (i = 0; i < sc.char.length; i++) {
         if (sc.char[i].show) {
             if (showCharcterCounter >= phone.charPointer && j < 18) {
-                $('#room-buttons').append('<div class="room-img resize" data-name="phone_char_bg" ' +
-                    'style="position: absolute; background: ' + sc.char[i].hex + '; z-index:2; ' +
-                    g.makeCss(150, 150, 180 + (Math.floor(j / 6) * 220), 485 + ((j % 6) * 190)) + '">' +
-                    '</div>');
-                nav.button({
-                    "type": "zbtn",
-                    "name": "phone_charselect_" + sc.char[i].name,
-                    "left": 485 + ((j % 6) * 190),
-                    "top": 180 + (Math.floor(j / 6) * 220),
-                    "width": 150,
-                    "height": 150,
-                    "image": "../speaker/" + sc.char[i].image,
-                }, 9999);
-
-                nav.t({
-                    type: "zimg",
-                    name: "phone_char_",
-                    "left": 485 + ((j % 6) * 190),
-                    "top": 330 + (Math.floor(j / 6) * 220),
-                    font: sc.char[i].display.length < 20 ? 20 : 12,
-                    hex: "#ffffff",
-                    text: sc.char[i].display,
-                }, 1);
-
-                $('#room-buttons').append('<div class="resize room-img" data-name="phone_char_" data-room="999" style=" ' + g.makeCss(5, (sc.char[i].l * 15), 360 + (Math.floor(j / 6) * 220), 485 + ((j % 6) * 190)) + '  background: #00ff00; border-radius:100px; z-index:2" ></div>');
-
-                //nav.t({
-                //    type: "zimg",
-                //    name: "phone_char_",
-                //    "left": 485 + ((j % 6) * 190),
-                //    "top": 360 + (Math.floor(j / 6) * 220),
-                //    font: 30,
-                //    hex: "#ffffff",
-                //    text: sc.levelName(i),
-                //}, 1);
-
-                nav.t({
-                    type: "zimg",
-                    name: "phone_char_",
-                    "left": 485 + ((j % 6) * 190),
-                    "top": 365 + (Math.floor(j / 6) * 220),
-                    font: 20,
-                    hex: "#ffc2ff",
-                    text: sc.char[i].secret > 99 ? "They know" : (sc.char[i].secret === 0 ? "" : "Suspicious"),
-                }, 1);
+                phone.addCharacterCard(sc.char[i], Math.floor(j / 6), j % 6);
                 j++;
             }
             showCharcterCounter++;
@@ -441,15 +1138,7 @@ phone.characterSelect = function (name) {
 
     var thisChar = sc.get(name);
 
-    nav.button({
-        "type": "zimg",
-        "name": "phone_",
-        "left": 451,
-        "top": 155,
-        "width": 1185,
-        "height": 815,
-        "image": "999_phone/rel_bg.jpg",
-    }, 9999);
+    phone.showPanel("999_phone/rel_bg.jpg");
 
     nav.button({
         "type": "zimg",
@@ -501,30 +1190,25 @@ phone.characterSelect = function (name) {
         hex: "#ffffff",
         text: sc.levelName(sc.i(name))
     }, 1);
-    nav.t({
-        type: "zimg",
-        name: "phone_",
-        "left": 500,
-        "top": 580,
+    phone.addStatBar({
+        left: 500,
+        top: 580,
         font: 14,
         hex: "#aaaaaa",
-        text: "Till Next Level"
-    }, 1);
-    $('#room-buttons').append('<div class="room-img" data-name="phone_charbar" style="position: absolute; bottom: 1%; background: #2d2d40; ' + g.makeCss(10, 250, 600, 500) + ' z-index:2;">' +
-        '<div style="background: #FF76FF; border-radius: 20px; height: ' + g.ratio * 10 + 'px; width: ' + thisChar.c + '%;" class="resize-height rl-bar"></div>' +
-            '</div>');
-    nav.t({
-        type: "zimg",
-        name: "phone_",
-        "left": 500,
-        "top": 620,
-        font: 30,
-        hex: "#ffffff",
-        text: "Secret:"
-    }, 1);
-    $('#room-buttons').append('<div class="room-img" data-name="phone_charbar" style="position: absolute; bottom: 1%; background: #2d2d40; ' + g.makeCss(10, 250, 650, 500) + ' z-index:2;">' +
-        '<div style="background: #189000; border-radius: 20px; height: ' + g.ratio * 10 + 'px; width: ' + thisChar.secret + '%;" class="resize-height rl-bar"></div>' +
-        '</div>');
+        label: "Till Next Level",
+        width: 250,
+        value: thisChar.c,
+        barColor: "#FF76FF"
+    });
+    phone.addStatBar({
+        left: 500,
+        top: 620,
+        label: "Secret:",
+        width: 250,
+        value: thisChar.secret,
+        barColor: "#189000",
+        barOffsetTop: 30
+    });
     var thisTimeline = sc.getTimeline(name);
     
     for (i = 0; i < thisTimeline.subList.length; i++) {
@@ -809,15 +1493,7 @@ phone.characterSelect = function (name) {
 phone.thankyou = function () {
     phone.clear(false);
 
-    nav.button({
-        "type": "zimg",
-        "name": "phone_",
-        "left": 451,
-        "top": 155,
-        "width": 1185,
-        "height": 815,
-        "image": "999_phone/thankyou_bg.jpg",
-    }, 9999);
+    phone.showPanel("999_phone/thankyou_bg.jpg");
     var l = [
         "Arothiel", "Asako", "Discretlysinful (Aaron M )",
         "Fuck you Arin",
@@ -855,15 +1531,7 @@ phone.passtime = function () {
     else if (currentTime >= 6)
         bgnum = 1;
 
-    nav.button({
-        "type": "zimg",
-        "name": "phone_",
-        "left": 451,
-        "top": 155,
-        "width": 1185,
-        "height": 815,
-        "image": "999_phone/time_bg_" + bgnum + ".jpg",
-    }, 9999);
+    phone.showPanel("999_phone/time_bg_" + bgnum + ".jpg");
     nav.t({
         type: "zimg",
         name: "phone_time_currenttime",
@@ -924,16 +1592,7 @@ phone.cheat = function () {
     phone.clear(false);
 
     if (gv.get("cheatMode")) {
-
-        nav.button({
-            "type": "zimg",
-            "name": "phone_",
-            "left": 451,
-            "top": 155,
-            "width": 1185,
-            "height": 815,
-            "image": "999_phone/cheat_bg.jpg",
-        }, 9999);
+        phone.showPanel("999_phone/cheat_bg.jpg");
 
         var levelToMod = ["fitness", "charisma"];
 
@@ -981,15 +1640,7 @@ phone.cheat = function () {
         }
     }
     else {
-        nav.button({
-            "type": "zimg",
-            "name": "phone_",
-            "left": 451,
-            "top": 155,
-            "width": 1185,
-            "height": 815,
-            "image": "999_phone/cheat_bg1.jpg",
-        }, 9999);
+        phone.showPanel("999_phone/cheat_bg1.jpg");
 
         nav.button({
             "type": "zbtn",
@@ -1010,70 +1661,9 @@ phone.purity = function () {
     let pussyvirgin = sex.getvirgin(28);
     let analvirgin = sex.getvirgin(26);
 
-    nav.button({
-        "type": "zimg",
-        "name": "phone_purity",
-        "left": 451,
-        "top": 155,
-        "width": 1185,
-        "height": 815,
-        "image": "999_phone/purity_bg.jpg",
-    }, 9999);
-    
-    nav.t({
-        type: "zimg",
-        name: "phone_purity",
-        "left": 850,
-        "top": 170,
-        font: 24,
-        hex: "#000",
-        text: "Boy"
-    }, 9999);
-    nav.t({
-        type: "zimg",
-        name: "phone_purity",
-        "left": 900,
-        "top": 170,
-        font: 24,
-        hex: "#000",
-        text: "Girl"
-    }, 9999);
-    nav.t({
-        type: "zimg",
-        name: "phone_purity",
-        "left": 950,
-        "top": 170,
-        font: 24,
-        hex: "#000",
-        text: "NB"
-    }, 9999);
-    nav.t({
-        type: "zimg",
-        name: "phone_purity",
-        "left": 1450,
-        "top": 170,
-        font: 24,
-        hex: "#fff",
-        text: "Boy"
-    }, 9999);
-    nav.t({
-        type: "zimg",
-        name: "phone_purity",
-        "left": 1500,
-        "top": 170,
-        font: 24,
-        hex: "#fff",
-        text: "Girl"
-    }, 9999);
-    nav.t({
-        type: "zimg",
-        name: "phone_purity",
-        "left": 1550,
-        "top": 170,
-        font: 24,
-        hex: "#fff",
-        text: "NB"
-    }, 9999);
+    phone.showPanel("999_phone/purity_bg.jpg", "phone_purity");
+    phone.addPurityColumnHeaders(850, 170, "#000", ["Boy", "Girl", "NB"]);
+    phone.addPurityColumnHeaders(1450, 170, "#fff", ["Boy", "Girl", "NB"]);
     
     let subcount, domcounter, l, t, col, lm, lf, ln;
     subcount = domcounter = 0;
@@ -1099,42 +1689,7 @@ phone.purity = function () {
                 domcounter++;
             }
 
-            nav.t({
-                type: "zbtn",
-                name: "phone_purity_" + sex.st[i].id,
-                "left": l,
-                "top": t,
-                font: 24,
-                hex: col,
-                text: sex.st[i].d
-            }, 9999);
-            nav.t({
-                type: "zbtn",
-                name: "phone_purity_" + sex.st[i].id,
-                "left": lm,
-                "top": t,
-                font: 24,
-                hex: col,
-                text: sex.st[i].ent[0].c
-            }, 9999);
-            nav.t({
-                type: "zbtn",
-                name: "phone_purity_" + sex.st[i].id,
-                "left": lf,
-                "top": t,
-                font: 24,
-                hex: col,
-                text: sex.st[i].ent[1].c
-            }, 9999);
-            nav.t({
-                type: "zbtn",
-                name: "phone_purity_" + sex.st[i].id,
-                "left": ln,
-                "top": t,
-                font: 24,
-                hex: col,
-                text: sex.st[i].ent[2].c
-            }, 9999);
+            phone.addPurityOverviewRow(sex.st[i], t, col, l, [lm, lf, ln]);
         }
     }
     let penisVirginTxt, analVirginTxt, pussyVirginTxt, oralVirginTxt;
@@ -1180,374 +1735,40 @@ phone.purity = function () {
     else
         analVirginTxt = "Lost your anal virginity to " + analvirgin.who + " on day: " + analvirgin.day;
 
-    nav.t({
-        type: "zimg",
-        name: "phone_purity",
-        "left": 750,
-        "top": 840,
-        font: 24,
-        hex: "#ffffff",
-        text: penisVirginTxt
-    }, 9999);
-    nav.t({
-        type: "zimg",
-        name: "phone_purity",
-        "left": 750,
-        "top": 870,
-        font: 24,
-        hex: "#ffffff",
-        text: analVirginTxt
-    }, 9999);
-    nav.t({
-        type: "zimg",
-        name: "phone_purity",
-        "left": 750,
-        "top": 900,
-        font: 24,
-        hex: "#ffffff",
-        text: oralVirginTxt
-    }, 9999);
-    nav.t({
-        type: "zimg",
-        name: "phone_purity",
-        "left": 750,
-        "top": 930,
-        font: 24,
-        hex: "#ffffff",
-        text: pussyVirginTxt
-    }, 9999);
+    phone.addPuritySummaryLine(840, penisVirginTxt);
+    phone.addPuritySummaryLine(870, analVirginTxt);
+    phone.addPuritySummaryLine(900, oralVirginTxt);
+    phone.addPuritySummaryLine(930, pussyVirginTxt);
 
     domcounter = 13;
     if (cl.c.cock === 5) {
-        nav.t({
-            type: "zbtn",
-            name: "phone_purity",
-            "left": 1100,
-            "top": (domcounter * 30) + 240,
-            font: 24,
-            hex: "#ffffff",
-            text: "Times you played with your pussy: " + gv.get("masturbate_pussy")
-        }, 9999);
+        phone.addPurityStatLine((domcounter * 30) + 240, "Times you played with your pussy: " + gv.get("masturbate_pussy"));
     }
     domcounter++;
-    nav.t({
-        type: "zbtn",
-        name: "phone_purity",
-        "left": 1100,
-        "top": (domcounter * 30) + 240,
-        font: 24,
-        hex: "#ffffff",
-        text: "Times you played with your penis: " + gv.get("masturbate_dick")
-    }, 9999);
+    phone.addPurityStatLine((domcounter * 30) + 240, "Times you played with your penis: " + gv.get("masturbate_dick"));
     domcounter++;
-    nav.t({
-        type: "zbtn",
-        name: "phone_purity",
-        "left": 1100,
-        "top": (domcounter * 30) + 240,
-        font: 24,
-        hex: "#ffffff",
-        text: "Times you used a vibrator on your penis: " + gv.get("masturbate_vibrator")
-    }, 9999);
+    phone.addPurityStatLine((domcounter * 30) + 240, "Times you used a vibrator on your penis: " + gv.get("masturbate_vibrator"));
     domcounter++;
-    nav.t({
-        type: "zbtn",
-        name: "phone_purity",
-        "left": 1100,
-        "top": (domcounter * 30) + 240,
-        font: 24,
-        hex: "#ffffff",
-        text: "Times sucked on a dildo: " + gv.get("masturbate_oral")
-    }, 9999);
+    phone.addPurityStatLine((domcounter * 30) + 240, "Times sucked on a dildo: " + gv.get("masturbate_oral"));
     domcounter++;
-    nav.t({
-        type: "zbtn",
-        name: "phone_purity",
-        "left": 1100,
-        "top": (domcounter * 30) + 240,
-        font: 24,
-        hex: "#ffffff",
-        text: "Times slid your finger in your anus: " + gv.get("masturbate_finger")
-    }, 9999);
+    phone.addPurityStatLine((domcounter * 30) + 240, "Times slid your finger in your anus: " + gv.get("masturbate_finger"));
     domcounter++;
-    nav.t({
-        type: "zbtn",
-        name: "phone_purity",
-        "left": 1100,
-        "top": (domcounter * 30) + 240,
-        font: 24,
-        hex: "#ffffff",
-        text: "Times you fucked a dildo: " + gv.get("masturbate_dildo")
-    }, 9999);
+    phone.addPurityStatLine((domcounter * 30) + 240, "Times you fucked a dildo: " + gv.get("masturbate_dildo"));
 };
 
 room9999.btnclick = function (name) {
-    if (name.startsWith("phone_photo_")) {
-        phone.clear(false);
-        var imgName = name.replace("phone_photo_", "");
-        for (var i = 0; i < pic.master.length; i++) {
-            if (pic.master[i].name === imgName) {
-                nav.button({
-                    "type": "zimg",
-                    "name": "phone_photo_",
-                    "left": 451,
-                    "top": 155,
-                    "width": 1185,
-                    "height": 815,
-                    "image": "999_phone/pic/" + pic.master[i].image,
-                }, 9999);
-            }
-            phone.backbutton("phone_pic");
-        }
-    }
-    else if (name.startsWith("phone_charselect_")) {
-        phone.characterSelect(name.replace("phone_charselect_", ""));
-    }
-    else if (name.startsWith("phone_modtime")) {
-        var modTime = name.replace("phone_modtime_", "");
-        if (modTime === "x") {
-            char.addtime(58);
-            char.room(g.roomID);
-            //phone.build("time");
-        }
-        else {
-            var timeHour = parseInt(modTime);
-            if (timeHour === 0)
-                g.dt.setDate(g.dt.getDate() + 1);
-            char.settime(parseInt(modTime), 0);
-            char.room(g.roomID);
-            //phone.build("time");
-        }
-    }
-    else if (name.startsWith("phone_charsel_")) {
-        nav.killbuttonStartsWith("phone_charsel_");
-        var charstep1 = name.replace("phone_charsel_", "");
-        var varstep2 = charstep1.split("_");
-        var ch = sc.getMission(varstep2[0], varstep2[1]);
-        var roomList = "";
-        nav.t({
-            type: "zimg",
-            name: "phone_charsel_" + sc.charMission[ch.i].name + "_" + sc.charMission[ch.i].mission[ch.j].missionName,
-            "left": 850,
-            "top": 250,
-            font: 30,
-            hex: "#ffffff",
-            text: sc.charMission[ch.i].mission[ch.j].title + " [" + sc.mStatus(sc.charMission[ch.i].mission[ch.j].mStatus) + "]"
-        }, 9999);
-        nav.t({
-            type: "zimg",
-            name: "phone_charsel_",
-            "left": 900,
-            "top": 300,
-            font: 20,
-            hex: "#ffffff",
-            text: sc.charMission[ch.i].mission[ch.j].desc
-        }, 1);
-        nav.button({
-            "type": "zbtn",
-            "name": "phone_charselect_" + varstep2[0],
-            "left": 800,
-            "top": 250,
-            "width": 40,
-            "height": 40,
-            "image": "999_phone/char_down.png",
-        }, 9999);
-        let taskcounter = 0;
-        for (i = 0; i < sc.charMission[ch.i].mission[ch.j].task.length; i++) {
-            if (sc.charMission[ch.i].mission[ch.j].task[i].show) {
-                roomList = " @: " + (g.getRooms(sc.charMission[ch.i].mission[ch.j].task[i].roomId).name ?? "");
-                var tcolor = "#ffffff";
-                var mstatus;
-                switch (sc.mStatus(sc.charMission[ch.i].mission[ch.j].task[i].mStatus)) {
-                    case "Failed": tcolor = "#cc3333"; mstatus = " ✘ "; break;
-                    case "Completed": tcolor = "#33cc33"; mstatus = " ☑ "; break;
-                    case "Not Started": tcolor = "#999999"; mstatus = " ☐ "; break;
-                    default: tcolor = "#ffffff"; mstatus = " ";
-                }
-                nav.t({
-                    type: "zimg",
-                    name: "phone_charsel_",
-                    "left": 910,
-                    "top": 350 + (taskcounter * 40),
-                    font: 24,
-                    hex: tcolor,
-                    text: mstatus + sc.charMission[ch.i].mission[ch.j].task[i].txt + roomList
-                }, 1);
-                taskcounter++;
-            }
-        }
-    }
-    else if (name.startsWith("phone_cheatmod")) {
-        if (name === "phone_cheatmod_money") {
-            gv.mod("money", 100);
-            phone.cheat();
-            $('#char_alert').hide();
-        }
-        else if (name === "phone_cheatmod_on") {
-            gv.set("cheatMode", true);
-            phone.cheat();
-        }
-        else {
-            var cheatLevel = name.replace("phone_cheatmod_level_", "");
-            levels.mod(cheatLevel, 100);
-            phone.cheat();
-            $('#char_alert').hide();
-        }
-    }
-    else if (name.startsWith("phone_charRename_")) {
-        var charrename = name.replace("phone_charRename_", "");
-        sc.setcharname(charrename, $(".room-img[data-name='phone_charRenameDisplay']").val());
-        g.popUpNoticeBottom(sc.n(charrename) + " has been renamed.");
-    }
-    else if (name.startsWith("phone_purity_")) {
-        let purid = parseInt(name.replace("phone_purity_", ""));
-        nav.killbuttonStartsWith("phone_purity");
-        phone.backbutton("phone_purity");
-        nav.button({
-            "type": "zimg",
-            "name": "phone_purity",
-            "left": 451,
-            "top": 155,
-            "width": 1185,
-            "height": 815,
-            "image": "999_phone/purity_bg.jpg",
-        }, 9999);
-        nav.t({
-            type: "zimg",
-            name: "phone_purity",
-            left: 500,
-            top: 200,
-            font: 60,
-            hex: "#000000",
-            text: sex.st[purid].d
-        }, 1);
-        nav.t({
-            type: "zimg",
-            name: "phone_purity",
-            left: 500,
-            top: 300,
-            font: 24,
-            hex: "#000000",
-            text: "Boys: "
-        }, 1);
-        nav.t({
-            type: "zimg",
-            name: "phone_purity",
-            left: 500,
-            top: 350,
-            font: 24,
-            hex: "#000000",
-            text: "Girls: "
-        }, 1);
-        nav.t({
-            type: "zimg",
-            name: "phone_purity",
-            left: 500,
-            top: 400,
-            font: 24,
-            hex: "#000000",
-            text: "Non-binary: "
-        }, 1);
-        nav.t({
-            type: "zimg",
-            name: "phone_purity",
-            left: 650,
-            top: 300,
-            font: 24,
-            hex: "#000000",
-            text: sex.st[purid].ent[0].c
-        }, 1);
-        nav.t({
-            type: "zimg",
-            name: "phone_purity",
-            left: 650,
-            top: 350,
-            font: 24,
-            hex: "#000000",
-            text: sex.st[purid].ent[1].c
-        }, 1);
-        nav.t({
-            type: "zimg",
-            name: "phone_purity",
-            left: 650,
-            top: 400,
-            font: 24,
-            hex: "#000000",
-            text: sex.st[purid].ent[2].c
-        }, 1);
-        nav.t({
-            type: "zimg",
-            name: "phone_purity",
-            left: 750,
-            top: 300,
-            font: 24,
-            hex: "#000000",
-            text: sex.st[purid].ent[0].day === null ? "" : "First time: Day " + sex.st[purid].ent[0].day
-        }, 1);
-        nav.t({
-            type: "zimg",
-            name: "phone_purity",
-            left: 750,
-            top: 350,
-            font: 24,
-            hex: "#000000",
-            text: sex.st[purid].ent[1].day === null ? "" : "First time: Day " + sex.st[purid].ent[1].day
-        }, 1);
-        nav.t({
-            type: "zimg",
-            name: "phone_purity",
-            left: 750,
-            top: 400,
-            font: 24,
-            hex: "#000000",
-            text: sex.st[purid].ent[2].day === null ? "" : "First time: Day " + sex.st[purid].ent[2].day
-        }, 1);
-        //who
-        nav.t({
-            type: "zimg",
-            name: "phone_purity",
-            left: 1100,
-            top: 180,
-            font: 24,
-            hex: "#ffffff",
-            text: "Boys: "
-        }, 1);
-        nav.t({
-            type: "zimg",
-            name: "phone_purity",
-            left: 1250,
-            top: 180,
-            font: 24,
-            hex: "#ffffff",
-            text: "Girls: "
-        }, 1);
-        nav.t({
-            type: "zimg",
-            name: "phone_purity",
-            left: 1400,
-            top: 180,
-            font: 24,
-            hex: "#ffffff",
-            text: "Non-binary: "
-        }, 1);
-        for (let i = 0; i < 3; i++) {
-            for (let j = 0; j < sex.st[purid].ent[i].names.length; j++) {
-                nav.t({
-                    type: "zimg",
-                    name: "phone_purity",
-                    left: 1100 + (i * 150),
-                    top: 210 + (j * 25),
-                    font: 20,
-                    hex: "#ffffff",
-                    text: g.trunc(sex.st[purid].ent[i].names[j], 15)
-                }, 1);
-            }
-        }
-    }
+    if (phone.handlePrefixAction(name))
+        return;
     else {
+        if (phone.handleSaveMenuAction(name))
+            return;
+
+        if (phone.handleSettingsAction(name))
+            return;
+
         switch (name) {
             case "phonex_power":
-                phone.clear(true);
+                phone.close();
                 break;
             case "phonex_menu":
                 phone.clear(true);
@@ -1561,12 +1782,10 @@ room9999.btnclick = function (name) {
                 phone.characters();
                 break;
             case "phone_rel_next":
-                phone.charPointer += 18;
-                phone.characters();
+                phone.changeCharacterPage(18);
                 break;
             case "phone_rel_prev":
-                phone.charPointer -= 18;
-                phone.characters();
+                phone.changeCharacterPage(-18);
                 break;
             case "phone_settings":
                 phone.settings();
@@ -1578,532 +1797,51 @@ room9999.btnclick = function (name) {
                 phone.cheat();
                 break;
             case "phone_help":
-                window.open("http://fapforce5.com", "_blank");
+                phone.help();
+                break;
+            case "phone_help_site":
+                phone.openExternal("http://fapforce5.com");
                 break;
             case "phone_patron":
-                window.open("https://www.patreon.com/FF5", "_blank");
+                phone.openExternal("https://www.patreon.com/FF5");
                 break;
             case "phone_thankyou":
                 phone.thankyou();
                 break;
             case "phone_contacts":
                 phone.clear(false);
-                nav.button({
-                    "type": "zimg",
-                    "name": "phone_",
-                    "left": 451,
-                    "top": 155,
-                    "width": 1185,
-                    "height": 815,
-                    "image": "999_phone/call_bg.jpg",
-                }, 9999);
+                phone.showPanel("999_phone/call_bg.jpg");
                 break;
             case "phone_ach":
-                phone.charPointer = 0;
-                room9999.btnclick("phone_ach_draw");
+                phone.showAchievementGroup(0);
                 break;
             case "phone_ach1":
-                phone.charPointer = 1;
-                room9999.btnclick("phone_ach_draw");
+                phone.showAchievementGroup(1);
                 break;
             case "phone_ach2":
-                phone.charPointer = 2;
-                room9999.btnclick("phone_ach_draw");
+                phone.showAchievementGroup(2);
                 break;
             case "phone_ach3":
-                phone.charPointer = 3;
-                room9999.btnclick("phone_ach_draw");
+                phone.showAchievementGroup(3);
                 break;
             case "phone_ach4":
-                phone.charPointer = 4;
-                room9999.btnclick("phone_ach_draw");
+                phone.showAchievementGroup(4);
                 break;
             case "phone_ach_draw":
-                phone.clear(false);
-                var phone_ach_draw;
-                switch (phone.charPointer) {
-                    case 0: phone_ach_draw = ["panties", "bra"]; break;
-                    case 1: phone_ach_draw = ["oral", "anal", "vaginal"]; break;
-                    case 2: phone_ach_draw = ["fuck"]; break;
-                    case 3: phone_ach_draw = ["event", "school", "pinkroom"]; break;
-                    case 4: phone_ach_draw = ["end"]; break;
-                    default: phone_ach_draw = []; // Fallback so .includes() doesn't crash
-                }
-                nav.button({
-                    "type": "zimg",
-                    "name": "phone_",
-                    "left": 451,
-                    "top": 155,
-                    "width": 1185,
-                    "height": 815,
-                    "image": "999_phone/Achievements_bg.jpg",
-                }, 9999);
-                nav.t({
-                    type: "zbtn",
-                    name: "phone_ach",
-                    left: 550,
-                    top: 800,
-                    font: 30,
-                    hex: "#ffffff",
-                    text: "Clothing"
-                }, 9999);
-                nav.t({
-                    type: "zbtn",
-                    name: "phone_ach1",
-                    left: 750,
-                    top: 800,
-                    font: 30,
-                    hex: "#ffffff",
-                    text: "Sex"
-                }, 9999);
-                nav.t({
-                    type: "zbtn",
-                    name: "phone_ach2",
-                    left: 950,
-                    top: 800,
-                    font: 30,
-                    hex: "#ffffff",
-                    text: "Events"
-                }, 9999);
-                nav.t({
-                    type: "zbtn",
-                    name: "phone_ach3",
-                    left: 1150,
-                    top: 800,
-                    font: 30,
-                    hex: "#ffffff",
-                    text: "Other"
-                }, 9999);
-                nav.t({
-                    type: "zbtn",
-                    name: "phone_ach4",
-                    left: 1350,
-                    top: 800,
-                    font: 30,
-                    hex: "#ffffff",
-                    text: "Endings"
-                }, 9999);
-                
-                let newAchList = trophy.st
-                    // 1. Filter: Only keep items whose group is in the current draw list
-                    .filter(item => phone_ach_draw.includes(item.group))
-
-                    // 2. Sort: First by the group's position in phone_ach_draw, then by .o
-                    .sort((a, b) => {
-                        const indexA = phone_ach_draw.indexOf(a.group);
-                        const indexB = phone_ach_draw.indexOf(b.group);
-
-                        // If groups are different, sort by their order in phone_ach_draw
-                        if (indexA !== indexB) {
-                            return indexA - indexB;
-                        }
-
-                        // If groups are the same, sort by the .o property
-                        return a.o - b.o;
-                    });
-                for (let i = 0; i < newAchList.length; i++) {
-                    if (newAchList[i].ach) {
-                        nav.button({
-                            "type": "zimg",
-                            "name": "phone_",
-                            "left": (i % 3 * 380) + 485,
-                            "top": 200 + (Math.floor(i / 3) * 100),
-                            "width": 350,
-                            "height": 84,
-                            "image": "999_phone/ach/" + newAchList[i].img,
-                        }, 9999);
-                        nav.t({
-                            type: "zimg",
-                            name: "phone_",
-                            "left": (i % 3 * 380) + 580,
-                            "top": 250 + (Math.floor(i / 3) * 100),
-                            font: 16,
-                            hex: "#cccccc",
-                            text: sc.replace(newAchList[i].display)
-                        }, 9999);
-                    }
-                    else {
-                        nav.button({
-                            "type": "zimg",
-                            "name": "phone_",
-                            "left": (i % 3 * 380) + 485,
-                            "top": 200 + (Math.floor(i / 3) * 100),
-                            "width": 350,
-                            "height": 84,
-                            "image": "999_phone/ach/x.webp",
-                        }, 9999);
-                        nav.t({
-                            type: "zimg",
-                            name: "phone_",
-                            "left": (i % 3 * 380) + 580,
-                            "top": 250 + (Math.floor(i / 3) * 100),
-                            font: 16,
-                            hex: "#cccccc",
-                            text: "Not Achieved"
-                        }, 9999);
-                    }
-                    nav.t({
-                        type: "zimg",
-                        name: "phone_",
-                        "left": (i % 3 * 380) + 580,
-                        "top": 210 + (Math.floor(i / 3) * 100),
-                        font: 20,
-                        hex: "#ffffff",
-                        text: sc.replace(newAchList[i].title)
-                    }, 9999);
-                    
-                }
+                phone.drawAchievements();
                 break;
             case "phone_time":
                 phone.passtime();
                 break;
-            case "phone_setting_diff0":
-            case "phone_setting_diff1":
-            case "phone_setting_diff2":
-                gv.set("difficulty", parseInt(name.replace("phone_setting_diff", "")));
-                phone.settings();
-                break;
-            case "phone_setting_clock12":
-            case "phone_setting_clock24":
-                gv.set("clock24", name.replace("phone_setting_clock", ""));
-                phone.settings();
-                break;
-            case "phone_setting_encM":
-                gv.set("encM", !gv.get("encM"));
-                phone.settings();
-                break;
-            case "phone_setting_encF":
-                gv.set("encF", !gv.get("encF"));
-                phone.settings();
-                break;
-            case "phone_setting_encBeast":
-                gv.set("encBeast", !gv.get("encBeast"));
-                phone.settings();
-                break;
-            case "phone_setting_encMyth":
-                gv.set("encMyth", !gv.get("encMyth"));
-                phone.settings();
-                break;
-            case "phone_setting_d_on":
-                gv.set("transformation", "voluntary");
-                phone.settings();
-                break;
-            case "phone_setting_d_off":
-                gv.set("transformation", "voluntaryoff");
-                phone.settings();
-                break;
-            case "phone_setting_m":
-            case "phone_setting_f":
-            case "phone_setting_a":
-                gv.set("pronouns", name.replace("phone_setting_", ""));
-                phone.settings();
-                break;
-            case "phone_setting_d_auto":
-                gv.set("transformation", "forced");
-                phone.settings();
-                break;
-            case "phone_save_save_0":
-            case "phone_save_save_1":
-            case "phone_save_save_2":
-            case "phone_save_save_3":
-            case "phone_save_save_4":
-            case "phone_save_save_5":
-            case "phone_save_save_6":
-            case "phone_save_save_7":
-            case "phone_save_save_8":
-                var saveID = name.replace("phone_save_save_", "");
-                menu.save('HatMP_' + saveID, true);
-                phone.saveMenu();
-                break;
-            case "phone_save_replace_0":
-            case "phone_save_replace_1":
-            case "phone_save_replace_2":
-            case "phone_save_replace_3":
-            case "phone_save_replace_4":
-            case "phone_save_replace_5":
-            case "phone_save_replace_6":
-            case "phone_save_replace_7":
-            case "phone_save_replace_8":
-                let replaceID = name.replace("phone_save_replace_", "");
-                nav.button({
-                    "type": "zimg",
-                    "name": "phone_replace_verify",
-                    "left": 0,
-                    "top": 0,
-                    "width": 1920,
-                    "height": 1080,
-                    "image": "999_phone/verify.png",
-                }, 9999);
-
-                nav.t({
-                    type: "zimg",
-                    name: "phone_",
-                    left: 650,
-                    top: 400,
-                    font: 30,
-                    hex: "#ffffff",
-                    text: "Are you sure you wish to overwrite save: "
-                }, 1);
-                nav.t({
-                    type: "zimg",
-                    name: "phone_",
-                    left: 650,
-                    top: 450,
-                    font: 30,
-                    hex: "#ffffff",
-                    text: $(".room-img[data-name='phone_save_load_name_" + replaceID + "']").text()
-                }, 1);
-                nav.button({
-                    "type": "zbtn",
-                    "name": "phone_save_replace_verify_" + replaceID,
-                    "left": 650,
-                    "top": 600,
-                    "width": 250,
-                    "height": 100,
-                    "image": "999_phone/save.png",
-                }, 9999);
-                nav.button({
-                    "type": "zbtn",
-                    "name": "phone_save_load_cancel",
-                    "left": 1030,
-                    "top": 600,
-                    "width": 250,
-                    "height": 100,
-                    "image": "999_phone/cancel_grey.png",
-                }, 9999);
-                break;
-            case "phone_save_replace_verify_0":
-            case "phone_save_replace_verify_1":
-            case "phone_save_replace_verify_2":
-            case "phone_save_replace_verify_3":
-            case "phone_save_replace_verify_4":
-            case "phone_save_replace_verify_5":
-            case "phone_save_replace_verify_6":
-            case "phone_save_replace_verify_7":
-            case "phone_save_replace_verify_8":
-                let replaceVerifyID = name.replace("phone_save_replace_verify_", "");
-                menu.saveDel('HatMP_' + replaceVerifyID);
-                menu.save('HatMP_' + replaceVerifyID, true);
-                phone.saveMenu();
-                break;
-            case "phone_save_load_0":
-            case "phone_save_load_1":
-            case "phone_save_load_2":
-            case "phone_save_load_3":
-            case "phone_save_load_4":
-            case "phone_save_load_5":
-            case "phone_save_load_6":
-            case "phone_save_load_7":
-            case "phone_save_load_8":
-            case "phone_save_load_9":
-                var loadId = name.replace("phone_save_load_", "");
-                if (g.newLoad) {
-                    chat(-1, 0);
-                    menu.load('HatMP_' + loadId);
-                }
-                else {
-                    nav.button({
-                        "type": "zimg",
-                        "name": "phone_load_verify",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "999_phone/verify.png",
-                    }, 9999);
-
-                    nav.t({
-                        type: "zimg",
-                        name: "phone_",
-                        left: 750,
-                        top: 400,
-                        font: 30,
-                        hex: "#ffffff",
-                        text: "Are you sure you wish to load: "
-                    }, 1);
-                    nav.t({
-                        type: "zimg",
-                        name: "phone_",
-                        left: 650,
-                        top: 450,
-                        font: 30,
-                        hex: "#ffffff",
-                        text: $(".room-img[data-name='phone_save_load_name_" + loadId + "']").text()
-                    }, 1);
-                    nav.button({
-                        "type": "zbtn",
-                        "name": "phone_save_load_verify_" + loadId,
-                        "left": 650,
-                        "top": 600,
-                        "width": 250,
-                        "height": 100,
-                        "image": "999_phone/load.png",
-                    }, 9999);
-                    nav.button({
-                        "type": "zbtn",
-                        "name": "phone_save_load_cancel",
-                        "left": 1030,
-                        "top": 600,
-                        "width": 250,
-                        "height": 100,
-                        "image": "999_phone/cancel.png",
-                    }, 9999); nav.button({
-                        "type": "zimg",
-                        "name": "phone_load_verify",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "999_phone/verify.png",
-                    }, 9999);
-
-                    nav.t({
-                        type: "zimg",
-                        name: "phone_",
-                        left: 750,
-                        top: 400,
-                        font: 30,
-                        hex: "#ffffff",
-                        text: "Are you sure you wish to load: "
-                    }, 1);
-                    nav.t({
-                        type: "zimg",
-                        name: "phone_",
-                        left: 650,
-                        top: 450,
-                        font: 30,
-                        hex: "#ffffff",
-                        text: $(".room-img[data-name='phone_save_load_name_" + loadId + "']").text()
-                    }, 1);
-                    nav.button({
-                        "type": "zbtn",
-                        "name": "phone_save_load_verify_" + loadId,
-                        "left": 650,
-                        "top": 600,
-                        "width": 250,
-                        "height": 100,
-                        "image": "999_phone/load.png",
-                    }, 9999);
-                    nav.button({
-                        "type": "zbtn",
-                        "name": "phone_save_load_cancel",
-                        "left": 1030,
-                        "top": 600,
-                        "width": 250,
-                        "height": 100,
-                        "image": "999_phone/cancel.png",
-                    }, 9999);
-
-                }
-                break;
-            case "phone_save_load_cancel":
-                phone.saveMenu();
-                break;
-            case "phone_save_load_verify_0":
-            case "phone_save_load_verify_1":
-            case "phone_save_load_verify_2":
-            case "phone_save_load_verify_3":
-            case "phone_save_load_verify_4":
-            case "phone_save_load_verify_5":
-            case "phone_save_load_verify_6":
-            case "phone_save_load_verify_7":
-            case "phone_save_load_verify_8":
-            case "phone_save_load_verify_9":
-                var loadverifyId = name.replace("phone_save_load_verify_", "");
-                chat(-1, 0);
-                menu.load('HatMP_' + loadverifyId);
-                break;
-            case "phone_save_delete_0":
-            case "phone_save_delete_1":
-            case "phone_save_delete_2":
-            case "phone_save_delete_3":
-            case "phone_save_delete_4":
-            case "phone_save_delete_5":
-            case "phone_save_delete_6":
-            case "phone_save_delete_7":
-            case "phone_save_delete_8":
-                var delId = name.replace("phone_save_delete_", "");
-                nav.button({
-                    "type": "zimg",
-                    "name": "phone_load_verify",
-                    "left": 0,
-                    "top": 0,
-                    "width": 1920,
-                    "height": 1080,
-                    "image": "999_phone/verify.png",
-                }, 9999);
-
-                nav.t({
-                    type: "zimg",
-                    name: "phone_",
-                    left: 750,
-                    top: 400,
-                    font: 30,
-                    hex: "#ffffff",
-                    text: "Are you sure you wish to delete: "
-                }, 1);
-                nav.t({
-                    type: "zimg",
-                    name: "phone_",
-                    left: 650,
-                    top: 450,
-                    font: 30,
-                    hex: "#ffffff",
-                    text: $(".room-img[data-name='phone_save_load_name_" + delId + "']").text()
-                }, 1);
-                nav.button({
-                    "type": "zbtn",
-                    "name": "phone_save_delete_verify_" + delId,
-                    "left": 650,
-                    "top": 600,
-                    "width": 250,
-                    "height": 100,
-                    "image": "999_phone/delete.png",
-                }, 9999);
-                nav.button({
-                    "type": "zbtn",
-                    "name": "phone_save_load_cancel",
-                    "left": 1030,
-                    "top": 600,
-                    "width": 250,
-                    "height": 100,
-                    "image": "999_phone/cancel_grey.png",
-                }, 9999);
-                break;
-            case "phone_save_delete_verify_0":
-            case "phone_save_delete_verify_1":
-            case "phone_save_delete_verify_2":
-            case "phone_save_delete_verify_3":
-            case "phone_save_delete_verify_4":
-            case "phone_save_delete_verify_5":
-            case "phone_save_delete_verify_6":
-            case "phone_save_delete_verify_7":
-            case "phone_save_delete_verify_8":
-                var deleteId = name.replace("phone_save_delete_verify_", "");
-                menu.saveDel('HatMP_' + deleteId);
-                phone.saveMenu();
-                break;
-            case "phone_save_export_0":
-            case "phone_save_export_1":
-            case "phone_save_export_2":
-            case "phone_save_export_3":
-            case "phone_save_export_4":
-            case "phone_save_export_5":
-            case "phone_save_export_6":
-            case "phone_save_export_7":
-            case "phone_save_export_8":
-            case "phone_save_export_9":
-                var exportId = name.replace("phone_save_export_", "");
-                char.export(exportId);
-                break;
             case "phone_save_import":
-                $('#room-export-text').hide();
-                $('#room-import-text').show();
-                $("#room_export").slideDown();
-                $("#room_export_data").val('');
-                $('#room_export_load').show();
-                $('#room_export_load_file').show();
-                $('#room_export_file').hide();
+                char.showExportDialog({
+                    data: '',
+                    showLoad: true,
+                    showLoadFile: true,
+                    showSaveFile: false,
+                    showExportText: false,
+                    showImportText: true
+                });
                 break;
             case "phone_purity":
                 phone.purity();
@@ -2113,3 +1851,17 @@ room9999.btnclick = function (name) {
         }
     }
 };
+
+invoker.registerRoom(9999, room9999);
+
+$(document).bind('keyup', function (e) {
+    if (e.which !== 27 || e.altKey || e.ctrlKey || e.metaKey)
+        return;
+    if (char.isTypingTarget(e.target))
+        return;
+    if ($('#room_export').is(":visible"))
+        return;
+
+    if (phone.close())
+        e.preventDefault();
+});

--- a/scripts/quickFight.js
+++ b/scripts/quickFight.js
@@ -54,29 +54,7 @@ quickFight.getProb = function (enemy, me) {
     return { txt: "Extremely Easy", num: 3 };
 };
 
-quickFight.init = function (enemyFightLevel, enemyName, btnPressWin, btnPressLost, btnPressRun, roomID) {
-    inv.hide();
-    var i = 0;
-    var stats = quickFight.getStats(enemyFightLevel);
-    nav.killbuttonStartsWith("quickfight");
-    nav.button({
-        "type": "img",
-        "name": "quickfight",
-        "left": 0,
-        "top": 0,
-        "width": 1920,
-        "height": 1080,
-        "image": "1002_quickfight/bg.png"
-    }, 1002);
-    //nav.button({
-    //    "type": "img",
-    //    "name": "quickfight",
-    //    "left": 1597,
-    //    "top": 147,
-    //    "width": 306,
-    //    "height": 712,
-    //    "image": "227_fight/menu.png"
-    //}, 1002);
+quickFight.showMainMenu = function () {
     nav.button({
         "type": "btn",
         "name": "quickfightFight",
@@ -106,6 +84,88 @@ quickFight.init = function (enemyFightLevel, enemyName, btnPressWin, btnPressLos
         "height": 100,
         "image": "1002_quickfight/run.png"
     }, 1002);
+};
+
+quickFight.showInventoryMenu = function () {
+    var btnCounter = 0;
+    nav.killbutton("quickfightFight");
+    nav.killbutton("quickfightInventory");
+    nav.killbutton("quickfightRun");
+
+    for (var i = 0; i < inv.master.length; i++) {
+        if ((inv.master[i].type === "e" || inv.master[i].type === "i") && inv.master[i].count > 0) {
+            nav.button({
+                "type": "btn",
+                "name": "quickfightinv_" + i,
+                "left": 760,
+                "top": 100 + (btnCounter * 125),
+                "width": 400,
+                "height": 100,
+                "image": "1002_quickfight/i_" + inv.master[i].name + ".png"
+            }, 1002);
+            btnCounter++;
+        }
+    }
+    nav.button({
+        "type": "btn",
+        "name": "quickfightGoBack",
+        "left": 760,
+        "top": 100 + (btnCounter * 125),
+        "width": 400,
+        "height": 100,
+        "image": "1002_quickfight/goback.png"
+    }, 1002);
+};
+
+quickFight.closeInventoryMenu = function () {
+    nav.killbuttonStartsWith("quickfightinv_");
+    nav.killbutton("quickfightGoBack");
+    quickFight.showMainMenu();
+};
+
+quickFight.resolveAftermathButton = function () {
+    if (g.fight.aftermath === "run")
+        return g.fight.btnPressRun;
+    if (g.fight.aftermath === "win")
+        return g.fight.btnPressWin;
+    return g.fight.btnPressLost;
+};
+
+quickFight.hideShellPanels = function () {
+    quickFight.prevPanel = char.currentMenuPanel();
+    char.hideMenuPanels();
+};
+
+quickFight.restoreShellPanels = function () {
+    if (quickFight.prevPanel && quickFight.prevPanel !== "hide")
+        char.changeMenu(quickFight.prevPanel, false, true);
+};
+
+quickFight.init = function (enemyFightLevel, enemyName, btnPressWin, btnPressLost, btnPressRun, roomID) {
+    inv.hide();
+    quickFight.hideShellPanels();
+    var i = 0;
+    var stats = quickFight.getStats(enemyFightLevel);
+    nav.killbuttonStartsWith("quickfight");
+    nav.button({
+        "type": "img",
+        "name": "quickfight",
+        "left": 0,
+        "top": 0,
+        "width": 1920,
+        "height": 1080,
+        "image": "1002_quickfight/bg.png"
+    }, 1002);
+    //nav.button({
+    //    "type": "img",
+    //    "name": "quickfight",
+    //    "left": 1597,
+    //    "top": 147,
+    //    "width": 306,
+    //    "height": 712,
+    //    "image": "227_fight/menu.png"
+    //}, 1002);
+    quickFight.showMainMenu();
 
     nav.t({
         type: "zimg",
@@ -367,7 +427,7 @@ quickFight.drawFight = function () {
         else {
             g.fight.aftermath = "lose";
             gv.mod("energy", -39);
-            gv.mod("strength", 15);
+            levels.mod("strength", 15);
             nav.t({
                 type: "img",
                 name: "quickfight",
@@ -391,7 +451,6 @@ quickFight.drawFight = function () {
 };
 
 room1002.btnclick = function (name) {
-    var i;
     if (name.startsWith("quickfightinv_")) {
         var invIndex = parseInt(name.replace("quickfightinv_", ""));
         switch (inv.master[invIndex].name) {
@@ -450,66 +509,10 @@ room1002.btnclick = function (name) {
                 quickFight.drawFight();
                 break;
             case "quickfightInventory":
-                nav.killbutton("quickfightFight");
-                nav.killbutton("quickfightInventory");
-                nav.killbutton("quickfightRun");
-                var btnCounter = 0;
-                for (i = 0; i < inv.master.length; i++) {
-                    if ((inv.master[i].type === "e" || inv.master[i].type === "i") && inv.master[i].count > 0) {
-                        nav.button({
-                            "type": "btn",
-                            "name": "quickfightinv_" + i,
-                            "left": 760,
-                            "top": 100 + (btnCounter * 125),
-                            "width": 400,
-                            "height": 100,
-                            "image": "1002_quickfight/i_" + inv.master[i].name + ".png"
-                        }, 1002);
-                        btnCounter++;
-                    }
-                }
-                nav.button({
-                    "type": "btn",
-                    "name": "quickfightGoBack",
-                    "left": 760,
-                    "top": 100 + (btnCounter * 125),
-                    "width": 400,
-                    "height": 100,
-                    "image": "1002_quickfight/goback.png"
-                }, 1002);
+                quickFight.showInventoryMenu();
                 break;
             case "quickfightGoBack":
-                nav.killbuttonStartsWith("quickfightinv_");
-                nav.killbutton("quickfightGoBack");
-                nav.button({
-                    "type": "btn",
-                    "name": "quickfightFight",
-                    "left": 760,
-                    "top": 300,
-                    "width": 400,
-                    "height": 100,
-                    "image": "1002_quickfight/fight.png"
-                }, 1002);
-
-                nav.button({
-                    "type": "btn",
-                    "name": "quickfightInventory",
-                    "left": 760,
-                    "top": 450,
-                    "width": 400,
-                    "height": 100,
-                    "image": "1002_quickfight/inventory.png"
-                }, 1002);
-
-                nav.button({
-                    "type": "btn",
-                    "name": "quickfightRun",
-                    "left": 760,
-                    "top": 600,
-                    "width": 400,
-                    "height": 100,
-                    "image": "1002_quickfight/run.png"
-                }, 1002);
+                quickFight.closeInventoryMenu();
                 break;
             case "quickfightRun":
                 quickFight.run();
@@ -541,15 +544,18 @@ quickFight.run = function () {
 quickFight.complete = function () {
     inv.show();
     nav.killbuttonStartsWith("quickfight");
-    var name;
     var roomId = g.fight.roomID;
-    if (g.fight.aftermath === "run")
-        name = g.fight.btnPressRun;
-    else if (g.fight.aftermath === "win")
-        name = g.fight.btnPressWin;
-    else
-        name = g.fight.btnPressLost;
+    var name = quickFight.resolveAftermathButton();
+    var pastSaveCount = g.pastSaves.length;
 
     g.fight = null;
-    window[g.room(roomId)]["btnclick"](name);
+    quickFight.restoreShellPanels();
+    invoker.invoke(roomId, "btnclick", name);
+    if (g.roomID === roomId && g.pastSaves.length > pastSaveCount) {
+        g.pastSaves.splice(pastSaveCount, g.pastSaves.length - pastSaveCount);
+        if (char.currentMenuPanel() === "walk")
+            char.makeWalk();
+    }
 };
+
+invoker.registerRoom(1002, room1002);

--- a/scripts/randomEvents.js
+++ b/scripts/randomEvents.js
@@ -3,6 +3,28 @@ fame.niceCounter = 0;
 fame.rapeCounter = 0;
 fame.moanCounter = null;
 fame.animateTimeout = null;
+
+fame.nextMoanFrame = function () {
+    if (fame.moanCounter === null)
+        fame.moanCounter = g.rand(0, 9);
+    fame.moanCounter++;
+    if (fame.moanCounter > 8)
+        fame.moanCounter = 0;
+    return fame.moanCounter;
+};
+
+fame.drawMoan = function (left, top, size) {
+    nav.button({
+        "type": "img",
+        "name": "fame.moan-kill",
+        "left": left,
+        "top": top,
+        "width": size * 2,
+        "height": size,
+        "image": "1001_rand/moan" + fame.nextMoanFrame() + ".webp"
+    }, 1010);
+};
+
 fame.event = function (roomId, returnBtn) {
     if (g.isNight()) {
         let orallevel = levels.get("oral").l;
@@ -67,7 +89,7 @@ fame.moanAnimate = function (side) {
     if (fame.animateTimeout !== null) return;
     fame.moan(side);
     fame.animateTimeout = setInterval(function () {
-        nav.killbutton("fame.moan-kill"); 
+        fame.moankill();
         fame.moan(side);
     }, 1200);
 };
@@ -81,72 +103,26 @@ fame.moanAnimateStop = function () {
 fame.moan = function (side = "center") {
     //0-8
     fame.moankill();
-    let initmoan0 = g.rand(150, 201);
-    let initmoan1 = g.rand(150, 201);
+    let primarySize = g.rand(150, 201);
+    let secondarySize = g.rand(150, 201);
     let top = g.rand(200, 700);
-    let left = g.rand(100, 540);
-    let center = g.rand(540, 1180);
-    let right = g.rand(1180, 1500);
-    if (fame.moanCounter === null)
-        fame.moanCounter = g.rand(0, 9);
-    fame.moanCounter++;
-    if (fame.moanCounter > 8)
-        fame.moanCounter = 0;
-    
+    let positions = {
+        left: g.rand(100, 540),
+        center: g.rand(540, 1180),
+        right: g.rand(1180, 1500)
+    };
+
     if (side === "left") {
-        nav.button({
-            "type": "img",
-            "name": "fame.moan-kill",
-            "left": left,
-            "top": top,
-            "width": initmoan0 * 2,
-            "height": initmoan0,
-            "image": "1001_rand/moan" + fame.moanCounter + ".webp"
-        }, 1010);
+        fame.drawMoan(positions.left, top, primarySize);
     }
     else if (side === "right") {
-        nav.button({
-            "type": "img",
-            "name": "fame.moan-kill",
-            "left": right,
-            "top": top,
-            "width": initmoan0 * 2,
-            "height": initmoan0,
-            "image": "1001_rand/moan" + fame.moanCounter + ".webp"
-        }, 1010);
+        fame.drawMoan(positions.right, top, primarySize);
     }
     else if (side === "center") {
-        nav.button({
-            "type": "img",
-            "name": "fame.moan-kill",
-            "left": center,
-            "top": top,
-            "width": initmoan0 * 2,
-            "height": initmoan0,
-            "image": "1001_rand/moan" + fame.moanCounter + ".webp"
-        }, 1010);
+        fame.drawMoan(positions.center, top, primarySize);
     }
     else if (side === "double") {
-        nav.button({
-            "type": "img",
-            "name": "fame.moan-kill",
-            "left": left,
-            "top": g.rand(400, 700),
-            "width": initmoan1 * 2,
-            "height": initmoan1,
-            "image": "1001_rand/moan" + fame.moanCounter + ".webp"
-        }, 1010);
-        fame.moanCounter++;
-        if (fame.moanCounter > 8)
-            fame.moanCounter = 0;
-        nav.button({
-            "type": "img",
-            "name": "fame.moan-kill",
-            "left": right,
-            "top": top,
-            "width": initmoan0 * 2,
-            "height": initmoan0,
-            "image": "1001_rand/moan" + fame.moanCounter + ".webp"
-        }, 1010);
+        fame.drawMoan(positions.left, g.rand(400, 700), secondarySize);
+        fame.drawMoan(positions.right, top, primarySize);
     }
 };

--- a/scripts/rape.js
+++ b/scripts/rape.js
@@ -11,6 +11,9 @@ rape.phase = 0;
 rape.modifier = "";
 rape.charMessage;
 rape.location;
+rape.actionButtonLeft = 1600;
+rape.actionButtonTop = 480;
+rape.actionButtonSpacing = 75;
 rape.phases = [
     { i: 0, n: "Surprise", c: 0 },
     { i: 1, n: "fully clothed only", c: 0 },
@@ -23,6 +26,48 @@ rape.phases = [
     { i: 8, n: "exit", c: 0 },
 ];
 
+rape.appendHudLayer = function (className, attrs, width, top, left, background) {
+    let attrText = "";
+    Object.keys(attrs).forEach(function (key) {
+        attrText += " data-" + key + "=\"" + attrs[key] + "\"";
+    });
+    $("#room-buttons").append(
+        '<div class="room-img room-zindex resize ' + className + '"' + attrText +
+        ' style=" ' + g.makeCss(10, width, top, left) + "  background: " + background + '; border-radius:10px;" ></div>'
+    );
+};
+
+rape.appendHudBar = function (className, top, left, layers) {
+    for (let i = 0; i < layers.length; i++) {
+        rape.appendHudLayer(className, layers[i].attrs, layers[i].width, top, left, layers[i].background);
+    }
+};
+
+rape.drawPanelBackground = function (image = "1004_rape/icon_bg.png") {
+    nav.button({
+        "type": "zimg",
+        "name": "m1004-d",
+        "left": 1600,
+        "top": 150,
+        "width": 300,
+        "height": 318,
+        "image": image
+    }, 1004);
+};
+
+rape.renderActionButtons = function (btnList, top = rape.actionButtonTop) {
+    for (let i = 0; i < btnList.length; i++) {
+        nav.button({
+            "type": "zbtn",
+            "name": "b1004-" + btnList[i].n,
+            "left": rape.actionButtonLeft,
+            "top": top + (i * rape.actionButtonSpacing),
+            "width": 300,
+            "height": 72,
+            "image": "1004_rape/" + btnList[i].i
+        }, 1004);
+    }
+};
 
 rape.init = function (charNum = null, location = "street", roomId = g.roomID, callback = "") {
     nav.killall();
@@ -109,21 +154,26 @@ rape.init = function (charNum = null, location = "street", roomId = g.roomID, ca
     
     
 
-    $('#room-buttons').append('<div class="room-img room-zindex resize enemy-life" data-name="myenergybase" data-room="1004" style=" ' + g.makeCss(10, 280, 1020, 1450) + '  background: #333; border-radius:10px;" ></div>');
-    $('#room-buttons').append('<div class="room-img room-zindex resize enemy-life" data-t="damage" data-room="1004" style=" ' + g.makeCss(10, 100, 1020, 1450) + '  background: #ff3333; border-radius:10px;" ></div>');
-    $('#room-buttons').append('<div class="room-img room-zindex resize enemy-life" data-t="energy" data-room="1004" style=" ' + g.makeCss(10, 100, 1020, 1450) + '  background: #33ff33; border-radius:10px;" ></div>');
-
-    $('#room-buttons').append('<div class="room-img room-zindex resize my-life" data-name="enemy0" data-room="9999" style=" ' + g.makeCss(10, 280, 1020, 200) + '  background: #333; border-radius:10px;" ></div>');
-    $('#room-buttons').append('<div class="room-img room-zindex resize my-life" data-t="damage" data-name="enemy0" data-room="9999" style=" ' + g.makeCss(10, 280, 1020, 200) + '  background: #ff3333; border-radius:10px;" ></div>');
-    $('#room-buttons').append('<div class="room-img room-zindex resize my-life" data-t="energy" data-name="enemy0" data-room="9999" style=" ' + g.makeCss(10, 280, 1020, 200) + '  background: #33ff33; border-radius:10px;" ></div>');
-
-    $('#room-buttons').append('<div class="room-img room-zindex resize enemy-arousal" data-name="enemy0" data-room="9999" style=" ' + g.makeCss(10, 280, 1050, 1450) + '  background: #333; border-radius:10px;" ></div>');
-    $('#room-buttons').append('<div class="room-img room-zindex resize enemy-arousal" data-t="damage" data-name="enemy0" data-room="9999" style=" ' + g.makeCss(10, 280, 1050, 1450) + '  background: #d9b568; border-radius:10px;" ></div>');
-    $('#room-buttons').append('<div class="room-img room-zindex resize enemy-arousal" data-t="energy" data-name="enemy0" data-room="9999" style=" ' + g.makeCss(10, 280, 1050, 1450) + '  background: #fff7e6; border-radius:10px;" ></div>');
-
-    $('#room-buttons').append('<div class="room-img room-zindex resize my-arousal" data-name="enemy0" data-room="9999" style=" ' + g.makeCss(10, 280, 1050, 200) + '  background: #333; border-radius:10px;" ></div>');
-    $('#room-buttons').append('<div class="room-img room-zindex resize my-arousal" data-t="damage" data-name="enemy0" data-room="9999" style=" ' + g.makeCss(10, 280, 1050, 200) + '  background: #d9b568; border-radius:10px;" ></div>');
-    $('#room-buttons').append('<div class="room-img room-zindex resize my-arousal" data-t="energy" data-name="enemy0" data-room="9999" style=" ' + g.makeCss(10, 280, 1050, 200) + '  background: #fff7e6; border-radius:10px;" ></div>');
+    rape.appendHudBar("enemy-life", 1020, 1450, [
+        { attrs: { name: "myenergybase", room: "1004" }, width: 280, background: "#333" },
+        { attrs: { t: "damage", room: "1004" }, width: 100, background: "#ff3333" },
+        { attrs: { t: "energy", room: "1004" }, width: 100, background: "#33ff33" }
+    ]);
+    rape.appendHudBar("my-life", 1020, 200, [
+        { attrs: { name: "enemy0", room: "9999" }, width: 280, background: "#333" },
+        { attrs: { t: "damage", name: "enemy0", room: "9999" }, width: 280, background: "#ff3333" },
+        { attrs: { t: "energy", name: "enemy0", room: "9999" }, width: 280, background: "#33ff33" }
+    ]);
+    rape.appendHudBar("enemy-arousal", 1050, 1450, [
+        { attrs: { name: "enemy0", room: "9999" }, width: 280, background: "#333" },
+        { attrs: { t: "damage", name: "enemy0", room: "9999" }, width: 280, background: "#d9b568" },
+        { attrs: { t: "energy", name: "enemy0", room: "9999" }, width: 280, background: "#fff7e6" }
+    ]);
+    rape.appendHudBar("my-arousal", 1050, 200, [
+        { attrs: { name: "enemy0", room: "9999" }, width: 280, background: "#333" },
+        { attrs: { t: "damage", name: "enemy0", room: "9999" }, width: 280, background: "#d9b568" },
+        { attrs: { t: "energy", name: "enemy0", room: "9999" }, width: 280, background: "#fff7e6" }
+    ]);
 
     
     rape.updateEnergy(null, null, null, null);
@@ -1436,8 +1486,10 @@ rape.kill = function () {
     nav.killall();
     inv.show();
     //char.room(0);
-    window[g.room(rape.roomId)]["btnclick"](rape.callback);
+    invoker.invoke(rape.roomId, "btnclick", rape.callback);
 }
+
+invoker.registerRoom(1004, room1004);
 
 rape.updateEnergy = function (enemyEnergyChange = null, myEnergyChange = null, enemyArousal = null, myarousal = null) {
     let startingEnemyEnergy = rape.char.energy;
@@ -1726,31 +1778,13 @@ rape.displayMenu = function (menu) {
             break;
     }
 
-    for (i = 0; i < btnList.length; i++) {
-        nav.button({
-            "type": "zbtn",
-            "name": "b1004-" + btnList[i].n,
-            "left": 1600,
-            "top": 480 + (i * 75),
-            "width": 300,
-            "height": 72,
-            "image": "1004_rape/" + btnList[i].i
-        }, 1004);
-    }
+    rape.renderActionButtons(btnList);
 };
 
 rape.message = function (message, speaker = null) {
     nav.killbutton("m1004-d");
     if (rape.phase === 0 || speaker === "rapeMessage") {
-        nav.button({
-            "type": "zimg",
-            "name": "m1004-d",
-            "left": 1600,
-            "top": 150,
-            "width": 300,
-            "height": 318,
-            "image": "1004_rape/icon_bg_rape.png"
-        }, 1004);
+        rape.drawPanelBackground("1004_rape/icon_bg_rape.png");
         return;
     }
     if (typeof message === "string") {
@@ -1811,15 +1845,7 @@ rape.rolldice = function (updateEnergy = false) {
     var fightStats = quickFight.getStats(rape.char.fight, rape.char.energy);
     myTotal = enemyTotal = 0;
 
-    nav.button({
-        "type": "zimg",
-        "name": "m1004-d",
-        "left": 1600,
-        "top": 150,
-        "width": 300,
-        "height": 318,
-        "image": "1004_rape/icon_bg.png"
-    }, 1002);
+    rape.drawPanelBackground();
     
     
     for (var i = 0; i < 4; i++) {
@@ -1900,17 +1926,7 @@ rape.rolldice = function (updateEnergy = false) {
         xbtnList.push({ n: "struggleLost", i: "lost" + rape.phase + ".png" });
     }
 
-    for (i = 0; i < xbtnList.length; i++) {
-        nav.button({
-            "type": "zbtn",
-            "name": "b1004-" + xbtnList[i].n,
-            "left": 1600,
-            "top": 480 + (i * 75),
-            "width": 300,
-            "height": 72,
-            "image": "1004_rape/" + xbtnList[i].i
-        }, 1004);
-    }
+    rape.renderActionButtons(xbtnList);
 
     if (updateEnergy) {
         if (myTotalWithFight >= enemyTotalWithFight) {
@@ -1992,15 +2008,7 @@ rape.kick = function () {
             hex: "#ffffff",
             text: "Success!"
         });
-        nav.button({
-            "type": "zbtn",
-            "name": "b1004-flee",
-            "left": 1600,
-            "top": 660,
-            "width": 300,
-            "height": 72,
-            "image": "1004_rape/icon_flee.png"
-        }, 1004);
+        rape.renderActionButtons([{ n: "flee", i: "icon_flee.png" }], 660);
     }
     else {
         nav.t({
@@ -2012,20 +2020,7 @@ rape.kick = function () {
             hex: "#ffffff",
             text: "Kick failed!"
         });
-        let xbtnList = new Array();
-        xbtnList.push({ n: "struggleLost", i: "lost" + rape.phase + ".png" });
-
-        for (i = 0; i < xbtnList.length; i++) {
-            nav.button({
-                "type": "zbtn",
-                "name": "b1004-" + xbtnList[i].n,
-                "left": 1600,
-                "top": 480,
-                "width": 300,
-                "height": 72,
-                "image": "1004_rape/" + xbtnList[i].i
-            }, 1004);
-        }
+        rape.renderActionButtons([{ n: "struggleLost", i: "lost" + rape.phase + ".png" }]);
     }
 };
 

--- a/scripts/rapeChar.js
+++ b/scripts/rapeChar.js
@@ -1,4 +1,25 @@
 ﻿function getRapeChar(location = null, num = null) {
+    function rapeCharImage(left, top, width, height, image, roomId = 1004, title = null) {
+        var button = {
+            "type": "img",
+            "name": "r1004bg",
+            "left": left,
+            "top": top,
+            "width": width,
+            "height": height,
+            "image": image
+        };
+
+        if (title !== null)
+            button.title = title;
+
+        nav.button(button, roomId);
+    }
+
+    function rapeCharFullscreen(image, roomId = 1004, title = null) {
+        rapeCharImage(0, 0, 1920, 1080, image, roomId, title);
+    }
+
     let retVar = [
         {
             num: 0,
@@ -23,15 +44,7 @@
             phase2: function () { return { default: true, complete: null }; },
             phase3: function () {
                 if (rape.phases[3].c === 0) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/rapeman0/rape0.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/rapeman0/rape0.png");
                     nav.button({
                         "type": "img",
                         "name": "r1004bg",
@@ -43,15 +56,7 @@
                     }, 1004);
                     return { complete: false, s: "!rape0", message: "I'm going to love raping your tight little holes " + gender.pronoun("girl") + "!" };
                 }
-                nav.button({
-                    "type": "img",
-                    "name": "r1004bg",
-                    "left": 0,
-                    "top": 0,
-                    "width": 1920,
-                    "height": 1080,
-                    "image": "1004_rape/rapeman0/rape1.png"
-                }, 1004);
+                rapeCharFullscreen("1004_rape/rapeman0/rape1.png");
                 return { complete: true, s: "!rape0", message: "Show me how much you want this fat cock inside your tiny little body." };
             },
             phase4: function(){
@@ -61,15 +66,7 @@
                 if (rape.phases[5].c === 0) {
                     if (rape.rapeType === "anal") {
                         zcl.assup(650, 500, .7, "");
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/rapeman0/rape3.png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/rapeman0/rape3.png");
                         nav.button({
                             "type": "img",
                             "name": "r1004bg",
@@ -100,15 +97,7 @@
                 if (rape.phases[6].c === 0) {
                     if (rape.rapeType === "anal") {
                         zcl.assup(650, 500, .7, "");
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/rapeman0/rape3.png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/rapeman0/rape3.png");
                         nav.button({
                             "type": "img",
                             "name": "r1004bg",
@@ -201,15 +190,7 @@
                         return { default: false, complete: false };
                     }
                     else if (rape.phaseChange === "phase3cover") {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/missx/slap_" + gender.pronoun("f") + ".png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/missx/slap_" + gender.pronoun("f") + ".png");
                         return { default: false, complete: false };
                     }
                     else if (rape.phaseChange === "phase3sub" || rape.phaseChange === "limp" || rape.phaseChange === "struggle") {
@@ -286,15 +267,7 @@
                     }
                     else {
                         zcl.bj(100, -50, 1, "", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/missx/phase5_oral.png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/missx/phase5_oral.png");
                         return { c: false, s: rape.char.name, m: "FFFFffuuucckkkk! You are a great pussy muncher! " }
                     }
                 }
@@ -304,27 +277,11 @@
                 if (rape.phases[7].c === 0) {
                     if (rape.rapeType === "anal") {
                         zcl.kill();
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/missx/phase6_" + gender.pronoun("f") + ".png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/missx/phase6_" + gender.pronoun("f") + ".png");
                     }
                     else {
                         zcl.kill();
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 456,
-                            "top": 0,
-                            "width": 1084,
-                            "height": 1080,
-                            "image": "1004_rape/phase6_cun_" + gender.pronoun("f") + ".png"
-                        }, 1004);
+                        rapeCharImage(456, 0, 1084, 1080, "1004_rape/phase6_cun_" + gender.pronoun("f") + ".png");
                     }
                     return false;
                 }
@@ -374,29 +331,13 @@
                     }, 1004);
                     return { complete: false, s: "!futa0", message: "So what do you like better in a futa? The big fat titties..." };
                 }
-                nav.button({
-                    "type": "img",
-                    "name": "r1004bg",
-                    "left": 476,
-                    "top": 56,
-                    "width": 969,
-                    "height": 969,
-                    "image": "1004_rape/futa0/phase2_1.png"
-                }, 1004);
+                rapeCharImage(476, 56, 969, 969, "1004_rape/futa0/phase2_1.png");
                 return { complete: true, s: "!futa0", message: "..or the cute little dicky?" };
             },
             phase4: function () {
                 if (rape.rapeType === "cunnilugus") {
                     if (rape.phases[4].c === 0) {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 360,
-                            "top": 0,
-                            "width": 1187,
-                            "height": 1080,
-                            "image": "1004_rape/futa0/phase2_oral.png"
-                        }, 1004);
+                        rapeCharImage(360, 0, 1187, 1080, "1004_rape/futa0/phase2_oral.png");
                         return { default: false, complete: false };
                     }
                     return { default: false, complete: true };
@@ -406,15 +347,7 @@
             phase5: function () {
                 if (rape.phases[5].c === 0) {
                     if (rape.rapeType === "anal") {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 605,
-                            "top": 425,
-                            "width": 1063,
-                            "height": 595,
-                            "image": "1004_rape/futa0/phase4_anal_bottom.png"
-                        }, 1004);
+                        rapeCharImage(605, 425, 1063, 595, "1004_rape/futa0/phase4_anal_bottom.png");
                         zcl.assup(600, 500, .75, "");
                         nav.button({
                             "type": "img",
@@ -437,15 +370,7 @@
                     }
                     else {
                         zcl.bj(200, 300, .5, "open", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 652,
-                            "top": 103,
-                            "width": 820,
-                            "height": 977,
-                            "image": "1004_rape/futa0/phase4_oral.png"
-                        }, 1004);
+                        rapeCharImage(652, 103, 820, 977, "1004_rape/futa0/phase4_oral.png");
                     }
                     return false;
                 }
@@ -454,39 +379,15 @@
             phase6: function () {
                 if (rape.phases[6].c === 0) {
                     if (rape.rapeType === "anal") {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 605,
-                            "top": 425,
-                            "width": 1063,
-                            "height": 595,
-                            "image": "1004_rape/futa0/phase4_anal_bottom.png"
-                        }, 1004);
+                        rapeCharImage(605, 425, 1063, 595, "1004_rape/futa0/phase4_anal_bottom.png");
                         zcl.assup(600, 500, .75, "");
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 605,
-                            "top": 425,
-                            "width": 1063,
-                            "height": 595,
-                            "image": "1004_rape/futa0/phase5_anal_top.png"
-                        }, 1004);
+                        rapeCharImage(605, 425, 1063, 595, "1004_rape/futa0/phase5_anal_top.png");
                         levels.anal(3, false, "n", true, "!futa0");
                         return { c: false, s: rape.char.name, m: "The best pussy to cum in is a smooth sissy bussy!" }
                     }
                     else {
                         zcl.bj(200, 300, .5, "open", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 652,
-                            "top": 103,
-                            "width": 820,
-                            "height": 977,
-                            "image": "1004_rape/futa0/phase5_oral.png"
-                        }, 1004);
+                        rapeCharImage(652, 103, 820, 977, "1004_rape/futa0/phase5_oral.png");
                         return { c: false, s: rape.char.name, m: "Oh fuck! I'm cumming! Fuck yeah you're a great pussy eater!" }
                     }
                 }
@@ -516,25 +417,9 @@
             kick: null,
             phase0: function () {
                 if (rape.phase === 0) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/plant/p0_b.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/plant/p0_b.png");
                     zcl.displayMain(-1200, 400, .3, "clothes", false);
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/plant/p0_f.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/plant/p0_f.png");
                     return { default: false, complete: false };
                 }
                 else return { default: false, complete: true };
@@ -550,15 +435,7 @@
                     else
                         img += "n_";
                     img += (cl.c.chest > 2 ? "f" : "m") + ".png";
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/plant/phase1_b.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/plant/phase1_b.png");
                     nav.button({
                         "type": "img",
                         "name": "r1004bg",
@@ -568,15 +445,7 @@
                         "height": 1080,
                         "image": "1004_rape/plant/" + img
                     }, 1004);
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/plant/phase1_f.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/plant/phase1_f.png");
                     return { default: false, complete: false };
                 }
                 else
@@ -585,15 +454,7 @@
             phase2: function () {
                 if (rape.phases[2].c === 0) {
                     zcl.kill();
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/plant/phase2_panties.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/plant/phase2_panties.png");
                     return { default: false, complete: false };
                 }
                 return { default: false, complete: true };
@@ -619,27 +480,11 @@
                         "height": 1080,
                         "image": "1004_rape/plant/" + img
                     }, 1004);
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/plant/phase3_0.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/plant/phase3_0.png");
                     return { complete: false, s: "me", message: "Oh gross. It's so slimey." };
                 }
                 else if (rape.phases[3].c === 1) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/plant/phase3_1_" + gender.pronoun("f") + ".png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/plant/phase3_1_" + gender.pronoun("f") + ".png");
                     return { complete: false, s: "thinking", message: "Hruck! So deep down my throat!" };
                 }
                 else if (rape.phases[3].c > 1 && rape.phases[3].c < 7) {
@@ -691,15 +536,7 @@
                         "height": 1080,
                         "image": "1004_rape/plant/" + img
                     }, 1004);
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/plant/phase4_" + chest
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/plant/phase4_" + chest);
                     nav.button({
                         "type": "img",
                         "name": "r1004bg",
@@ -715,15 +552,7 @@
             },
             phase6: function () {
                 if (rape.phases[6].c === 0) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/plant/phase5.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/plant/phase5.png");
                     return { c: false, s: "thinking", m: "GAK! I can feel it pollinating me! My holes are totally coated in this thick green slime!" }
                 }
                 return { c: true, s: null, m: null };
@@ -746,15 +575,7 @@
                     }
                     else {
                         zcl.kill();
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 456,
-                            "top": 0,
-                            "width": 1084,
-                            "height": 1080,
-                            "image": "1004_rape/phase6_oral_" + gender.pronoun("f") + ".png"
-                        }, 1004);
+                        rapeCharImage(456, 0, 1084, 1080, "1004_rape/phase6_oral_" + gender.pronoun("f") + ".png");
                     }
                     return false;
                 }
@@ -851,27 +672,11 @@
                 if (cl.c.hairLength > 2)
                     img = "f";
                 if (rape.phases[4].c === 0) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/wolf2/phase2_0_" + img + ".png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/wolf2/phase2_0_" + img + ".png");
                     return { default: false, complete: false };
                 }
                 else if (rape.phases[4].c === 1) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/wolf2/phase2_1_" + img + ".png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/wolf2/phase2_1_" + img + ".png");
                     return { default: false, complete: false };
                 }
                 return { default: false, complete: true };
@@ -879,25 +684,9 @@
             phase5: function () {
 
                 if (rape.phases[5].c === 0) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/wolf2/phase5_u.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/wolf2/phase5_u.png");
                     zcl.double(370, 600, .5, "open", false)
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/wolf2/phase5_t.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/wolf2/phase5_t.png");
                     return false;
                 }
                 return true;
@@ -908,28 +697,12 @@
                     levels.oral(4, "m", "!wolf", true, "dog");
                     zcl.double(250, 700, 1, "", false);
 
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/wolf2/phase6_0.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/wolf2/phase6_0.png");
                     return { c: false, s: "thinking", m: "GAK! dire wolf cum is so bitter...." }
                 }
                 else if (rape.phases[6].c === 1) {
                     zcl.double(-100, -200, 1, "", false);
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/wolf2/phase6_1.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/wolf2/phase6_1.png");
                     return { c: false, s: "thinking", m: "But their knots are so thick! Damn it's so good! " }
                 }
                 return { c: true, s: null, m: null };
@@ -1053,27 +826,11 @@
                 if (rape.phases[5].c === 0) {
                     if (rape.rapeType === "oral") {
                         zcl.double(370, 600, .5, "open", false);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/wolf2/single_phase5_oral_" + rape.modifier + ".png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/wolf2/single_phase5_oral_" + rape.modifier + ".png");
                     }
                     else {
                         zcl.assup(550, 300, .8, true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/wolf2/single_phase5_anal_" + rape.modifier + ".png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/wolf2/single_phase5_anal_" + rape.modifier + ".png");
                     }
 
                     return false;
@@ -1085,30 +842,14 @@
                     if (rape.rapeType === "oral") {
                         levels.oral(4, "m", "!wolf", true, "dog");
                         zcl.double(250, 700, 1, "", false);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/wolf2/single_phase6_oral_" + rape.modifier + ".png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/wolf2/single_phase6_oral_" + rape.modifier + ".png");
                         return { c: false, s: "thinking", m: "OOooo that cum is so thick and bitter. I'm such a lowly fuck hole... " }
 
                     }
                     else {
                         levels.anal(5, false, "m", true, "!wolf", "dog");
                         zcl.double(-100, -200, 1, "", false);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/wolf2/phase6_1.png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/wolf2/phase6_1.png");
                         return { c: false, s: "me", m: "I just got fucked and used like a cum sock by a dire wolf. " }
                     }
                 }
@@ -1143,15 +884,7 @@
             phase1: function () { return { default: true, complete: null }; },
             phase2: function () { return { default: true, complete: null }; },
             phase3: function () {
-                nav.button({
-                    "type": "img",
-                    "name": "r1004bg",
-                    "left": 496,
-                    "top": 0,
-                    "width": 875,
-                    "height": 1080,
-                    "image": "1004_rape/cult/phase_3_" + rape.modifier + ".png"
-                }, 1004);
+                rapeCharImage(496, 0, 875, 1080, "1004_rape/cult/phase_3_" + rape.modifier + ".png");
                 zcl.displayMain(400, 500, .3, "clothes", true);
                 return { complete: true, s: "cult", message: "In the name of Azrael, you will empty my balls!" };
             },
@@ -1162,15 +895,7 @@
                 if (rape.phases[5].c === 0) {
                     if (rape.rapeType === "anal") {
                         zcl.assup(650, 500, .7, "");
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 628,
-                            "top": 332,
-                            "width": 991,
-                            "height": 736,
-                            "image": "1004_rape/cult/phase5_anal_" + rape.modifier + ".png"
-                        }, 1004);
+                        rapeCharImage(628, 332, 991, 736, "1004_rape/cult/phase5_anal_" + rape.modifier + ".png");
                         nav.button({
                             "type": "img",
                             "name": "r1004bg",
@@ -1182,25 +907,9 @@
                         }, 1004);
                     }
                     else {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 535,
-                            "top": 0,
-                            "width": 648,
-                            "height": 1080,
-                            "image": "1004_rape/cult/phase5_oral_0_b_0.png"
-                        }, 1004);
+                        rapeCharImage(535, 0, 648, 1080, "1004_rape/cult/phase5_oral_0_b_0.png");
                         zcl.bj(0, 200, .7, "open", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 535,
-                            "top": 0,
-                            "width": 648,
-                            "height": 1080,
-                            "image": "1004_rape/cult/phase5_oral_0_f_" + rape.modifier + ".png"
-                        }, 1004);
+                        rapeCharImage(535, 0, 648, 1080, "1004_rape/cult/phase5_oral_0_f_" + rape.modifier + ".png");
                     }
                     return false;
                 }
@@ -1210,15 +919,7 @@
                 if (rape.phases[6].c === 0) {
                     if (rape.rapeType === "anal") {
                         zcl.assup(650, 500, .7, "");
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 628,
-                            "top": 332,
-                            "width": 991,
-                            "height": 736,
-                            "image": "1004_rape/cult/phase6_anal_" + rape.modifier + ".png"
-                        }, 1004);
+                        rapeCharImage(628, 332, 991, 736, "1004_rape/cult/phase6_anal_" + rape.modifier + ".png");
                         if(rape.modifier === 2)
                             levels.anal(4, false, "m", true, "cult");
                         else
@@ -1271,15 +972,7 @@
             phase1: function () { return { default: true, complete: null }; },
             phase2: function () { return { default: true, complete: null }; },
             phase3: function () {
-                nav.button({
-                    "type": "img",
-                    "name": "r1004bg",
-                    "left": 496,
-                    "top": 0,
-                    "width": 875,
-                    "height": 1080,
-                    "image": "1004_rape/cult/phase_3_" + rape.modifier + ".png"
-                }, 1004);
+                rapeCharImage(496, 0, 875, 1080, "1004_rape/cult/phase_3_" + rape.modifier + ".png");
                 zcl.displayMain(400, 500, .3, "clothes", true);
                 return { complete: true, s: "cult", message: "I'm going to enjoy raping a tasty treat like you!" };
             },
@@ -1290,15 +983,7 @@
                 if (rape.phases[5].c === 0) {
                     if (rape.rapeType === "anal") {
                         zcl.assup(650, 500, .7, "");
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 628,
-                            "top": 332,
-                            "width": 991,
-                            "height": 736,
-                            "image": "1004_rape/cult/phase5_anal_" + rape.modifier + ".png"
-                        }, 1004);
+                        rapeCharImage(628, 332, 991, 736, "1004_rape/cult/phase5_anal_" + rape.modifier + ".png");
                         nav.button({
                             "type": "img",
                             "name": "r1004bg",
@@ -1310,25 +995,9 @@
                         }, 1004);
                     }
                     else {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 535,
-                            "top": 0,
-                            "width": 648,
-                            "height": 1080,
-                            "image": "1004_rape/cult/phase5_oral_0_b_0.png"
-                        }, 1004);
+                        rapeCharImage(535, 0, 648, 1080, "1004_rape/cult/phase5_oral_0_b_0.png");
                         zcl.bj(0, 200, .7, "open", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 535,
-                            "top": 0,
-                            "width": 648,
-                            "height": 1080,
-                            "image": "1004_rape/cult/phase5_oral_0_f_" + rape.modifier + ".png"
-                        }, 1004);
+                        rapeCharImage(535, 0, 648, 1080, "1004_rape/cult/phase5_oral_0_f_" + rape.modifier + ".png");
                     }
                     return false;
                 }
@@ -1338,15 +1007,7 @@
                 if (rape.phases[6].c === 0) {
                     if (rape.rapeType === "anal") {
                         zcl.assup(650, 500, .7, "");
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 628,
-                            "top": 332,
-                            "width": 991,
-                            "height": 736,
-                            "image": "1004_rape/cult/phase6_anal_" + rape.modifier + ".png"
-                        }, 1004);
+                        rapeCharImage(628, 332, 991, 736, "1004_rape/cult/phase6_anal_" + rape.modifier + ".png");
                         if (rape.modifier === 2)
                             levels.anal(4, false, "m", true, "cult");
                         else
@@ -1399,15 +1060,7 @@
             phase1: function () { return { default: true, complete: null }; },
             phase2: function () { return { default: true, complete: null }; },
             phase3: function () {
-                nav.button({
-                    "type": "img",
-                    "name": "r1004bg",
-                    "left": 496,
-                    "top": 0,
-                    "width": 875,
-                    "height": 1080,
-                    "image": "1004_rape/cult/phase_3_" + rape.modifier + ".png"
-                }, 1004);
+                rapeCharImage(496, 0, 875, 1080, "1004_rape/cult/phase_3_" + rape.modifier + ".png");
                 zcl.displayMain(400, 500, .3, "clothes", true);
                 return { complete: true, s: "cult", message: "I love tearing " + gender.pronoun("faggot") + " holes open!" };
             },
@@ -1418,15 +1071,7 @@
                 if (rape.phases[5].c === 0) {
                     if (rape.rapeType === "anal") {
                         zcl.assup(650, 500, .7, "");
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 628,
-                            "top": 332,
-                            "width": 991,
-                            "height": 736,
-                            "image": "1004_rape/cult/phase5_anal_" + rape.modifier + ".png"
-                        }, 1004);
+                        rapeCharImage(628, 332, 991, 736, "1004_rape/cult/phase5_anal_" + rape.modifier + ".png");
                         nav.button({
                             "type": "img",
                             "name": "r1004bg",
@@ -1438,25 +1083,9 @@
                         }, 1004);
                     }
                     else {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 535,
-                            "top": 0,
-                            "width": 648,
-                            "height": 1080,
-                            "image": "1004_rape/cult/phase5_oral_0_b_0.png"
-                        }, 1004);
+                        rapeCharImage(535, 0, 648, 1080, "1004_rape/cult/phase5_oral_0_b_0.png");
                         zcl.bj(0, 200, .7, "open", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 535,
-                            "top": 0,
-                            "width": 648,
-                            "height": 1080,
-                            "image": "1004_rape/cult/phase5_oral_0_f_" + rape.modifier + ".png"
-                        }, 1004);
+                        rapeCharImage(535, 0, 648, 1080, "1004_rape/cult/phase5_oral_0_f_" + rape.modifier + ".png");
                     }
                     return false;
                 }
@@ -1466,15 +1095,7 @@
                 if (rape.phases[6].c === 0) {
                     if (rape.rapeType === "anal") {
                         zcl.assup(650, 500, .7, "");
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 628,
-                            "top": 332,
-                            "width": 991,
-                            "height": 736,
-                            "image": "1004_rape/cult/phase6_anal_" + rape.modifier + ".png"
-                        }, 1004);
+                        rapeCharImage(628, 332, 991, 736, "1004_rape/cult/phase6_anal_" + rape.modifier + ".png");
                         if (rape.modifier === 2)
                             levels.anal(4, false, "m", true, "cult");
                         else
@@ -1526,38 +1147,14 @@
             phase2: function () { return { default: true, complete: null }; },
             phase3: function () {
                 if (rape.phases[3].c === 0) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 681,
-                        "top": 21,
-                        "width": 583,
-                        "height": 1059,
-                        "image": "1004_rape/futa1/phase3_0.png"
-                    }, 1004);
+                    rapeCharImage(681, 21, 583, 1059, "1004_rape/futa1/phase3_0.png");
                     return { complete: false, s: "!futa1", message: "My my my. What do we have here? " };
                 }
                 else if (rape.phases[3].c === 1) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 681,
-                        "top": 21,
-                        "width": 583,
-                        "height": 1059,
-                        "image": "1004_rape/futa1/phase3_1.png"
-                    }, 1004);
+                    rapeCharImage(681, 21, 583, 1059, "1004_rape/futa1/phase3_1.png");
                     return { complete: false, s: "!futa1", message: "Oh no! You made my cock fall out!" };
                 }
-                nav.button({
-                    "type": "img",
-                    "name": "r1004bg",
-                    "left": 681,
-                    "top": 21,
-                    "width": 583,
-                    "height": 1059,
-                    "image": "1004_rape/futa1/phase3_2.png"
-                }, 1004);
+                rapeCharImage(681, 21, 583, 1059, "1004_rape/futa1/phase3_2.png");
                 return { complete: true, s: "!futa1", message: "I guess you'll have to milk my cock till I cum. " };
             },
             phase4: function () {
@@ -1566,25 +1163,9 @@
             phase5: function () {
                 if (rape.phases[5].c === 0) {
                     if (rape.rapeType === "anal") {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 619,
-                            "top": 440,
-                            "width": 985,
-                            "height": 594,
-                            "image": "1004_rape/futa1/phase5_anal_b.png"
-                        }, 1004);
+                        rapeCharImage(619, 440, 985, 594, "1004_rape/futa1/phase5_anal_b.png");
                         zcl.assup(650, 500, .7, "");
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 619,
-                            "top": 440,
-                            "width": 985,
-                            "height": 594,
-                            "image": "1004_rape/futa1/phase5_anal_f.png"
-                        }, 1004);
+                        rapeCharImage(619, 440, 985, 594, "1004_rape/futa1/phase5_anal_f.png");
                         nav.button({
                             "type": "img",
                             "name": "r1004bg",
@@ -1597,15 +1178,7 @@
                     }
                     else {
                         zcl.bj(250, 400, .6, "open", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 544,
-                            "top": 0,
-                            "width": 699,
-                            "height": 1080,
-                            "image": "1004_rape/futa1/phase6_oral.png"
-                        }, 1004);
+                        rapeCharImage(544, 0, 699, 1080, "1004_rape/futa1/phase6_oral.png");
                     }
                     return false;
                 }
@@ -1614,39 +1187,15 @@
             phase6: function () {
                 if (rape.phases[6].c === 0) {
                     if (rape.rapeType === "anal") {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 619,
-                            "top": 440,
-                            "width": 985,
-                            "height": 594,
-                            "image": "1004_rape/futa1/phase5_anal_b.png"
-                        }, 1004);
+                        rapeCharImage(619, 440, 985, 594, "1004_rape/futa1/phase5_anal_b.png");
                         zcl.assup(650, 500, .7, "");
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 619,
-                            "top": 440,
-                            "width": 985,
-                            "height": 594,
-                            "image": "1004_rape/futa1/phase6_anal_f.png"
-                        }, 1004);
+                        rapeCharImage(619, 440, 985, 594, "1004_rape/futa1/phase6_anal_f.png");
                         levels.anal(5, false, "n", true, "!futa1");
                         return { c: false, s: rape.char.name, m: "Oh fuck! I'm cummin'!!!!!" };
                     }
                     else {
                         zcl.bj(0, 200, 1, "w", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 522,
-                            "top": 0,
-                            "width": 1171,
-                            "height": 1080,
-                            "image": "1004_rape/futa1/phase7_oral.png"
-                        }, 1004);
+                        rapeCharImage(522, 0, 1171, 1080, "1004_rape/futa1/phase7_oral.png");
                         levels.oral(4, "n", "!futa1", true);
                         return { c: false, s: rape.char.name, m: "Oh yeah! Feels so good baby!" };
                     }
@@ -1680,26 +1229,10 @@
             phase2: function () { return { default: true, complete: null }; },
             phase3: function () {
                 if (!gender.canUseCock()) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/girl2/phase3_small.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/girl2/phase3_small.png");
                     return { complete: true, s: "!girl2", message: "I was going to try to ride that cock, but you don't have one!" };
                 }
-                nav.button({
-                    "type": "img",
-                    "name": "r1004bg",
-                    "left": 744,
-                    "top": 86,
-                    "width": 465,
-                    "height": 994,
-                    "image": "1004_rape/girl2/phase3.png"
-                }, 1004);
+                rapeCharImage(744, 86, 465, 994, "1004_rape/girl2/phase3.png");
                 return { complete: true, s: "!girl2", message: "Wow! I would hate to have a cock like that go to waste! I need your cum inside me now!" };
             },
             phase4: function () {
@@ -1709,37 +1242,13 @@
                 
                 if (rape.phases[5].c === 0) {
                     if (rape.rapeType === "cock") {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 486,
-                            "top": 86,
-                            "width": 954,
-                            "height": 963,
-                            "image": "1004_rape/girl2/phase5_b.png"
-                        }, 1004);
+                        rapeCharImage(486, 86, 954, 963, "1004_rape/girl2/phase5_b.png");
                         zcl.amazon(350, 500, .6, "", false);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 486,
-                            "top": 86,
-                            "width": 954,
-                            "height": 963,
-                            "image": "1004_rape/girl2/phase5_f.png"
-                        }, 1004);
+                        rapeCharImage(486, 86, 954, 963, "1004_rape/girl2/phase5_f.png");
                     }
                     else {
                         zcl.bj(200, 200, .8, "open", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 411,
-                            "top": 0,
-                            "width": 1067,
-                            "height": 1080,
-                            "image": "1004_rape/girl2/phase5_oral.png"
-                        }, 1004);
+                        rapeCharImage(411, 0, 1067, 1080, "1004_rape/girl2/phase5_oral.png");
                     }
                     return false;
                 }
@@ -1748,39 +1257,15 @@
             phase6: function () {
                 if (rape.phases[6].c === 0) {
                     if (rape.rapeType === "cock") {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 486,
-                            "top": 86,
-                            "width": 954,
-                            "height": 963,
-                            "image": "1004_rape/girl2/phase6_b.png"
-                        }, 1004);
+                        rapeCharImage(486, 86, 954, 963, "1004_rape/girl2/phase6_b.png");
                         zcl.amazon(350, 500, .6, "", false);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 486,
-                            "top": 86,
-                            "width": 954,
-                            "height": 963,
-                            "image": "1004_rape/girl2/phase6_f.png"
-                        }, 1004);
+                        rapeCharImage(486, 86, 954, 963, "1004_rape/girl2/phase6_f.png");
                         levels.fuckpussy("!girl2");
                         return { c: false, s: rape.char.name, m: "YES YES yes yes yes! Oh fuck! I'm cummin'! I love your dick! Fuck that's good!" };
                     }
                     else {
                         zcl.bj(200, 200, .8, "open", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 549,
-                            "top": 0,
-                            "width": 1064,
-                            "height": 1080,
-                            "image": "1004_rape/girl2/phase6_oral.png"
-                        }, 1004);
+                        rapeCharImage(549, 0, 1064, 1080, "1004_rape/girl2/phase6_oral.png");
                         return { c: false, s: rape.char.name, m: "Oh my god! I'm squirting all over your face it was so good!" };
                     }
                 }
@@ -1813,52 +1298,20 @@
             phase2: function () { return { default: true, complete: null }; },
             phase3: function () {
                 if (!gender.canUseCock()) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/girl3/introhaha.png"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/girl3/introhaha.png");
                     return { complete: true, s: "!girl3", message: "Look at the tiny dick " + gender.pronoun("faggot") + "! " };
                 }
-                nav.button({
-                    "type": "img",
-                    "name": "r1004bg",
-                    "left": 430,
-                    "top": 0,
-                    "width": 1148,
-                    "height": 1080,
-                    "image": "1004_rape/girl3/intro.png"
-                }, 1004);
+                rapeCharImage(430, 0, 1148, 1080, "1004_rape/girl3/intro.png");
                 return { complete: true, s: "!girl3", message: "Our pussies are itching for cock!" };
 
             },
             phase4: function () {
                 if (rape.rapeType === "cock") {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 920,
-                        "height": 1080,
-                        "image": "1004_rape/girl3/phase4_dick.png"
-                    }, 1004);
+                    rapeCharImage(0, 0, 920, 1080, "1004_rape/girl3/phase4_dick.png");
                 }
                 else {
                     if (rape.phases[4].c === 0) {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/girl3/phase4_anal.png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/girl3/phase4_anal.png");
                         return { default: false, complete: false };
                     }
                     else
@@ -1894,15 +1347,7 @@
                     }
                     else {
                         zcl.bj(200, 200, .8, "open", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/girl3/phase5_dick.png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/girl3/phase5_dick.png");
                         nav.button({
                             "type": "img",
                             "name": "r1004bg",
@@ -1920,15 +1365,7 @@
             phase6: function () {
                 if (rape.phases[6].c === 0) {
                     if (rape.rapeType === "cock") {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/girl3/phase6_dick.png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/girl3/phase6_dick.png");
                         levels.fuckpussy("!girl3");
                         levels.fuckpussy("!girl3");
                         levels.fuckass("!girl3", "f");
@@ -1936,15 +1373,7 @@
                         return { c: false, s: rape.char.name, m: "Thanks mister! Never lose that cock, it's the best dick we've ever had!" };
                     }
                     else {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/girl3/phase6_anal.png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/girl3/phase6_anal.png");
                         zcl.asshole(261, 200, 1.4, "", false);
                         levels.gotfisted("f", "!girl3");
                         return { c: false, s: rape.char.name, m: "We love fisting loser sissy boys like you!" };
@@ -1979,15 +1408,7 @@
             phase2: function () { return { default: true, complete: null }; },
             phase3: function () {
                 if (rape.phases[3].c === 0) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 523,
-                        "top": 0,
-                        "width": 1003,
-                        "height": 1080,
-                        "image": "1004_rape/rapeman12/phase3.webp"
-                    }, 1004);
+                    rapeCharImage(523, 0, 1003, 1080, "1004_rape/rapeman12/phase3.webp");
                     nav.button({
                         "type": "img",
                         "name": "r1004bg",
@@ -1999,15 +1420,7 @@
                     }, 1004);
                     return { complete: false, message: "My favorite snack, a weak little white boy aching for a big black dick!" };
                 }
-                nav.button({
-                    "type": "img",
-                    "name": "r1004bg",
-                    "left": 0,
-                    "top": 0,
-                    "width": 1920,
-                    "height": 1080,
-                    "image": "1004_rape/rapeman12/phase3a.webp"
-                }, 1004);
+                rapeCharFullscreen("1004_rape/rapeman12/phase3a.webp");
                 nav.button({
                     "type": "img",
                     "name": "r1004bg",
@@ -2026,15 +1439,7 @@
                 if (rape.phases[5].c === 0) {
                     if (rape.rapeType === "anal") {
                         zcl.facedown(350, 300, .7, "", false);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/rapeman12/phase5.webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/rapeman12/phase5.webp");
                         nav.button({
                             "type": "img",
                             "name": "r1004bg",
@@ -2064,15 +1469,7 @@
             phase6: function () {
                 if (rape.phases[6].c === 0) {
                     zcl.facedown(350, 300, .7, "", false);
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/rapeman12/phase6.webp"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/rapeman12/phase6.webp");
                     levels.anal(4, false, "m", true, "!rape12");
                     return { c: false, s: rape.char.name, m: "I love breeding sissy " + gender.pronoun("girl") + "s like you. It's what you are here for. " };
                 }
@@ -2104,15 +1501,7 @@
             phase1: function () { return { default: true, complete: null }; },
             phase2: function () { return { default: true, complete: null }; },
             phase3: function () {
-                nav.button({
-                    "type": "img",
-                    "name": "r1004bg",
-                    "left": 0,
-                    "top": 0,
-                    "width": 1920,
-                    "height": 1080,
-                    "image": "1004_rape/duo13/phase3_" + gender.pronoun("f") + ".webp"
-                }, 1004);
+                rapeCharFullscreen("1004_rape/duo13/phase3_" + gender.pronoun("f") + ".webp");
                 return { complete: true, s: "!duo13a", message: "Looks like we got a bitch that wants to get stuffed with cock. Air tight!" };
             },
             phase4: function () {
@@ -2121,43 +1510,19 @@
             phase5: function () {
                 if (rape.phases[5].c === 0) {
                     zcl.double(0, 800, 1.4, "", false);
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/duo13/phase5_0.webp"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/duo13/phase5_0.webp");
                     return false;
                 }
                 else if (rape.phases[5].c === 1) {
                     zcl.kill();
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/duo13/phase5_1.webp"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/duo13/phase5_1.webp");
                     return false;
 
                 }
                 else if (rape.phases[5].c === 2) {
                     zcl.double(400, 550, .5, "open", false);
                     nav.killbutton("r1004bg");
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/duo13/phase5_2.webp"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/duo13/phase5_2.webp");
                     return false;
                 }
                 if (rape.phases[6].c % 2 === 0)
@@ -2169,41 +1534,17 @@
             phase6: function () {
                 if (rape.phases[6].c === 0) {
                     zcl.double(400, 550, .5, "open", false);
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/duo13/phase6_0.webp"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/duo13/phase6_0.webp");
                     return { c: false, s: "thinking", m: "WHAT!! No! That dick's been up my ass!" };
                 }
                 else if (rape.phases[6].c === 1) {
                     zcl.kill();
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/duo13/phase6_1.webp"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/duo13/phase6_1.webp");
                     return { c: false, s: "thinking", m: "Blech! Tastes like sweaty dick, cum, and ass! Why whould they treat me like this?" };
                 }
                 else if (rape.phases[6].c === 2) {
                     zcl.kill();
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/duo13/phase6_2.webp"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/duo13/phase6_2.webp");
                     return { c: false, s: "thinking", m: "And his loser friend just came down my bussy! I'm just a cum dumpster for strange men. " };
                 }
                
@@ -2218,7 +1559,7 @@
             name: "futa1",
             displayName: "",
             location: ["sewer"],
-            img: "14_futa/icon.png",
+            img: "1004_rape/14_futa/icon.png",
             openingLine: ["You will pay for ", "destroying my home!!"],
             openingImg: null,
             fight: g.rand(8, 15),
@@ -2230,32 +1571,16 @@
             gender: "m",
             t: "futa",
             cocksize: 5,
-            kick: "14_futa/kick.webp",
+            kick: "1004_rape/14_futa/kick.webp",
             phase0: function () { return { default: true, complete: null }; },
             phase1: function () { return { default: true, complete: null }; },
             phase2: function () { return { default: true, complete: null }; },
             phase3: function () {
                 if (rape.phases[3].c === 0) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/14_futa/phase3_0.webp"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/14_futa/phase3_0.webp");
                     return { complete: false, s: "futa1", message: "My panties are like a clown car " };
                 }
-                nav.button({
-                    "type": "img",
-                    "name": "r1004bg",
-                    "left": 0,
-                    "top": 0,
-                    "width": 1920,
-                    "height": 1080,
-                    "image": "1004_rape/14_futa/phase3_1.webp"
-                }, 1004);
+                rapeCharFullscreen("1004_rape/14_futa/phase3_1.webp");
                 return { complete: true, s: "futa1", message: "There's so much more than you expect!" };
             },
             phase4: function () {
@@ -2264,26 +1589,10 @@
             phase5: function () {
                 if (rape.phases[5].c === 0) {
                     if (rape.rapeType === "anal") {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/14_futa/phase5_anal_" + gender.pronoun("f") + ".webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/14_futa/phase5_anal_" + gender.pronoun("f") + ".webp");
                     }
                     else {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/14_futa/phase5_bj_" + gender.pronoun("f") + ".webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/14_futa/phase5_bj_" + gender.pronoun("f") + ".webp");
                     }
                     return false;
                 }
@@ -2292,38 +1601,14 @@
             phase6: function () {
                 if (rape.phases[6].c === 0) {
                     if (rape.rapeType === "anal") {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/14_futa/phase6.webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/14_futa/phase6.webp");
                         zcl.bellydown(300, 500, .6, "", true);
                         levels.anal(4, false, "n", true, "futa1");
                         return { c: false, s: rape.char.name, m: "Love seeing my cum leak out of a slut!" };
                     }
                     else {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/14_futa/phase5_bj_" + gender.pronoun("f") + ".webp"
-                        }, 1004);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/14_futa/phase6gulp.webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/14_futa/phase5_bj_" + gender.pronoun("f") + ".webp");
+                        rapeCharFullscreen("1004_rape/14_futa/phase6gulp.webp");
                         levels.oral(4, "n", "futa1", true);
                         return { c: false, s: rape.char.name, m: "Oh yeah! Feels so good baby!" };
                     }
@@ -2339,7 +1624,7 @@
             name: "futa2",
             displayName: "",
             location: ["sewer"],
-            img: "15_futa/icon.png",
+            img: "1004_rape/15_futa/icon.png",
             openingLine: ["You will pay for ", "destroying my home!!"],
             openingImg: null,
             fight: g.rand(8, 15),
@@ -2351,32 +1636,16 @@
             gender: "m",
             t: "futa",
             cocksize: 5,
-            kick: "15_futa/kick.webp",
+            kick: "1004_rape/15_futa/kick.webp",
             phase0: function () { return { default: true, complete: null }; },
             phase1: function () { return { default: true, complete: null }; },
             phase2: function () { return { default: true, complete: null }; },
             phase3: function () {
                 if (rape.phases[3].c === 0) {
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/15_futa/phase3_0.webp"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/15_futa/phase3_0.webp");
                     return { complete: false, s: "futa2", message: "I hope your holes are deep" };
                 }
-                nav.button({
-                    "type": "img",
-                    "name": "r1004bg",
-                    "left": 0,
-                    "top": 0,
-                    "width": 1920,
-                    "height": 1080,
-                    "image": "1004_rape/15_futa/phase3_1.webp"
-                }, 1004);
+                rapeCharFullscreen("1004_rape/15_futa/phase3_1.webp");
                 return { complete: true, s: "futa2", message: "Becuase this cock is going all the way down!" };
             },
             phase4: function () {
@@ -2385,26 +1654,10 @@
             phase5: function () {
                 if (rape.phases[5].c === 0) {
                     if (rape.rapeType === "anal") {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/15_futa/phase5_anal_" + gender.pronoun("f") + ".webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/15_futa/phase5_anal_" + gender.pronoun("f") + ".webp");
                     }
                     else {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/15_futa/phase5_bj_" + gender.pronoun("f") + ".webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/15_futa/phase5_bj_" + gender.pronoun("f") + ".webp");
                     }
                     return false;
                 }
@@ -2413,37 +1666,13 @@
             phase6: function () {
                 if (rape.phases[6].c === 0) {
                     if (rape.rapeType === "anal") {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/15_futa/phase6_anal.webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/15_futa/phase6_anal.webp");
                         levels.anal(4, false, "n", true, "futa1");
                         return { c: false, s: rape.char.name, m: "CLOWN CUM IS BEST CUM!!!" };
                     }
                     else {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/15_futa/phase5_bj_" + gender.pronoun("f") + ".webp"
-                        }, 1004);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/15_futa/phase6gulp.webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/15_futa/phase5_bj_" + gender.pronoun("f") + ".webp");
+                        rapeCharFullscreen("1004_rape/15_futa/phase6gulp.webp");
                         levels.oral(4, "n", "futa1", true);
                         return { c: false, s: rape.char.name, m: "Oh yeah! Feels so good baby!" };
                     }
@@ -2475,30 +1704,14 @@
             phase1: function () { return { default: true, complete: true }; },
             phase2: function () { return { default: true, complete: null }; },
             phase3: function () {
-                nav.button({
-                    "type": "img",
-                    "name": "r1004bg",
-                    "left": 0,
-                    "top": 0,
-                    "width": 1920,
-                    "height": 1080,
-                    "image": "1004_rape/16_clown/phase3.webp"
-                }, 1004);
+                rapeCharFullscreen("1004_rape/16_clown/phase3.webp");
                 zcl.embarrass(0, 900, .9, "back", false);
                 return { complete: true, s: "clownqueen", message: "I hope you're hungry 'cuase you're going to eat a big plate of clown pussy!" };
             },
             phase4: function () {
                 if (rape.rapeType === "cunnilugus") {
                     if (rape.phases[4].c === 0) {
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/16_clown/phase4.webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/16_clown/phase4.webp");
                         return { default: false, complete: false };
                     }
                         
@@ -2509,25 +1722,9 @@
                 if (rape.rapeType === "anal") {
                     if (rape.phases[5].c === 0 || rape.phases[5].c === 2) {
                         nav.killbutton("r1004bg");
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/16_clown/phase5_anal0.webp"
-                        }, 1);
+                        rapeCharFullscreen("1004_rape/16_clown/phase5_anal0.webp", 1);
                         zcl.facedown(670, 700, .35, "", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/16_clown/phase5_anal1.webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/16_clown/phase5_anal1.webp");
                         if (rape.phases[5].c === 2)
                             return true;
                         return false;
@@ -2535,39 +1732,15 @@
                     else if (rape.phases[5].c === 1) {
                         nav.killbutton("r1004bg");
                         levels.piss(false, true, false, "f", "clownqueen");
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/16_clown/phase5_anal0_p.webp"
-                        }, 1);
+                        rapeCharFullscreen("1004_rape/16_clown/phase5_anal0_p.webp", 1);
                         zcl.facedown(670, 700, .35, "", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/16_clown/phase5_anal1.webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/16_clown/phase5_anal1.webp");
                         return false;
                     }
                 }
                 else {
                     zcl.bj(100, 190, 1, "open", true);
-                    nav.button({
-                        "type": "img",
-                        "name": "r1004bg",
-                        "left": 0,
-                        "top": 0,
-                        "width": 1920,
-                        "height": 1080,
-                        "image": "1004_rape/16_clown/phase5_oral.webp"
-                    }, 1004);
+                    rapeCharFullscreen("1004_rape/16_clown/phase5_oral.webp");
                     return false;
                 }
                 return true;
@@ -2576,29 +1749,13 @@
                 if (rape.phases[6].c === 0) {
                     if (rape.rapeType === "anal") {
                         zcl.kill();
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/16_clown/phase6_anal.webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/16_clown/phase6_anal.webp");
                         return { c: false, s: rape.char.name, m: "Don't we just make the sluttiest pair of holes ever! *HONK*" }
 
                     }
                     else {
                         zcl.bj(100, 190, 1, "open", true);
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/16_clown/phase6_oral.webp"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/16_clown/phase6_oral.webp");
                         return { c: false, s: rape.char.name, m: "*Honk* You made my clussy squirt! " }
                     }
                 }
@@ -2608,27 +1765,11 @@
                 if (rape.phases[7].c === 0) {
                     if (rape.rapeType === "anal") {
                         zcl.kill();
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 0,
-                            "top": 0,
-                            "width": 1920,
-                            "height": 1080,
-                            "image": "1004_rape/missx/phase6_" + gender.pronoun("f") + ".png"
-                        }, 1004);
+                        rapeCharFullscreen("1004_rape/missx/phase6_" + gender.pronoun("f") + ".png");
                     }
                     else {
                         zcl.kill();
-                        nav.button({
-                            "type": "img",
-                            "name": "r1004bg",
-                            "left": 456,
-                            "top": 0,
-                            "width": 1084,
-                            "height": 1080,
-                            "image": "1004_rape/phase6_cun_" + gender.pronoun("f") + ".png"
-                        }, 1004);
+                        rapeCharImage(456, 0, 1084, 1080, "1004_rape/phase6_cun_" + gender.pronoun("f") + ".png");
                     }
                     return false;
                 }

--- a/scripts/revents.js
+++ b/scripts/revents.js
@@ -1,6 +1,40 @@
 ﻿var revents = {};
 var room1010 = {};
 
+revents.bookPageName = function (direction, page) {
+    return "1010js_book" + direction + page;
+};
+
+revents.bookPageNumber = function (name) {
+    if (name.startsWith("1010js_booknext"))
+        return parseInt(name.replace("1010js_booknext", ""));
+    if (name.startsWith("1010js_bookprev"))
+        return parseInt(name.replace("1010js_bookprev", ""));
+    return null;
+};
+
+revents.drawBookNavButton = function (direction, page) {
+    var isNext = direction === "next";
+    nav.button({
+        "type": "btn",
+        "name": revents.bookPageName(direction, page),
+        "left": isNext ? 1621 : 108,
+        "top": isNext ? 854 : 860,
+        "width": isNext ? 195 : 188,
+        "height": isNext ? 154 : 153,
+        "image": "1010_rand/cum_" + direction + ".png"
+    }, 1010);
+};
+
+revents.refreshCultBookNav = function (currentpage) {
+    nav.killbuttonStartsWith("1010js_booknext");
+    nav.killbuttonStartsWith("1010js_bookprev");
+    if (currentpage < 7)
+        revents.drawBookNavButton("next", currentpage + 1);
+    if (currentpage > 0)
+        revents.drawBookNavButton("prev", currentpage - 1);
+};
+
 revents.cultbook = function (roomNum, btnclickName) {
     nav.button({
         "type": "img",
@@ -13,7 +47,7 @@ revents.cultbook = function (roomNum, btnclickName) {
     }, 1010);
     nav.button({
         "type": "btn",
-        "name": "1010js_booknext1",
+        "name": revents.bookPageName("next", 1),
         "left": 1621,
         "top": 854,
         "width": 195,
@@ -36,37 +70,10 @@ room1010.btnclick = function (name) {
         nav.killbutton("magazineCloseInventory");
     }
     if (name.startsWith("1010js_booknext") || name.startsWith("1010js_bookprev")) {
-        let currentpage;
-        if (name.startsWith("1010js_booknext")) {
-            currentpage = parseInt(name.replace("1010js_booknext", ""));
-        }
-        else {
-            currentpage = parseInt(name.replace("1010js_bookprev", ""));
-        }
+        let currentpage = revents.bookPageNumber(name);
         nav.modbutton("1010js_book0", "1010_rand/book" + currentpage + ".webp");
-        nav.killbuttonStartsWith("1010js_booknext");
-        nav.killbuttonStartsWith("1010js_bookprev");
-        if (currentpage < 7) {
-            nav.button({
-                "type": "btn",
-                "name": "1010js_booknext" + (currentpage + 1),
-                "left": 1621,
-                "top": 854,
-                "width": 195,
-                "height": 154,
-                "image": "1010_rand/cum_next.png"
-            }, 1010);
-        }
-        if (currentpage > 0) {
-            nav.button({
-                "type": "btn",
-                "name": "1010js_bookprev" + (currentpage - 1),
-                "left": 108,
-                "top": 860,
-                "width": 188,
-                "height": 153,
-                "image": "1010_rand/cum_prev.png"
-            }, 1010);
-        }
+        revents.refreshCultBookNav(currentpage);
     }
 };
+
+invoker.registerRoom(1010, room1010);

--- a/scripts/room/room000.js
+++ b/scripts/room/room000.js
@@ -12,18 +12,21 @@ room0.main = function () {
     $('#room_footer').hide();
     var tempMap = gv.get("map");
     if (tempMap === 0)
-        room0.btnclick("map_0");
+        invoker.invokeCurrent("btnclick", "map_0");
     else if (tempMap === 2)
-        room0.btnclick("map_2");
+        invoker.invokeCurrent("btnclick", "map_2");
     else if (tempMap === 3)
-        room0.btnclick("map_3");
+        invoker.invokeCurrent("btnclick", "map_3");
     else
-        room0.btnclick("map_1");
+        invoker.invokeCurrent("btnclick", "map_1");
     if (!gv.get("panties") && cl.getEntry("panties", cl.c.panties).sex === "f") {
         gv.set("panties", true);
         dreams.add("firstTimeInPanties");
     }
-    setTimeout(function () { $('#room_footer').hide(); }, 200);
+    g.roomTimeout2 = setTimeout(function () {
+        g.roomTimeout2 = null;
+        $('#room_footer').hide();
+    }, 200);
     
 };
 
@@ -41,25 +44,25 @@ room0.btnclick = function (name) {
         nav.bg("map/map0.jpg", "map/map0_night.jpg");
         gv.set("map", 0);
         char.map();
-        room0.btnclick("redrawIcons");
+        invoker.invokeCurrent("btnclick", "redrawIcons");
     }
     else if (name === "map_1") {
         nav.bg("map/map1.jpg", "map/map1_night.jpg");
         gv.set("map", 1);
         char.map();
-        room0.btnclick("redrawIcons");
+        invoker.invokeCurrent("btnclick", "redrawIcons");
     }
     else if (name === "map_2") {
         nav.bg("map/map2.jpg", "map/map2_night.jpg");
         gv.set("map", 2);
         char.map();
-        room0.btnclick("redrawIcons");
+        invoker.invokeCurrent("btnclick", "redrawIcons");
     }
     else if (name === "map_3") {
         nav.bg("map/map3.jpg", "map/map3_night.jpg");
         gv.set("map", 3);
         char.map();
-        room0.btnclick("redrawIcons");
+        invoker.invokeCurrent("btnclick", "redrawIcons");
     }
     else if (name === "redrawIcons") {
         nav.killall();
@@ -67,7 +70,7 @@ room0.btnclick = function (name) {
         var btnList = new Array();
         var tempMap = gv.get("map");
         g.internal = tempMap;
-        room0.chatcatch("walk");
+        invoker.invokeCurrent("chatcatch", "walk");
         let carnival = gv.get("carnival");
         $.each(g.roomMap, function (i, v) {
             if (tempMap === v.map) {
@@ -179,7 +182,8 @@ room0.btnclick = function (name) {
                     "height": 327,
                     "image": "map/money.png"
                 }, 0);
-                setTimeout(function () {
+                g.roomTimeout = setTimeout(function () {
+                    g.roomTimeout = null;
                     char.room(roomnum);
                 }, 4000);
             }
@@ -222,7 +226,8 @@ room0.btnclick = function (name) {
                     }
                 }
                 
-                setTimeout(function () {
+                g.roomTimeout = setTimeout(function () {
+                    g.roomTimeout = null;
                     char.room(roomnum);
                 }, 800);
             }
@@ -273,7 +278,7 @@ room0.chatcatch = function (callback) {
             g.internal = null;
             break;
         case "moveChar":
-            room0.btnclick("moveChar");
+            invoker.invokeCurrent("btnclick", "moveChar");
             break;
         default:
             break;
@@ -343,3 +348,5 @@ room0.chat = function (chatID) {
     ];
     return cArray[chatID];
 };
+
+invoker.registerRoom(0, room0);

--- a/scripts/room/room001.js
+++ b/scripts/room/room001.js
@@ -108,3 +108,5 @@ room1.chat = function (chatID) {
     ];
     return cArray[chatID];
 };
+
+invoker.registerRoom(1, room1);

--- a/scripts/room/room002.js
+++ b/scripts/room/room002.js
@@ -8,7 +8,7 @@ room2.main = function () {
     $('.room-topper').hide();
     nav.killall();
     $('.room-left').hide();
-    room2.chatcatch('init');
+    invoker.invokeCurrent("chatcatch", "init");
 
 };
 
@@ -188,3 +188,5 @@ room2.chat = function(chatID){
     else
         return [];
 };
+
+invoker.registerRoom(2, room2);

--- a/scripts/room/room003.js
+++ b/scripts/room/room003.js
@@ -18,8 +18,8 @@ room3.main = function () {
         'Click Next to play the game. Press "Exit Game" to exit.<br />'  +
         'Happy Fapping!<br />' +
         
-        '<button style="width:49%; margin-right:1%;" class="intro-button" onclick="room3.btnclick(0)">Next</button>' +
-        '<button style="width:49%;" class="intro-button" onclick="room3.btnclick(1)">Exit Game (Underage)</button>' +
+        '<button style="width:49%; margin-right:1%;" class="intro-button" onclick="invoker.invoke(3, \'btnclick\', 0)">Next</button>' +
+        '<button style="width:49%;" class="intro-button" onclick="invoker.invoke(3, \'btnclick\', 1)">Exit Game (Underage)</button>' +
         
         
         '</div>');
@@ -63,3 +63,5 @@ room3.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(3, room3);

--- a/scripts/room/room004.js
+++ b/scripts/room/room004.js
@@ -39,7 +39,7 @@ room4.main = function () {
 room4.btnclick = function (name) {
     switch (name) {
         case "massageFinish":
-            room4.chatcatch("massageFinish");
+            invoker.invokeCurrent("chatcatch", "massageFinish");
             break;
         case "massage1Shirt":
             nav.killbutton("massage1Shirt");
@@ -158,12 +158,12 @@ room4.btnclick = function (name) {
                 charisma.init(g.internal.level + 1 + 7, "charisma5Win", "charisma5Lose", 4);
             }
             else {
-                room4.btnclick("massage5_2");
+                invoker.invokeCurrent("btnclick", "massage5_2");
             }
             break;
         case "charisma6Win":
             sc.modLevel("lola", 100, 7);
-            room4.btnclick("massage5_2");
+            invoker.invokeCurrent("btnclick", "massage5_2");
             break;
         case "massage5_2":
             nav.killall();
@@ -192,10 +192,10 @@ room4.btnclick = function (name) {
             break;
         case "charisma4Win":
             sc.modLevel("lola", 100, 7);
-            room4.btnclick("massage4");
+            invoker.invokeCurrent("btnclick", "massage4");
             break;
         case "charisma5Win":
-            room4.btnclick("massage5_2");
+            invoker.invokeCurrent("btnclick", "massage5_2");
             break;
         case "cancel":
             char.room(13);
@@ -553,3 +553,5 @@ room4.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(4, room4);

--- a/scripts/room/room005.js
+++ b/scripts/room/room005.js
@@ -210,11 +210,11 @@ room5.chatcatch = function (callback) {
             break;
         case "massageFinish0":
             g.internal.level = 0;
-            room5.chatcatch("massageFinish");
+            invoker.invokeCurrent("chatcatch", "massageFinish");
             break;
         case "massageFinishFail":
             sc.completeMission("eva", "massage", false);
-            room5.chatcatch("massageFinish");
+            invoker.invokeCurrent("chatcatch", "massageFinish");
             break;
         case "check50":
             if (gv.get("money") > 49) {
@@ -623,3 +623,5 @@ room5.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(5, room5);

--- a/scripts/room/room006.js
+++ b/scripts/room/room006.js
@@ -2,7 +2,7 @@
 var room6 = {};
 room6.main = function () {
     g.internal = q3.list();
-    room6.chatcatch("drawmain");
+    invoker.invokeCurrent("chatcatch", "drawmain");
 };
 
 //room6.getNameList = function () {
@@ -49,26 +49,26 @@ room6.btnclick = function (name) {
         }
         else if (g.internal.level === 1) {
             g.internal.level = 0;
-            room6.chatcatch("drawmain");
+            invoker.invokeCurrent("chatcatch", "drawmain");
         }
         else if (g.internal.level === 2) {
             g.internal.level = 1;
             nav.killall();
-            room6.chatcatch("drawscreen");
+            invoker.invokeCurrent("chatcatch", "drawscreen");
         }
         else if (g.internal.level === 3) {
             g.internal.level = 1;
             nav.killall();
-            room6.chatcatch("drawinactive");
+            invoker.invokeCurrent("chatcatch", "drawinactive");
         }
     }
     else if (name === "zzzactive") {
         nav.killall();
-        room6.chatcatch("drawscreen");
+        invoker.invokeCurrent("chatcatch", "drawscreen");
     }
     else if (name === "zzzinactive") {
         nav.killall();
-        room6.chatcatch("drawinactive");
+        invoker.invokeCurrent("chatcatch", "drawinactive");
     }
     else if (name === "zzznotes") {
         g.internal.level = 1;
@@ -562,3 +562,5 @@ room6.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(6, room6);

--- a/scripts/room/room007.js
+++ b/scripts/room/room007.js
@@ -501,7 +501,7 @@ room7.chatcatch = function (callback) {
                 "height": 800,
                 "image": "7_mainCharRoomAlt/eva10b3ht.gif"
             }, 7);
-            g.roomTimeout = setTimeout(function () { room7.chatcatch("eva10it"); }, 4000);
+            g.roomTimeout = setTimeout(function () { invoker.invokeCurrent("chatcatch", "eva10it"); }, 4000);
             break;
         case "eva10it":
             nav.killbutton("eva10b3ht");
@@ -587,19 +587,19 @@ room7.chatcatch = function (callback) {
             nav.bg("7_mainCharRoomAlt/bigguy5a.jpg");
             break;
         case "bigguy5b":
-            nav.bg("7_mainCharRoomAlt/bigguy5b.jpg");
+            nav.bg("7_mainCharRoomAlt/New folder/bigguy5b.jpg");
             break;
         case "bigguy5c":
-            nav.bg("7_mainCharRoomAlt/bigguy5c.jpg");
+            nav.bg("7_mainCharRoomAlt/New folder/bigguy5c.jpg");
             break;
         case "bigguy5d":
-            nav.bg("7_mainCharRoomAlt/bigguy5d.jpg");
+            nav.bg("7_mainCharRoomAlt/New folder/bigguy5d.jpg");
             break;
         case "bigguy5e":
-            nav.bg("7_mainCharRoomAlt/bigguy5e.jpg");
+            nav.bg("7_mainCharRoomAlt/New folder/bigguy5e.jpg");
             break;
         case "bigguy5f":
-            nav.bg("7_mainCharRoomAlt/bigguy5f.jpg");
+            nav.bg("7_mainCharRoomAlt/New folder/bigguy5f.jpg");
             break;
         case "bigguy5g":
             nav.bg("7_mainCharRoomAlt/black.jpg");
@@ -607,9 +607,9 @@ room7.chatcatch = function (callback) {
         case "bigguy5h":
             nav.killall();
             if(cl.c.chest < 3)
-                nav.bg("7_mainCharRoomAlt/bigguy5_b.jpg");
+                nav.bg("7_mainCharRoomAlt/New folder/bigguy5_b.jpg");
             else
-                nav.bg("7_mainCharRoomAlt/bigguy5_g.jpg");
+                nav.bg("7_mainCharRoomAlt/New folder/bigguy5_g.jpg");
 
             nav.button({
                 "type": "img",
@@ -618,11 +618,11 @@ room7.chatcatch = function (callback) {
                 "top": 0,
                 "width": 1920,
                 "height": 1080,
-                "image": "7_mainCharRoomAlt/bigguy5h.png"
+                "image": "7_mainCharRoomAlt/New folder/bigguy5h.png"
             }, 7);
             break;
         case "bigguy5i":
-            nav.modbutton("bigguy5h", "7_mainCharRoomAlt/bigguy5i.png", null, null);
+            nav.modbutton("bigguy5h", "7_mainCharRoomAlt/New folder/bigguy5i.png", null, null);
             break;
         case "bigguy5j":
             nav.killbutton("bigguy5h");
@@ -633,7 +633,7 @@ room7.chatcatch = function (callback) {
                 "top": 377,
                 "width": 1808,
                 "height": 280,
-                "image": "7_mainCharRoomAlt/bigguy5j.png"
+                "image": "7_mainCharRoomAlt/New folder/bigguy5j.png"
             }, 7);
             break;
         case "bigguy5k":
@@ -645,7 +645,7 @@ room7.chatcatch = function (callback) {
                 "top": 0,
                 "width": 1920,
                 "height": 1080,
-                "image": "7_mainCharRoomAlt/bigguy5k.png"
+                "image": "7_mainCharRoomAlt/New folder/bigguy5k.png"
             }, 7);
             break;
         case "bigguy5l":
@@ -657,7 +657,7 @@ room7.chatcatch = function (callback) {
                 "top": 288,
                 "width": 1741,
                 "height": 562,
-                "image": "7_mainCharRoomAlt/bigguy5l.png"
+                "image": "7_mainCharRoomAlt/New folder/bigguy5l.png"
             }, 7);
             break;
         case "bigguy5m":
@@ -669,7 +669,7 @@ room7.chatcatch = function (callback) {
                 "top": 317,
                 "width": 1801,
                 "height": 533,
-                "image": "7_mainCharRoomAlt/bigguy5m.png"
+                "image": "7_mainCharRoomAlt/New folder/bigguy5m.png"
             }, 7);
             break;
         case "bigguy5n":
@@ -681,7 +681,7 @@ room7.chatcatch = function (callback) {
                 "top": 317,
                 "width": 1801,
                 "height": 533,
-                "image": "7_mainCharRoomAlt/bigguy5n.png"
+                "image": "7_mainCharRoomAlt/New folder/bigguy5n.png"
             }, 7);
             break;
         case "bigguy5o":
@@ -820,7 +820,7 @@ room7.chatcatch = function (callback) {
             break;
         case "workmonday":
             gv.set("workMonday", true);
-            room7.chatcatch("clearRoom");
+            invoker.invokeCurrent("chatcatch", "clearRoom");
             break;
         case "mondaywork":
             g.pass = 40;
@@ -1520,3 +1520,5 @@ room7.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(7, room7);

--- a/scripts/room/room008.js
+++ b/scripts/room/room008.js
@@ -14,7 +14,7 @@ room8.main = function () {
             "top": 220,
             "width": 120,
             "height": 40,
-            "title": v.title,
+            "title": "Wear " + v.name,
             "image": "8_wardrobe/save_wear.png"
         }, 8);
         nav.button({
@@ -24,7 +24,7 @@ room8.main = function () {
             "top": 220,
             "width": 120,
             "height": 40,
-            "title": v.title,
+            "title": "Save " + v.name,
             "image": "8_wardrobe/save_save.png"
         }, 8);
 
@@ -46,7 +46,7 @@ room8.main = function () {
         chat(1, 8);
     }
 
-    room8.btnclick("checkSleepEnable");
+    invoker.invokeCurrent("btnclick", "checkSleepEnable");
 
     if (g.pass === 52)
         nav.bg("8_wardrobe/52_wardrobe.jpg");
@@ -125,7 +125,7 @@ room8.btnclick = function (name) {
         type = name.replace("main_", "");
         if (type === "nude") {
             cl.nude();
-            room8.btnclick("checkSleepEnable");
+            invoker.invokeCurrent("btnclick", "checkSleepEnable");
         }
         else {
             j = 0;
@@ -234,14 +234,14 @@ room8.btnclick = function (name) {
             case "accessories": cl.c.accessories = clname; break;
             default: "can't find " + clname; break;
         }
-        room8.btnclick("checkSleepEnable");
-        room8.btnclick("main_" + type);
+        invoker.invokeCurrent("btnclick", "checkSleepEnable");
+        invoker.invokeCurrent("btnclick", "main_" + type);
         cl.display();
     }
     else if (name.startsWith("wear_")) {
         var wearOutfit = parseInt(name.replace("wear_", ""));
         cl.wearSavedOutfit(wearOutfit);
-        room8.btnclick("checkSleepEnable");
+        invoker.invokeCurrent("btnclick", "checkSleepEnable");
     }
     else if (name.startsWith("save_")) {
         var entry = parseInt(name.replace("save_", ""));
@@ -575,3 +575,5 @@ room8.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(8, room8);

--- a/scripts/room/room009.js
+++ b/scripts/room/room009.js
@@ -257,8 +257,61 @@ room9.btnclick = function (name) {
             chat(1, 9);
             break;
         case "files":
-
-
+            nav.killall();
+            nav.button({
+                "type": "img",
+                "name": "filesBG",
+                "left": 442,
+                "top": 46,
+                "width": 1425,
+                "height": 737,
+                "image": "9_computer/09_jobBackground.png"
+            }, 9);
+            nav.button({
+                "type": "img",
+                "name": "school",
+                "left": 654,
+                "top": 250,
+                "width": 157,
+                "height": 162,
+                "image": "31_puter/school.png"
+            }, 9);
+            nav.button({
+                "type": "img",
+                "name": "english",
+                "left": 831,
+                "top": 250,
+                "width": 157,
+                "height": 162,
+                "image": "31_puter/english.png"
+            }, 9);
+            nav.button({
+                "type": "img",
+                "name": "history",
+                "left": 1008,
+                "top": 250,
+                "width": 157,
+                "height": 162,
+                "image": "31_puter/history.png"
+            }, 9);
+            nav.button({
+                "type": "img",
+                "name": "math",
+                "left": 1185,
+                "top": 250,
+                "width": 157,
+                "height": 162,
+                "image": "31_puter/math.png"
+            }, 9);
+            nav.button({
+                "type": "btn",
+                "name": "close",
+                "left": 450,
+                "top": 53,
+                "width": 42,
+                "height": 42,
+                "image": "9_computer/09_close.png"
+            }, 9);
             break;
         case "porn":
             nav.killall();
@@ -471,7 +524,7 @@ room9.btnclick = function (name) {
                 nav.bg("9_computer/52_computer.jpg");
             else
                 nav.bg("9_computer/09_computer.jpg");
-            room9.btnclick(g.internal);
+            invoker.invokeCurrent("btnclick", g.internal);
             break;
         case "jackitNo1":
             char.room(9);
@@ -579,14 +632,14 @@ room9.chatcatch = function (callback) {
             char.room(9);
             break;
         case "internet":
-            room9.btnclick("internet");
+            invoker.invokeCurrent("btnclick", "internet");
             break;
         case "jackoff2":
         case "jackoffCaught":
             nav.bg("9_computer/" + callback + ".jpg");
             break;
         case "powerOff":
-            room9.btnclick("powerOff");
+            invoker.invokeCurrent("btnclick", "powerOff");
             break;
         case "jackoffEnd":
             levels.gottitjob("f", "landlord");
@@ -596,7 +649,7 @@ room9.chatcatch = function (callback) {
             break;
         case "porn":
             nav.bg("9_computer/09_computer.jpg");
-            room9.btnclick("porn");
+            invoker.invokeCurrent("btnclick", "porn");
             break;
         default:
             break;
@@ -747,3 +800,5 @@ room9.chat = function(chatID){
         return cArray[chatID];
 
 }
+
+invoker.registerRoom(9, room9);

--- a/scripts/room/room010.js
+++ b/scripts/room/room010.js
@@ -6,13 +6,13 @@ room10.main = function () {
     }
     else if (cl.c.cock === 5 && !gv.get("playWithPussy")) {
         gv.set("playWithPussy", true);
-        room10.btnclick("drawRoom");
+        invoker.invokeCurrent("btnclick", "drawRoom");
         chat(47, 10);
         return;
     }
     else {
         $('.room-topper').show();
-        room10.btnclick("drawRoom");
+        invoker.invokeCurrent("btnclick", "drawRoom");
         var navList = [];
         var missingClothing = cl.hasoutfit("public");
 
@@ -258,7 +258,7 @@ room10.btnclick = function (name) {
             sc.selectCancel("reset", 1);
             break;
         case "sleep":
-            room10.chatcatch("nap_sleep");
+            invoker.invokeCurrent("chatcatch", "nap_sleep");
             break;
         case "lola_sleep1":
             nav.kill();
@@ -1488,3 +1488,5 @@ room10.chat = function (chatID) {
         return cArray[chatID];
     }
 }
+
+invoker.registerRoom(10, room10);

--- a/scripts/room/room011.js
+++ b/scripts/room/room011.js
@@ -299,3 +299,5 @@ room11.chat = function (chatID) {
     ];
     return cArray[chatID];
 };
+
+invoker.registerRoom(11, room11);

--- a/scripts/room/room012.js
+++ b/scripts/room/room012.js
@@ -512,7 +512,7 @@ room12.chatcatch = function (callback) {
             }
             else {
                 cl.nude();
-                room12.chatcatch("200_2");
+                invoker.invokeCurrent("chatcatch", "200_2");
             }
             break;
         case "200_2":
@@ -562,7 +562,7 @@ room12.chatcatch = function (callback) {
         case "200_finish0":
             //scc.love("lola", 5, 100);
             //scc.love("eva", 5, 100);
-            room12.chatcatch("200_finish1");
+            invoker.invokeCurrent("chatcatch", "200_finish1");
             break;
         case "200_finish1":
             char.addtime(120);
@@ -1016,3 +1016,5 @@ room12.chat = function(chatID){
 
     return cArray[chatID];
 }
+
+invoker.registerRoom(12, room12);

--- a/scripts/room/room013.js
+++ b/scripts/room/room013.js
@@ -530,7 +530,7 @@ room13.btnclick = function (name) {
             nav.killbutton("practiceDate");
             break
         case "lolachat":
-            room13.btnclick("clearChat");
+            invoker.invokeCurrent("btnclick", "clearChat");
             if (daily.get("lolatalk")) {
                 chat(24, 13);
             }
@@ -545,7 +545,7 @@ room13.btnclick = function (name) {
             }
             break;
         case "evachat":
-            room13.btnclick("clearChat");
+            invoker.invokeCurrent("btnclick", "clearChat");
             if (daily.get("evatalk")) {
                 chat(46, 13);
             }
@@ -559,7 +559,7 @@ room13.btnclick = function (name) {
             break;
         case "lolamassage":
             if (g.isNight()) {
-                room13.btnclick("clearChat");
+                invoker.invokeCurrent("btnclick", "clearChat");
                 chat(42, 13);
             }
             else
@@ -567,7 +567,7 @@ room13.btnclick = function (name) {
             break;
         case "evamassage":
             if (g.isNight()) {
-                room13.btnclick("clearChat");
+                invoker.invokeCurrent("btnclick", "clearChat");
                 chat(41, 13);
             }
             else
@@ -575,7 +575,7 @@ room13.btnclick = function (name) {
             break;
         case "spin":
             if (!inv.has("wine")) {
-                room13.btnclick("clearChat");
+                invoker.invokeCurrent("btnclick", "clearChat");
                 chat(43, 13)
             }
             else if (!g.isNight()) {
@@ -587,7 +587,7 @@ room13.btnclick = function (name) {
             break;
         case "tord":
             if (cl.c.shirt === null || cl.c.pants === null) {
-                room13.btnclick("clearChat");
+                invoker.invokeCurrent("btnclick", "clearChat");
                 chat(205, 13);
             }
             else if (!inv.has("wine")) {
@@ -603,7 +603,7 @@ room13.btnclick = function (name) {
         case "dick":
             if (!daily.get("lolaDick")) {
                 daily.set("lolaDick");
-                room13.btnclick("clearChat");
+                invoker.invokeCurrent("btnclick", "clearChat");
                 if (cl.c.chastity !== null) {
                     sc.modSecret("lola", 100);
                     sc.modSecret("eva", 100);
@@ -696,7 +696,7 @@ room13.btnclick = function (name) {
                     "height": 801,
                     "image": "13_sisterRoom/13_sheet1.png"
                 }, 13);
-                room13.chatcatch("displaySnore");
+                invoker.invokeCurrent("chatcatch", "displaySnore");
             }
             break;
         case "sheet1":
@@ -779,7 +779,7 @@ room13.btnclick = function (name) {
                     "image": "13_sisterRoom/pj_eva_pants.png"
                 }, 13);
             }
-            room13.chatcatch("displaySnore");
+            invoker.invokeCurrent("chatcatch", "displaySnore");
             g.internal.step = 0;
             if (g.internal.lolaPanties)
                 sc.select("lolaStrip", "13_sisterRoom/icon_focuslolastrip.png", 0);
@@ -800,10 +800,10 @@ room13.btnclick = function (name) {
                 else if (g.internal.step === 3) {
                     g.internal.lolaPants = false;
                     if (!daily.get("lolaDrunk")) {
-                        room13.btnclick("sleepAngry");
+                        invoker.invokeCurrent("btnclick", "sleepAngry");
                         return;
                     }
-                    room13.btnclick("choice");
+                    invoker.invokeCurrent("btnclick", "choice");
                     daily.set("elsleep");
                 }
                 else {
@@ -873,10 +873,10 @@ room13.btnclick = function (name) {
                 else if (g.internal.step === 4) {
                     g.internal.lolaPanties = false;
                     if (!daily.get("lolaDrunk")) {
-                        room13.btnclick("sleepAngry");
+                        invoker.invokeCurrent("btnclick", "sleepAngry");
                         return;
                     }
-                    room13.btnclick("choice");
+                    invoker.invokeCurrent("btnclick", "choice");
                 }
             }
             break;
@@ -892,11 +892,11 @@ room13.btnclick = function (name) {
                 else if (g.internal.step === 4) {
                     g.internal.evaPants = false;
                     if (!daily.get("evaDrunk")) {
-                        room13.btnclick("sleepAngry");
+                        invoker.invokeCurrent("btnclick", "sleepAngry");
                         return;
                     }
                     else {
-                        room13.btnclick("choice");
+                        invoker.invokeCurrent("btnclick", "choice");
                         daily.set("elsleep");
                     }
                 }
@@ -955,10 +955,10 @@ room13.btnclick = function (name) {
                 else if (g.internal.step === 3) {
                     g.internal.evaPanties = false;
                     if (!daily.get("evaDrunk")) {
-                        room13.btnclick("sleepAngry");
+                        invoker.invokeCurrent("btnclick", "sleepAngry");
                         return;
                     }
-                    room13.btnclick("choice");
+                    invoker.invokeCurrent("btnclick", "choice");
                 }
             }
             break;
@@ -1338,7 +1338,7 @@ room13.btnclick = function (name) {
             chat(57, 13);
             break;
         case "practiceDate":
-            room13.btnclick("clearChat");
+            invoker.invokeCurrent("btnclick", "clearChat");
             switch (sc.taskGetStep("lola", "date")) {
                 case 0: chat(61, 13); break;
                 case 1: chat(65, 13); break;
@@ -1362,7 +1362,7 @@ room13.btnclick = function (name) {
             nav.killbutton("dateFair");
             nav.killbutton("dateHere");
             nav.killbutton("dateCancel");
-            room13.btnclick("lola");
+            invoker.invokeCurrent("btnclick", "lola");
             break;
         case "dateFair":
             g.pass = { who: "lola", ferrisWheel: false, bong: false, ball: false };
@@ -1638,7 +1638,7 @@ room13.chatcatch = function (callback) {
                 break;
             case "sleepReset":
                 nav.bg("13_sisterRoom/bedbg.jpg");
-                room13.btnclick("bothRoll");
+                invoker.invokeCurrent("btnclick", "bothRoll");
                 break;
             case "evaSleepingJackTits":
                 nav.button({
@@ -2115,6 +2115,8 @@ room13.chatcatch = function (callback) {
         }
     });
 };
+
+invoker.registerRoom(13, room13);
 
 room13.chat = function (chatID) {
     if (chatID === 999) {

--- a/scripts/room/room014.js
+++ b/scripts/room/room014.js
@@ -466,7 +466,8 @@ room14.btnclick = function (name) {
                 sc.select("icon_finger", "14_motherRoom/icon_finger.png", 0);
                 sc.select("icon_ass", "14_motherRoom/icon_ass.png", 1);
                 sc.select("icon_lickass", "14_motherRoom/icon_lickass.png", 2);
-                sc.select("icon_fuck", "14_motherRoom/icon_fuck.png", 3);
+                if (cl.c.chastity === null)
+                    sc.select("icon_fuck", "14_motherRoom/icon_fuck.png", 3);
                 sc.selectCancel("motherSleep", 4);
                 nav.killbutton("sleepmolest");
                 nav.killbutton("takePic");
@@ -856,12 +857,12 @@ room14.chatcatch = function (callback) {
             char.room(14);
             break;
         case "resetDresser":
-            room14.btnclick("dresser");
+            invoker.invokeCurrent("btnclick", "dresser");
             break;
         case "stealplug":
             cl.add("buttplug", "s");
             levels.mod("xdress", 40);
-            room14.btnclick("dresser");
+            invoker.invokeCurrent("btnclick", "dresser");
             break;
         case "domlaugh":
             levels.mod("dom", 38);
@@ -1293,7 +1294,7 @@ room14.chatcatch = function (callback) {
             nav.next("confess4");
             break;
         case "confess5":
-            nav.bg("14_motherRoom/16_downStairsNight.jpg");
+            nav.bg("16_livingRoom/16_downStairsNight.jpg");
             break;
         case "confess_end":
             sc.completeMissionTaskAll("bigguy", "sissy", 4);
@@ -1319,6 +1320,8 @@ room14.chatcatch = function (callback) {
             break;
     }
 };
+
+invoker.registerRoom(14, room14);
 
 room14.chat = function (chatID) {
     if (chatID === 999) {

--- a/scripts/room/room015.js
+++ b/scripts/room/room015.js
@@ -395,3 +395,5 @@ room15.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(15, room15);

--- a/scripts/room/room016.js
+++ b/scripts/room/room016.js
@@ -1193,3 +1193,5 @@ room16.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(16, room16);

--- a/scripts/room/room017.js
+++ b/scripts/room/room017.js
@@ -226,3 +226,5 @@ room17.chat = function (chatID) {
     ];
     return cArray[chatID];
 };
+
+invoker.registerRoom(17, room17);

--- a/scripts/room/room018.js
+++ b/scripts/room/room018.js
@@ -110,3 +110,5 @@ room18.chat = function (chatID) {
 
     return cArray[chatID]
 };
+
+invoker.registerRoom(18, room18);

--- a/scripts/room/room019.js
+++ b/scripts/room/room019.js
@@ -2,7 +2,7 @@
 var room19 = {};
 
 room19.main = function () {
-    room19.chatcatch("toybox");
+    invoker.invokeCurrent("chatcatch", "toybox");
     nav.button({
         "type": "img",
         "name": "bghide",
@@ -404,11 +404,11 @@ room19.chatcatch = function (callback) {
             break;
         case "bj":
             g.internal = "bj";
-            room19.chatcatch("toybox");
+            invoker.invokeCurrent("chatcatch", "toybox");
             break;
         case "analtoy":
             g.internal = "anal";
-            room19.chatcatch("toybox");
+            invoker.invokeCurrent("chatcatch", "toybox");
             break;
         case "addFinger":
             g.internal.f += 1;
@@ -622,3 +622,5 @@ room19.chat = function (chatID) {
 
     return cArray[chatID];
 };
+
+invoker.registerRoom(19, room19);

--- a/scripts/room/room020.js
+++ b/scripts/room/room020.js
@@ -43,3 +43,5 @@ room20.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(20, room20);

--- a/scripts/room/room021.js
+++ b/scripts/room/room021.js
@@ -203,3 +203,5 @@ room21.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(21, room21);

--- a/scripts/room/room022.js
+++ b/scripts/room/room022.js
@@ -45,14 +45,14 @@ room22.main = function () {
     $.each(btnList, function (i, v) {
         nav.button(v, 22);
     });
-    room22.btnclick("drawIconsMaster");  
+    invoker.invokeCurrent("btnclick", "drawIconsMaster");
     nav.buildnav(navList);
 };
 
 room22.btnclick = function (name) {
     switch (name) {
         case "drawIconsMaster":
-            room22.btnclick("clearRoom");
+            invoker.invokeCurrent("btnclick", "clearRoom");
             if (gv.get("bladder") > 0) {
                 sc.select("pee", "22_toilet/icon_pee.png", 0);
             }
@@ -68,15 +68,15 @@ room22.btnclick = function (name) {
             sc.selectCancel("leave", 2);
             break;
         case "peex":
-            room22.btnclick("clearRoom");
+            invoker.invokeCurrent("btnclick", "clearRoom");
             chat(0, 22);
             break;
         case "cumx":
-            room22.btnclick("clearRoom");
+            invoker.invokeCurrent("btnclick", "clearRoom");
             chat(1, 22);
             break;
         case "pee":
-            room22.btnclick("clearRoom");
+            invoker.invokeCurrent("btnclick", "clearRoom");
             if (cl.c.chastity !== null) {
                 sc.select("peemanx", "22_toilet/icon_peeMan.png", 0);
                 sc.select("peebitch", "22_toilet/icon_peeBitch.png", 1);
@@ -93,7 +93,7 @@ room22.btnclick = function (name) {
             }
             break;
         case "peemanx":
-            room22.btnclick("clearRoom");
+            invoker.invokeCurrent("btnclick", "clearRoom");
             chat(2, 22);
             break;
         case "peeman":
@@ -406,3 +406,5 @@ room22.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(22, room22);

--- a/scripts/room/room023.js
+++ b/scripts/room/room023.js
@@ -474,16 +474,16 @@ room23.chatcatch = function (callback) {
         case "myDare":
             if (g.internal.gamephase > g.internal.myphase) {
                 if (g.internal.nextTurn === "lola")
-                    room23.chatcatch("lolatalk evasit");
+                    invoker.invokeCurrent("chatcatch", "lolatalk evasit");
                 else
-                    room23.chatcatch("evatalk lolasit");
+                    invoker.invokeCurrent("chatcatch", "evatalk lolasit");
                 chat(701, 23);
             }
             else {
                 if (g.internal.nextTurn === "lola")
-                    room23.chatcatch("lolatalk evasit");
+                    invoker.invokeCurrent("chatcatch", "lolatalk evasit");
                 else
-                    room23.chatcatch("evatalk lolasit");
+                    invoker.invokeCurrent("chatcatch", "evatalk lolasit");
                 chat(702, 23);
             }
             break;
@@ -513,7 +513,7 @@ room23.chatcatch = function (callback) {
                     if (cl.c.bra !== null) {
                         sc.modSecret("eva", 100);
                         sc.modSecret("lola", 100);
-                        room23.chatcatch("lolasad evagiggle");
+                        invoker.invokeCurrent("chatcatch", "lolasad evagiggle");
                         chat(84, 23);
                     }
                     else {
@@ -530,7 +530,7 @@ room23.chatcatch = function (callback) {
                     if (cl.getEntry("panties", cl.c.panties).sex === "f") {
                         sc.modSecret("eva", 100);
                         sc.modSecret("lola", 100);
-                        room23.chatcatch("lolasad evagiggle");
+                        invoker.invokeCurrent("chatcatch", "lolasad evagiggle");
                         chat(85, 23);
                     }
                     else {
@@ -545,7 +545,7 @@ room23.chatcatch = function (callback) {
                     if (cl.c.chastity !== null) {
                         sc.modSecret("eva", 100);
                         sc.modSecret("lola", 100);
-                        room23.chatcatch("lolasad evagiggle");
+                        invoker.invokeCurrent("chatcatch", "lolasad evagiggle");
                         chat(86, 23);
                     }
                     else {
@@ -784,8 +784,8 @@ room23.chatcatch = function (callback) {
                     "height": 732,
                     "image": "24_spinTheBottle/talent_lola.png"
                 }, 13);
-                room23.chatcatch("lolaWine");
-                room23.chatcatch("evatalk");
+                invoker.invokeCurrent("chatcatch", "lolaWine");
+                invoker.invokeCurrent("chatcatch", "evatalk");
                 chat(42, 23);
             }
             else {
@@ -799,7 +799,7 @@ room23.chatcatch = function (callback) {
                     "height": 732,
                     "image": "24_spinTheBottle/talent_eva.png"
                 }, 13);
-                room23.chatcatch("evaWin");
+                invoker.invokeCurrent("chatcatch", "evaWin");
                 chat(42, 23);
             }
             //g.internal.dares[g.internal.gamephase].splice(g.internal.gamepointer, 1);
@@ -831,12 +831,12 @@ room23.chatcatch = function (callback) {
                 g.internal.gamephase = 2;
                 if (g.internal.nextTurn === "lola") {
                     g.internal.lolaphase = 2;
-                    room23.chatcatch("lolatalk");
+                    invoker.invokeCurrent("chatcatch", "lolatalk");
                     chat(54, 23);
                 }
                 else {
                     g.internal.evaphase = 2;
-                    room23.chatcatch("evatalk");
+                    invoker.invokeCurrent("chatcatch", "evatalk");
                     chat(55, 23);
                 }
             }
@@ -929,11 +929,11 @@ room23.chatcatch = function (callback) {
 
         case "dareLickCock":
             if (g.internal.nextTurn === "lola") {
-                room23.chatcatch("evagiggle lolahappy");
+                invoker.invokeCurrent("chatcatch", "evagiggle lolahappy");
                 chat(79, 23);
             }
             else {
-                room23.chatcatch("evascared lolasad");
+                invoker.invokeCurrent("chatcatch", "evascared lolasad");
                 chat(80, 23);
             }
             nav.button({
@@ -3573,3 +3573,5 @@ room23.getTheirQuestion = function () {
         ]
     };
 };
+
+invoker.registerRoom(23, room23);

--- a/scripts/room/room024.js
+++ b/scripts/room/room024.js
@@ -14,7 +14,7 @@ room24.main = function () {
         whoTurn: "me",
         totalTurn: 0
     };
-    room24.chatcatch("evaTalk lolaSit");
+    invoker.invokeCurrent("chatcatch", "evaTalk lolaSit");
     inv.use("wine");
     daily.set("lola");
     daily.set("eva");
@@ -34,7 +34,7 @@ room24.btnclick = function (name) {
         case "spin":
             gv.mod("arousal", 3);
             nav.kill();
-            room24.chatcatch("topbg evaTop lolaTop");
+            invoker.invokeCurrent("chatcatch", "topbg evaTop lolaTop");
             if (g.internal.whoTurn === "eva") {
                 //nav.button({
                 //    "type": "img",
@@ -109,7 +109,7 @@ room24.btnclick = function (name) {
                 }
             }
             setTimeout(function () {
-                room24.btnclick("spinStop1");
+                invoker.invokeCurrent("btnclick", "spinStop1");
                 //$('.room-chatBox').show(); window.getSelection().removeAllRanges();
             }, 3000);
             break;
@@ -122,14 +122,14 @@ room24.btnclick = function (name) {
                 }
             }
             else 
-                room24.btnclick("spinStop");
+                invoker.invokeCurrent("btnclick", "spinStop");
             break;
         case "spinStop":
             nav.killbutton("hlkill");
             switch (g.internal.prevWho) {
                 case "lola":
                     if (g.internal.lolaWine < 2 && g.internal.lolaNude === 0 && g.rand(0, 2) !== 0) {
-                        room24.chatcatch("bg evaSit lolaTalk");
+                        invoker.invokeCurrent("chatcatch", "bg evaSit lolaTalk");
                         g.internal.lolaNude = 1;
                         if (g.internal.evaNude === 1)
                             chat(5, 24);
@@ -140,20 +140,20 @@ room24.btnclick = function (name) {
                         if (g.internal.lolaWine > 0) {
                             if (g.internal.whoTurn === "lola") {
                                 g.internal.lolaWine--; 
-                                room24.chatcatch("bg evaSit lolaDrink");
+                                invoker.invokeCurrent("chatcatch", "bg evaSit lolaDrink");
                                 chat(10, 24); //drink wine
                             }
                             else if (g.internal.whoTurn === "eva") {
-                                room24.chatcatch("bg bothKiss");
+                                invoker.invokeCurrent("chatcatch", "bg bothKiss");
                                 chat(11, 24);//kiss eva
                             }
                             else {
-                                room24.chatcatch("bg evaSit lolaKiss");
+                                invoker.invokeCurrent("chatcatch", "bg evaSit lolaKiss");
                                 chat(12, 24);//kiss mc
                             }
                         }
                         else {
-                            room24.chatcatch("bg evaSit lolaTalk");
+                            invoker.invokeCurrent("chatcatch", "bg evaSit lolaTalk");
                             chat(21, 24);
                         }
                     }
@@ -161,7 +161,7 @@ room24.btnclick = function (name) {
                 case "eva":
                     if (g.internal.evaWine < 3 && g.internal.evaNude === 0 && g.rand(0, 4) !== 0) {
                         g.internal.evaNude = 1;
-                        room24.chatcatch("bg lolaSit evaTalk");
+                        invoker.invokeCurrent("chatcatch", "bg lolaSit evaTalk");
                         if (g.internal.lolaNude === 1)
                             chat(13, 24);
                         else
@@ -171,20 +171,20 @@ room24.btnclick = function (name) {
                         if (g.internal.evaWine > 0) {
                             if (g.internal.whoTurn === "eva") {
                                 g.internal.evaWine--;
-                                room24.chatcatch("bg lolaSit evaDrink");
+                                invoker.invokeCurrent("chatcatch", "bg lolaSit evaDrink");
                                 chat(16, 24); //drink wine
                             }
                             else if (g.internal.whoTurn === "lola") {
-                                room24.chatcatch("bg bothKiss");
+                                invoker.invokeCurrent("chatcatch", "bg bothKiss");
                                 chat(17, 24);//kiss eva
                             }
                             else {
-                                room24.chatcatch("bg lolaSit evaKiss");
+                                invoker.invokeCurrent("chatcatch", "bg lolaSit evaKiss");
                                 chat(18, 24);//kiss mc
                             }
                         }
                         else {
-                            room24.chatcatch("bg evaTalk lolaSit");
+                            invoker.invokeCurrent("chatcatch", "bg evaTalk lolaSit");
                             chat(22, 24);
                         }
                     }
@@ -220,14 +220,14 @@ room24.btnclick = function (name) {
             cl.c.shirt = null;
             cl.display();
             if (cl.c.bra === null) {
-                room24.chatcatch("bg evaSit lolaTalk");
+                invoker.invokeCurrent("chatcatch", "bg evaSit lolaTalk");
                 sc.modLevel("lola", 25, 3);
                 chat(25, 24);
             }
             else {
                 sc.modSecret("eva", 65);
                 sc.modSecret("lola", 65);
-                room24.chatcatch("bg evaSit lolaTalk");
+                invoker.invokeCurrent("chatcatch", "bg evaSit lolaTalk");
                 chat(27, 24);
             }
             break;
@@ -237,18 +237,18 @@ room24.btnclick = function (name) {
             nav.killbutton("quit");
             if (g.internal.whoTurn === "lola") {
                 sc.modLevel("lola", 10, 7);
-                room24.chatcatch("bg evaSit lolaKiss");
+                invoker.invokeCurrent("chatcatch", "bg evaSit lolaKiss");
                 chat(19, 24);
             }
             else {
                 sc.modLevel("eva", 10, 7);
-                room24.chatcatch("bg lolaSit evaKiss");
+                invoker.invokeCurrent("chatcatch", "bg lolaSit evaKiss");
                 chat(20, 24);
             }
             break;
         case "drink":
             nav.killall();
-            room24.chatcatch("bg lolaSit evaSit");
+            invoker.invokeCurrent("chatcatch", "bg lolaSit evaSit");
             g.internal.meWine--;
             nav.button({
                 "type": "img",
@@ -287,7 +287,7 @@ room24.btnclick = function (name) {
             break;
         case "lolaPic":
             pic.add("lolaTopless");
-            room24.chatcatch("lolaSit evaTalk");
+            invoker.invokeCurrent("chatcatch", "lolaSit evaTalk");
             chat(9, 24);
             break;
     }
@@ -331,7 +331,7 @@ room24.chatcatch = function (callback) {
                         "height": 1071,
                         "image": "24_spinTheBottle/sit_lola_" + g.internal.lolaNude + "_nt.png"
                     }, 13);
-                    room24.btnclick("lolaWine");
+                    invoker.invokeCurrent("btnclick", "lolaWine");
                     break;
                 case "lolaHeart":
                     nav.killbutton("lola");
@@ -344,7 +344,7 @@ room24.chatcatch = function (callback) {
                         "height": 1071,
                         "image": "24_spinTheBottle/sit_lola_heart.png"
                     }, 13);
-                    room24.btnclick("lolaWine");
+                    invoker.invokeCurrent("btnclick", "lolaWine");
                     sc.select("lolaPic", "icon_pic.png", 8);
                     break;
                 case "evaSit":
@@ -358,7 +358,7 @@ room24.chatcatch = function (callback) {
                         "height": 1036,
                         "image": "24_spinTheBottle/sit_eva_" + g.internal.evaNude + "_nt.png"
                     }, 13);
-                    room24.btnclick("evaWine");
+                    invoker.invokeCurrent("btnclick", "evaWine");
                     break;
                 case "lolaDrink":
                     nav.killbutton("lola");
@@ -397,7 +397,7 @@ room24.chatcatch = function (callback) {
                         "height": 1071,
                         "image": "24_spinTheBottle/sit_lola_" + g.internal.evaNude + "_t.png"
                     }, 13);
-                    room24.btnclick("lolaWine");
+                    invoker.invokeCurrent("btnclick", "lolaWine");
                     break;
                 case "evaTalk":
                     nav.killbutton("eva");
@@ -410,11 +410,11 @@ room24.chatcatch = function (callback) {
                         "height": 1036,
                         "image": "24_spinTheBottle/sit_eva_" + g.internal.evaNude + "_t.png"
                     }, 13);
-                    room24.btnclick("evaWine");
+                    invoker.invokeCurrent("btnclick", "evaWine");
                     break;
                 case "lolaKiss":
                     nav.killbutton("lola");
-                    room24.btnclick("lolaWine");
+                    invoker.invokeCurrent("btnclick", "lolaWine");
                     nav.button({
                         "type": "img",
                         "name": "lola",
@@ -428,7 +428,7 @@ room24.chatcatch = function (callback) {
                     break;
                 case "evaKiss":
                     nav.killbutton("eva");
-                    room24.btnclick("evaWine");
+                    invoker.invokeCurrent("btnclick", "evaWine");
                     nav.button({
                         "type": "img",
                         "name": "eva",
@@ -452,8 +452,8 @@ room24.chatcatch = function (callback) {
                         "height": 1080,
                         "image": "24_spinTheBottle/both_kiss_eva" + g.internal.evaNude + "_lola" + g.internal.lolaNude + ".png"
                     }, 13);
-                    room24.btnclick("evaWine");
-                    room24.btnclick("lolaWine");
+                    invoker.invokeCurrent("btnclick", "evaWine");
+                    invoker.invokeCurrent("btnclick", "lolaWine");
                     //gv.mod("arousal", 60);
                     break;
                 case "lolaTop":
@@ -496,17 +496,17 @@ room24.chatcatch = function (callback) {
                     g.internal.meNextChat = 77;
                     break;
                 case "meEnd":
-                    room24.chatcatch("topbg evaTop lolaTop");
+                    invoker.invokeCurrent("chatcatch", "topbg evaTop lolaTop");
                     chat(g.internal.meNextChat, 24);
                     break;
                 case "meSecret":
                     if (g.internal.meSecret === 0) {
-                        room24.chatcatch("bg evaSit lolaSit");
+                        invoker.invokeCurrent("chatcatch", "bg evaSit lolaSit");
                         g.internal.meSecret = 1;
                         chat(18, 24);
                     }
                     else if (g.internal.meSecret === 1) {
-                        room24.chatcatch("bg evaSit lolaTalk");
+                        invoker.invokeCurrent("chatcatch", "bg evaSit lolaTalk");
                         g.internal.meSecret = 1;
                         chat(38, 24);
                     }
@@ -515,11 +515,11 @@ room24.chatcatch = function (callback) {
                     pic.add("lolaTopless");
                     break;
                 case "meKissLola":
-                    room24.chatcatch("bg evaSit lolaKiss");
+                    invoker.invokeCurrent("chatcatch", "bg evaSit lolaKiss");
                     chat(27, 24);
                     break;
                 case "meKissEva":
-                    room24.chatcatch("bg lolaSit evaKiss");
+                    invoker.invokeCurrent("chatcatch", "bg lolaSit evaKiss");
                     chat(29, 24);
                     break;
                 case "killWine":
@@ -527,13 +527,13 @@ room24.chatcatch = function (callback) {
                     nav.killbutton("evaWine");
                     break;
                 case "evaSpin":
-                    room24.btnclick("spin");
+                    invoker.invokeCurrent("btnclick", "spin");
                     //$('.room-img[data-name="bottle"]').addClass('evaSpin');
                     //$('.room-chatBox').hide();
                     //setTimeout(function () { $('.room-chatBox').show(); window.getSelection().removeAllRanges(); }, 3000);
                     break;
                 case "lolaSpin":
-                    room24.btnclick("spin");
+                    invoker.invokeCurrent("btnclick", "spin");
                     //$('.room-img[data-name="bottle"]').addClass('lolaSpin');
                     //$('.room-chatBox').hide();
                     //setTimeout(function () { $('.room-chatBox').show(); window.getSelection().removeAllRanges(); }, 3000);
@@ -542,7 +542,7 @@ room24.chatcatch = function (callback) {
                     sc.select("spin", "24_spinTheBottle/spin.png", 8);
                     break;
                 case "spinStop":
-                    room24.btnclick("spinStop");
+                    invoker.invokeCurrent("btnclick", "spinStop");
                     break;
                 case "spinEnd":
                     char.settime(22, 37);
@@ -572,12 +572,12 @@ room24.chatcatch = function (callback) {
                 case "picture":
                     if (pic.has("lolaTopless")) {
                         chat(7, 24);
-                        room24.chatcatch("evaTalk");
-                        room24.chatcatch("lolaSit");
+                        invoker.invokeCurrent("chatcatch", "evaTalk");
+                        invoker.invokeCurrent("chatcatch", "lolaSit");
                     }
                     else {
                         sc.modLevel("lola", 10, 7);
-                        room24.btnclick("spin");
+                        invoker.invokeCurrent("btnclick", "spin");
                     }
                     break;
                 case "evaLevel":
@@ -874,3 +874,5 @@ room24.chat = function (chatID) {
     ];
     return cArray[chatID];
 };
+
+invoker.registerRoom(24, room24);

--- a/scripts/room/room025.js
+++ b/scripts/room/room025.js
@@ -119,7 +119,7 @@ room25.btnclick = function (name) {
             char.room(11);
             break;
         case "mom":
-            room26.btnclick("chat_landlord");
+            invoker.invoke(26, "btnclick", "chat_landlord");
             break;
         case "lolaAndEva":
             var le = sc.getLevel("lola");
@@ -159,33 +159,33 @@ room25.chatcatch = function (callback) {
         case "passtime1":
             sc.setstep("landlord", 1);
             daily.set("landlord");
-            room25.chatcatch("motherPassTime");
+            invoker.invokeCurrent("chatcatch", "motherPassTime");
             break;
         case "passtime2":
             sc.setstep("landlord", 2);
             daily.set("landlord");
-            room25.chatcatch("motherPassTime");
+            invoker.invokeCurrent("chatcatch", "motherPassTime");
             break;
         case "passtime3":
             sc.setstep("landlord", 3);
             sc.setstep("landlord", -3);
             daily.set("landlord");
-            room25.chatcatch("motherPassTime");
+            invoker.invokeCurrent("chatcatch", "motherPassTime");
             break;
         case "passtime4":
             sc.setstep("landlord", 4);
             daily.set("landlord");
-            room25.chatcatch("motherPassTime");
+            invoker.invokeCurrent("chatcatch", "motherPassTime");
             break;
         case "passtime5":
             sc.setstep("landlord", 5);
             daily.set("landlord");
-            room25.chatcatch("motherPassTime");
+            invoker.invokeCurrent("chatcatch", "motherPassTime");
             break;
         case "passtime6":
             sc.setstep("landlord", 6);
             daily.set("landlord");
-            room25.chatcatch("motherPassTime");
+            invoker.invokeCurrent("chatcatch", "motherPassTime");
             break;
         case "motherPassTime":
             char.addtime(60);
@@ -207,6 +207,8 @@ room25.chatcatch = function (callback) {
             break;
     }
 };
+
+invoker.registerRoom(25, room25);
 
 room25.chat = function (chatID) {
     var cArray = [

--- a/scripts/room/room026.js
+++ b/scripts/room/room026.js
@@ -1,5 +1,37 @@
 ﻿//Living Room
 var room26 = {};
+room26.landlordOverlayButtons = [
+    "chatbg",
+    "chat_cancel",
+    "sit_landlord",
+    "sit_dick",
+    "sissy_confess",
+    "chat_landlord",
+    "chat_landlordSissy",
+    "sit_dickSissy",
+    "confess_bigguy",
+    "icon_girl",
+    "icon_paint"
+];
+room26.showLandlordOverlay = function () {
+    nav.button({
+        "type": "img",
+        "name": "chatbg",
+        "left": 0,
+        "top": 0,
+        "width": 1920,
+        "height": 1080,
+        "image": "1001_rand/black_25.png"
+    }, g.roomID);
+};
+room26.selectLandlordOverlayOption = function (name, image, slot) {
+    sc.select(name, image, slot);
+};
+room26.closeLandlordOverlay = function () {
+    $.each(room26.landlordOverlayButtons, function (i, buttonName) {
+        nav.killbutton(buttonName);
+    });
+};
 room26.main = function () {
     var btnList = new Array();
 
@@ -83,46 +115,38 @@ room26.main = function () {
 room26.btnclick = function (name) {
     switch (name) {
         case "landlord":
-            nav.button({
-                "type": "img",
-                "name": "chatbg",
-                "left": 0,
-                "top": 0,
-                "width": 1920,
-                "height": 1080,
-                "image": "1001_rand/black_25.png"
-            }, g.roomID);
+            room26.showLandlordOverlay();
             if (sc.getMission("landlord", "sissy").notStarted) {
                 if (!daily.get("landlordChat")) {
-                    sc.select("chat_landlord", "26_livingRoom/chat_landlord.png", 0);
+                    room26.selectLandlordOverlayOption("chat_landlord", "26_livingRoom/chat_landlord.png", 0);
                 }
                 if (sc.getMissionTask("landlord", "talk", 2).complete) {
-                    sc.select("sit_landlord", "26_livingRoom/icon_tv.png", 1);
-                    sc.select("sit_dick", "26_livingRoom/icon_dick.png", 2);
+                    room26.selectLandlordOverlayOption("sit_landlord", "26_livingRoom/icon_tv.png", 1);
+                    room26.selectLandlordOverlayOption("sit_dick", "26_livingRoom/icon_dick.png", 2);
                 }
 
                 if (sissy.getNumPassed() > 5)
-                    sc.select("sissy_confess", "26_livingRoom/icon_sissy.png", 3);
+                    room26.selectLandlordOverlayOption("sissy_confess", "26_livingRoom/icon_sissy.png", 3);
                 sc.selectCancel("chat_cancel", 4);
             }
             else {
                 if (!daily.get("landlordChat")) {
-                    sc.select("chat_landlordSissy", "26_livingRoom/chat_landlord.png", 0);
+                    room26.selectLandlordOverlayOption("chat_landlordSissy", "26_livingRoom/chat_landlord.png", 0);
                     daily.set("landlordChat");
                 }
-                sc.select("sit_dickSissy", "26_livingRoom/icon_bussy.png", 1);
+                room26.selectLandlordOverlayOption("sit_dickSissy", "26_livingRoom/icon_bussy.png", 1);
                 if (sc.getMissionTask("bigguy", "rent", 2).complete && sc.getMissionTask("bigguy", "rent", 3).notStarted) {
-                    sc.select("confess_bigguy", "26_livingRoom/icon_confess.png", 3);
+                    room26.selectLandlordOverlayOption("confess_bigguy", "26_livingRoom/icon_confess.png", 3);
                 }
-                sc.select("icon_girl", "26_livingRoom/icon_girl.png", 2);
+                room26.selectLandlordOverlayOption("icon_girl", "26_livingRoom/icon_girl.png", 2);
                 if (gv.get("mr_paint") === "mr_blue" || gv.get("mr_paint") === null) {
-                    sc.select("icon_paint", "26_livingRoom/icon_paint.webp", 4);
+                    room26.selectLandlordOverlayOption("icon_paint", "26_livingRoom/icon_paint.webp", 4);
                 }
                 sc.selectCancel("chat_cancel", 5);
             }
             break;
         case "chat_landlordSissy":
-            room26.btnclick("chat_cancel");
+            room26.closeLandlordOverlay();
             switch (sc.taskGetStep("landlord", "sissy")) {
                 case -1:
                 case 0:
@@ -142,24 +166,24 @@ room26.btnclick = function (name) {
             }
             break;
         case "icon_girl":
-            room26.btnclick("chat_cancel");
+            room26.closeLandlordOverlay();
             chat(109, 26);
             break;
         case "sit_dickSissy":
-            room26.btnclick("chat_cancel");
+            room26.closeLandlordOverlay();
             cl.nude();
             chat(101, 26);
             break;
         case "confess_bigguy":
-            room26.btnclick("chat_cancel");
+            room26.closeLandlordOverlay();
             chat(106, 26);
             break;
         case "sissy_confess":
-            room26.btnclick("chat_cancel");
+            room26.closeLandlordOverlay();
             chat(73, 26);
             break;
         case "sit_dick":
-            room26.btnclick("chat_cancel");
+            room26.closeLandlordOverlay();
             if (cl.c.chastity !== null) {
                 sc.modSecret("landlord", 100);
                 chat(59, 26);
@@ -183,20 +207,10 @@ room26.btnclick = function (name) {
             }
             break;
         case "chat_cancel":
-            nav.killbutton("chatbg");
-            nav.killbutton("chat_cancel");
-            nav.killbutton("sit_landlord");
-            nav.killbutton("sit_dick");
-            nav.killbutton("sissy_confess");
-            nav.killbutton("chat_landlord");
-            nav.killbutton("chat_landlordSissy");
-            nav.killbutton("sit_dickSissy");
-            nav.killbutton("confess_bigguy");
-            nav.killbutton("icon_girl");
-            nav.killbutton("icon_paint");
+            room26.closeLandlordOverlay();
             return;
         case "chat_landlord":
-            room26.btnclick("chat_cancel");
+            room26.closeLandlordOverlay();
             daily.set("landlordChat");
             var jobapplyconst = gv.get("jobapplyconst");
             var chatEvent = sc.taskGetStep("landlord", "talk");
@@ -455,7 +469,7 @@ room26.btnclick = function (name) {
             chat(131, 26);
             break;
         case "icon_paint":
-            room26.btnclick("chat_cancel");
+            room26.closeLandlordOverlay();
             chat(149, 26);
             break;
         default:
@@ -687,7 +701,7 @@ room26.chatcatch = function (callback) {
                 }, 26);
                 break;
             case "e_tv":
-                room26.btnclick("e_tv");
+                invoker.invokeCurrent("btnclick", "e_tv");
                 break;
             case "m5":
                 if (sc.getLevel("lola") > 4) {
@@ -768,7 +782,7 @@ room26.chatcatch = function (callback) {
                 nav.kill();
                 gv.set("mr_paint", "mr_pink");
                 char.addtime(180);
-                room10.btnclick("drawRoom");
+                invoker.invoke(10, "btnclick", "drawRoom");
                 nav.button({
                     "type": "img",
                     "name": "ll",
@@ -2352,3 +2366,5 @@ room26.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(26, room26);

--- a/scripts/room/room027.js
+++ b/scripts/room/room027.js
@@ -110,17 +110,17 @@ room27.btnclick = function (name) {
             char.room(27);
             break;
         case "menu":
-            room27.chatcatch("checkmakeup");
+            invoker.invokeCurrent("chatcatch", "checkmakeup");
             break;
         case "reset":
             char.room(27);
             break;
         case "wash":
             cl.clean("face");
-            room27.chatcatch("checkmakeup");
+            invoker.invokeCurrent("chatcatch", "checkmakeup");
             break;
         case "makeup":
-            room27.btnclick("clear");
+            invoker.invokeCurrent("btnclick", "clear");
             if (inv.has("makeup") || g.pass === 57) {
                 sc.select("makeup_natural", "27_mirror/icon_natural.png", 3);
                 if (makeuplevel > 0)
@@ -147,7 +147,7 @@ room27.btnclick = function (name) {
                 chat(1, 27);
             break;
         case "lipstick":
-            room27.btnclick("clear");
+            invoker.invokeCurrent("btnclick", "clear");
             if (inv.has("redl"))
                 sc.select("lipstick_red", "27_mirror/icon_lipstick_red.png", 7);
             if (inv.has("pinkl"))
@@ -162,7 +162,7 @@ room27.btnclick = function (name) {
             sc.selectBack("menu", 13);
             break;
         case "eyeshadow":
-            room27.btnclick("clear");
+            invoker.invokeCurrent("btnclick", "clear");
             if (makeuplevel > 2 || g.pass === 170) {
                 if (inv.get("eyeshadow").count < 1) {
                     chat(28, 27);
@@ -940,3 +940,5 @@ room27.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(27, room27);

--- a/scripts/room/room028.js
+++ b/scripts/room/room028.js
@@ -280,7 +280,7 @@ room28.main = function () {
                         if (validForcedTransformation) {
                             if (qdress.st[transformationOrder[i]].p <= transformationPoints) {
                                 if ((qdress.st[transformationOrder[i]].h && validTransformationHormone) || !qdress.st[transformationOrder[i]].h) {
-                                    room28.btnclick("qgrow_" + transformationOrder[i]);
+                                    invoker.invokeCurrent("btnclick", "qgrow_" + transformationOrder[i]);
                                     return;
                                 }
                                 else {
@@ -477,6 +477,8 @@ room28.future = function () {
     }
 };
 
+invoker.registerRoom(28, room28);
+
 room28.dreams = function () {
     var getFirstDream = null;
     var hasText = false;
@@ -575,10 +577,10 @@ room28.dreams = function () {
         }
         else if (g.pass === 7) {
             if (sc.getMission("lola", "*wife").startedOrComplete) {
-                nav.bg("10_mainchar/sleep_wife.webp");
+                nav.bg("28_transformation/sleep_wife.webp");
             }
             else if (gv.get("cat") > 0) {
-                nav.bg("10_mainchar/sleep_cat.jpg");
+                nav.bg("28_transformation/sleep_cat.jpg");
             }
         }
     }
@@ -1174,7 +1176,7 @@ room28.chat = function (chatID) {
             {
                 chatID: 29,
                 speaker: "thinking",
-                text: "I need to make sure I feed " + sc.n("cooper") + " tomorrow. ",
+                text: "I need to make sure I feed " + sc.n("dog") + " tomorrow. ",
                 button: [
                     { chatID: -1, text: "...", callback: "endDream" }
                 ]

--- a/scripts/room/room029.js
+++ b/scripts/room/room029.js
@@ -55,3 +55,5 @@ room29.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(29, room29);

--- a/scripts/room/room030.js
+++ b/scripts/room/room030.js
@@ -149,3 +149,5 @@ room30.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(30, room30);

--- a/scripts/room/room031.js
+++ b/scripts/room/room031.js
@@ -98,12 +98,12 @@ room31.btnclick = function (name) {
         case "z":
             if (g.internal.length < 16)
                 g.internal += name;
-            room31.btnclick("drawString");
+            invoker.invokeCurrent("btnclick", "drawString");
             break;
         case "del":
             if (g.internal.length > 0)
                 g.internal = g.internal.slice(0, -1);
-            room31.btnclick("drawString");
+            invoker.invokeCurrent("btnclick", "drawString");
             break;
         case "drawString":
             nav.killbutton("password");
@@ -462,3 +462,5 @@ room31.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(31, room31);

--- a/scripts/room/room032.js
+++ b/scripts/room/room032.js
@@ -90,3 +90,5 @@ room32.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(32, room32);

--- a/scripts/room/room040.js
+++ b/scripts/room/room040.js
@@ -117,18 +117,20 @@ room40.chatcatch = function (callback) {
             sc.completeMission("lola", "sissy");
             sc.startMission("lola", "tom");
             sc.completeMissionTask("lola", "tom", 0);
-            room40.chatcatch("cleanOnly");
+            invoker.invokeCurrent("chatcatch", "cleanOnly");
             break;
         case "endlolaboyChad":
             future.kill("lolaboy");
             sc.completeMissionTask("lola", "sissy", 5, false);
             sc.completeMission("lola", "tom", false);
-            room40.chatcatch("cleanOnly");
+            invoker.invokeCurrent("chatcatch", "cleanOnly");
             break;
         default:
             break;
     }
 };
+
+invoker.registerRoom(40, room40);
 
 room40.chat = function (chatID) {
     if (chatID === 1000) {

--- a/scripts/room/room041.js
+++ b/scripts/room/room041.js
@@ -76,3 +76,5 @@ room41.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(41, room41);

--- a/scripts/room/room049.js
+++ b/scripts/room/room049.js
@@ -132,7 +132,7 @@ room49.chatcatch = function (callback) {
             zcl.displayMain(150, 1100, .11, "clothes", true);
             break;
         case "nextStop":
-            room49.btnclick("nextStop");
+            invoker.invokeCurrent("btnclick", "nextStop");
             break;
         case "rape":
             var chastity49 = cl.c.chastity === null ? "_n" : "_c";
@@ -263,3 +263,5 @@ room49.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(49, room49);

--- a/scripts/room/room050.js
+++ b/scripts/room/room050.js
@@ -173,3 +173,5 @@ room50.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(50, room50);

--- a/scripts/room/room051.js
+++ b/scripts/room/room051.js
@@ -725,3 +725,5 @@ room51.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(51, room51);

--- a/scripts/room/room052.js
+++ b/scripts/room/room052.js
@@ -376,3 +376,5 @@ room52.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(52, room52);

--- a/scripts/room/room053.js
+++ b/scripts/room/room053.js
@@ -890,3 +890,5 @@ room53.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(53, room53);

--- a/scripts/room/room054.js
+++ b/scripts/room/room054.js
@@ -925,3 +925,5 @@ room54.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(54, room54);

--- a/scripts/room/room055.js
+++ b/scripts/room/room055.js
@@ -139,3 +139,5 @@ room55.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(55, room55);

--- a/scripts/room/room056.js
+++ b/scripts/room/room056.js
@@ -143,3 +143,5 @@ room56.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(56, room56);

--- a/scripts/room/room057.js
+++ b/scripts/room/room057.js
@@ -12,7 +12,7 @@ room57.main = function () {
             "height": 1080,
             "image": "57_pussyPalace/fuck.gif"
         }, 57);
-        g.roomTimeout = setTimeout(function () { room57.btnclick("f1"); }, 3000);
+        g.roomTimeout = setTimeout(function () { invoker.invokeCurrent("btnclick", "f1"); }, 3000);
     }
     else {
         var btnList = [
@@ -62,7 +62,7 @@ room57.btnclick = function (name) {
                 "image": "57_pussyPalace/c3.gif"
             }, 57);
             nav.bg("57_pussyPalace/c3.jpg");
-            g.roomTimeout = setTimeout(function () { room57.btnclick("c4"); }, 2000);
+            g.roomTimeout = setTimeout(function () { invoker.invokeCurrent("btnclick", "c4"); }, 2000);
             break;
         case "c4":
             nav.bg("57_pussyPalace/c4.jpg");
@@ -538,3 +538,5 @@ room57.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(57, room57);

--- a/scripts/room/room058.js
+++ b/scripts/room/room058.js
@@ -32,9 +32,9 @@ room58.main = function () {
     if (!cl.naked())
         chat(0, 58);
     else
-        room58.btnclick("sit");
+        invoker.invokeCurrent("btnclick", "sit");
 
-    room58.btnclick("buttons");
+    invoker.invokeCurrent("btnclick", "buttons");
     g.roomTimeout = setTimeout(function () { room58.gameloop(); }, 800);
 };
 
@@ -192,48 +192,48 @@ room58.btnclick = function (name) {
             char.room(57);
             break;
         case "icon_wait":
-            room58.btnclick("sit");
+            invoker.invokeCurrent("btnclick", "sit");
             g.internal.excitement -= 1;
             gv.mod("energy", -2);
             g.internal.prev = "wait";
             break;
         case "icon_chat":
             g.internal.button = "chat";
-            room58.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_chattips":
             g.internal.ticks = 0;
-            room58.btnclick("sit");
+            invoker.invokeCurrent("btnclick", "sit");
             room58.sidechat("tips");
             g.internal.button = "main";
-            room58.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_chatflirt":
             g.internal.ticks = 0;
-            room58.btnclick("sit");
+            invoker.invokeCurrent("btnclick", "sit");
             room58.sidechat("flirt");
             g.internal.button = "main";
-            room58.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_chatInsult":
             g.internal.ticks = 0;
-            room58.btnclick("sit");
+            invoker.invokeCurrent("btnclick", "sit");
             room58.sidechat("insult");
             g.internal.button = "main";
-            room58.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_main":
             g.internal.button = "main";
-            room58.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_show":
             g.internal.button = "show";
-            room58.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_showdildo":
             g.internal.ticks = 0;
             gv.mod("arousal", 20);
-            room58.btnclick("dildo");
+            invoker.invokeCurrent("btnclick", "dildo");
             g.internal.excitement += 1;
             gv.mod("energy", -10);
             if (gv.get("arousal") > 95) {
@@ -242,39 +242,39 @@ room58.btnclick = function (name) {
             else {
                 g.internal.button = "keepdildo";
             }
-            room58.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_shoedildocum":
             g.internal.ticks = 0;
-            room58.btnclick("dildocum");
+            invoker.invokeCurrent("btnclick", "dildocum");
             g.internal.excitement += 4;
             gv.mod("energy", -15);
             levels.anal(3, true);
             g.internal.button = "quit";
-            room58.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_showsuck":
             g.internal.ticks = 0;
             gv.mod("arousal", 5);
-            room58.btnclick("suck");
+            invoker.invokeCurrent("btnclick", "suck");
             g.internal.excitement += 1;
             gv.mod("energy", -4);
             g.internal.button = "main";
-            room58.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_showbutthole":
             g.internal.ticks = 0;
             gv.mod("arousal", 5);
-            room58.btnclick("butthole");
+            invoker.invokeCurrent("btnclick", "butthole");
             g.internal.excitement += 1;
             gv.mod("energy", -4);
             g.internal.button = "main";
-            room58.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_strokecock":
             g.internal.ticks = 0;
             gv.mod("arousal", 25);
-            room58.btnclick("strokecock");
+            invoker.invokeCurrent("btnclick", "strokecock");
             g.internal.excitement += 2;
             gv.mod("energy", -10);
             if (gv.get("arousal") > 95) {
@@ -283,18 +283,18 @@ room58.btnclick = function (name) {
             else {
                 g.internal.button = "keepstroking";
             }
-            room58.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_strokecum":
             g.internal.ticks = 0;
             gv.mod("arousal", 25);
-            room58.btnclick("strokecum");
+            invoker.invokeCurrent("btnclick", "strokecum");
             g.internal.excitement += 4;
             gv.mod("energy", -15);
             cl.doCum(false);
             gv.mod("masturbate_dick", 1);
             g.internal.button = "quit";
-            room58.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         default:
             break;
@@ -307,7 +307,7 @@ room58.chatcatch = function (callback) {
             char.room(55);
             break;
         case "strip":
-            room58.btnclick("sit");
+            invoker.invokeCurrent("btnclick", "sit");
             cl.nude();
             break;
         default:
@@ -564,3 +564,5 @@ room58.sidechat = function (metalk) {
         }, 58);
     }
 };
+
+invoker.registerRoom(58, room58);

--- a/scripts/room/room075.js
+++ b/scripts/room/room075.js
@@ -97,3 +97,5 @@ room75.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(75, room75);

--- a/scripts/room/room076.js
+++ b/scripts/room/room076.js
@@ -221,7 +221,7 @@ room76.chatcatch = function (callback) {
                 "height": 1080,
                 "image": "76_bimboRoom/76_boobjob1.gif"
             }, 76);
-            g.roomTimeout = setTimeout(function () { room76.chatcatch("titfuck3"); }, 4600);
+            g.roomTimeout = setTimeout(function () { invoker.invokeCurrent("chatcatch", "titfuck3"); }, 4600);
             break;
         case "titfuck3":
             nav.killbutton("bimbo");
@@ -422,3 +422,5 @@ room76.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(76, room76);

--- a/scripts/room/room077.js
+++ b/scripts/room/room077.js
@@ -619,3 +619,5 @@ room77.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(77, room77);

--- a/scripts/room/room078.js
+++ b/scripts/room/room078.js
@@ -99,3 +99,5 @@ room78.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(78, room78);

--- a/scripts/room/room100.js
+++ b/scripts/room/room100.js
@@ -145,3 +145,5 @@ room100.chat = function(chatID){
     ];
     return cArray[chatID];
 }
+
+invoker.registerRoom(100, room100);

--- a/scripts/room/room101.js
+++ b/scripts/room/room101.js
@@ -195,7 +195,7 @@ room101.chatcatch = function (callback) {
                 "height": 711,
                 "image": "101_constFrontOffice/jackit2.png"
             }, 101);
-            room101.btnclick("tina");
+            invoker.invokeCurrent("btnclick", "tina");
             break;
         case "endday":
             char.settime(18, 15);
@@ -205,6 +205,8 @@ room101.chatcatch = function (callback) {
             break;
     }
 };
+
+invoker.registerRoom(101, room101);
 
 room101.chat = function (chatID) {
     if (chatID === 900) {

--- a/scripts/room/room102.js
+++ b/scripts/room/room102.js
@@ -214,3 +214,5 @@ room102.chat = function (chatID) {
     ];
     return cArray[chatID];
 };
+
+invoker.registerRoom(102, room102);

--- a/scripts/room/room103.js
+++ b/scripts/room/room103.js
@@ -10,7 +10,7 @@ room103.main = function () {
     }
     else if (jobapplyconst > 4 && jobapplyconst < 100) {
         g.internal = true;
-        room103.chatcatch("sweep");
+        invoker.invokeCurrent("chatcatch", "sweep");
     }
     else if (jobapplyconst === 100) {
         if (sc.getMission("river", "bully").notStarted) {
@@ -19,11 +19,11 @@ room103.main = function () {
         }
         else {
             g.internal = false;
-            room103.chatcatch("sweep");
+            invoker.invokeCurrent("chatcatch", "sweep");
         }
     }
     else {
-        room103.chatcatch("sweep");
+        invoker.invokeCurrent("chatcatch", "sweep");
     }
     
     //var thisRand = Math.floor(Math.random() * 10);
@@ -267,7 +267,7 @@ room103.chatcatch = function (callback) {
         case "work2shirt":
             cl.c.shirt = g.pass;
             cl.display();
-            room103.chatcatch("work2");
+            invoker.invokeCurrent("chatcatch", "work2");
             break;
         case "work2":
             nav.killall();
@@ -428,7 +428,7 @@ room103.chatcatch = function (callback) {
             sc.startMission("tina", "cat");
             sc.completeMissionTask("tina", "cat", 0);
             g.internal = false;
-            room103.chatcatch("sweep");
+            invoker.invokeCurrent("chatcatch", "sweep");
             break;
         case "rapeman0":
             nav.bg("103_constSite/103_sweep.jpg");
@@ -1285,3 +1285,5 @@ room103.chat = function (chatID) {
 
     return cArray[chatID];
 };
+
+invoker.registerRoom(103, room103);

--- a/scripts/room/room125.js
+++ b/scripts/room/room125.js
@@ -270,12 +270,12 @@ room125.btnclick = function (name) {
                 chat(98, 125);
             }
             else {
-                room125.chatcatch("deal");
+                invoker.invokeCurrent("chatcatch", "deal");
             }
             break;
         case "fold":
             g.internal[3].playing = false;
-            room125.btnclick("winner");
+            invoker.invokeCurrent("btnclick", "winner");
             break;
         case "play":
             g.internal[3].playing = true;
@@ -291,7 +291,7 @@ room125.btnclick = function (name) {
                 hex: "#ffffff",
                 text: "Pot $" + g.pass.pot
             }, 125);
-            room125.btnclick("winner");
+            invoker.invokeCurrent("btnclick", "winner");
             break;
         case "winner":
             nav.killbutton("fold");
@@ -445,7 +445,7 @@ room125.btnclick = function (name) {
             };
             if (sc.getMissionTask("ralph", "cards", 2).complete) {
                 g.internal.icons.splice(1, 1);
-                room125.chatcatch("suck0");
+                invoker.invokeCurrent("chatcatch", "suck0");
             }
             else {
                 sc.completeMissionTask("ralph", "cards", 2);
@@ -563,7 +563,7 @@ room125.chatcatch = function (callback) {
         case "keiInc":
             if (sc.getstep("kei") < 3)
                 sc.incstep("kei", 1);
-            room125.chatcatch("deal");
+            invoker.invokeCurrent("chatcatch", "deal");
             break;
         case "deal":
             $('#room_footer').hide();
@@ -698,7 +698,7 @@ room125.chatcatch = function (callback) {
 
             if (willplay) {
                 g.internal[0].b = 6;
-                room125.chatcatch("keiPlay");
+                invoker.invokeCurrent("chatcatch", "keiPlay");
             }
             else {
                 chat(4, 125);
@@ -717,7 +717,7 @@ room125.chatcatch = function (callback) {
 
             if (willplay) {
                 g.internal[1].b = 6;
-                room125.chatcatch("jimmyPlay");
+                invoker.invokeCurrent("chatcatch", "jimmyPlay");
             }
             else {
                 g.internal[1].v1 = 0;
@@ -738,7 +738,7 @@ room125.chatcatch = function (callback) {
 
             if (willplay) {
                 g.internal[2].b = 6;
-                room125.chatcatch("mePlay");
+                invoker.invokeCurrent("chatcatch", "mePlay");
             }
             else {
                 chat(5, 125);
@@ -751,28 +751,28 @@ room125.chatcatch = function (callback) {
             nav.killbutton("ralphcard");
             g.internal[0].v1 = 0;
             g.internal[0].v2 = 0;
-            room125.chatcatch("keiPlay");
+            invoker.invokeCurrent("chatcatch", "keiPlay");
             break;
         case "keifold":
             nav.killbutton("keiback");
             nav.killbutton("keicard");
             g.internal[1].v1 = 0;
             g.internal[1].v2 = 0;
-            room125.chatcatch("jimmyPlay");
+            invoker.invokeCurrent("chatcatch", "jimmyPlay");
             break;
         case "jimmyfold":
             nav.killbutton("jimmyback");
             nav.killbutton("jimmycard");
             g.internal[2].v1 = 0;
             g.internal[2].v2 = 0;
-            room125.chatcatch("mePlay");
+            invoker.invokeCurrent("chatcatch", "mePlay");
             break;
         case "fold":
             gv.mod("money", -1);
             nav.killbutton("mycard");
             g.internal[3].v1 = 0;
             g.internal[3].v2 = 0;
-            room125.chatcatch("call");
+            invoker.invokeCurrent("chatcatch", "call");
             break;
         case "mePlay":
             if (g.internal[0].b + g.internal[1].b + g.internal[2].b === 18)
@@ -1028,7 +1028,7 @@ room125.chatcatch = function (callback) {
             nav.bg("125_poker/j1.jpg");
             break;
         case "reset":
-            room125.btnclick("reset");
+            invoker.invokeCurrent("btnclick", "reset");
             break;
         case "Rachel":
         case "Ralphina":
@@ -1055,7 +1055,7 @@ room125.chatcatch = function (callback) {
             sc.select("leave", "125_poker/icon_leave.png", 1);
             break;
         case "bjbitch":
-            room125.btnclick("bjbitch");
+            invoker.invokeCurrent("btnclick", "bjbitch");
             break;
         case "suck0":
             nav.killall();
@@ -2007,3 +2007,5 @@ room125.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(125, room125);

--- a/scripts/room/room150.js
+++ b/scripts/room/room150.js
@@ -136,7 +136,7 @@ room150.btnclick = function (name) {
                     chat(902, 150);
                     break;
                 default:
-                    room150.chatcatch("exposedCleanWait");
+                    invoker.invokeCurrent("chatcatch", "exposedCleanWait");
                     break;
             }
             break;
@@ -664,3 +664,5 @@ room150.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(150, room150);

--- a/scripts/room/room151.js
+++ b/scripts/room/room151.js
@@ -756,3 +756,5 @@ room151.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(151, room151);

--- a/scripts/room/room152.js
+++ b/scripts/room/room152.js
@@ -139,3 +139,5 @@ room152.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(152, room152);

--- a/scripts/room/room153.js
+++ b/scripts/room/room153.js
@@ -61,7 +61,7 @@ room153.chatcatch = function (callback) {
             }
             break;
         case "clean":
-            room153.btnclick("clean");
+            invoker.invokeCurrent("btnclick", "clean");
             break;
         default:
             break;
@@ -184,3 +184,5 @@ room153.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(153, room153);

--- a/scripts/room/room154.js
+++ b/scripts/room/room154.js
@@ -336,3 +336,5 @@ room154.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(154, room154);

--- a/scripts/room/room155.js
+++ b/scripts/room/room155.js
@@ -375,3 +375,5 @@ room155.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(155, room155);

--- a/scripts/room/room170.js
+++ b/scripts/room/room170.js
@@ -4,7 +4,7 @@ room170.main = function () {
     if (gv.get("sissySchoolClass") === "ex317") {
         if (g.pass === 170) {
             g.pass = null;
-            room170.btnclick("dressingRoom");
+            invoker.invokeCurrent("btnclick", "dressingRoom");
             return;
         }
         switch (gv.get("sissySchoolClassDays")) {
@@ -317,7 +317,7 @@ room170.chatcatch = function (callback) {
             break;
         case "ex317_3":
             cl.add("dress", "rose");
-            room170.chatcatch("dressingRoom");
+            invoker.invokeCurrent("chatcatch", "dressingRoom");
             return;
         case "dressingRoom":
             nav.bg("170_stage/hallway.jpg");
@@ -332,7 +332,7 @@ room170.chatcatch = function (callback) {
             }, 170);
             break;
         case "gotoDressingRoom":
-            room170.btnclick("dressingRoom");
+            invoker.invokeCurrent("btnclick", "dressingRoom");
             break;
         case "hallwayCatwalk":
             nav.kill();
@@ -459,12 +459,12 @@ room170.chatcatch = function (callback) {
         case "fashion27":
             nav.kill();
             nav.bg("170_stage/fashion27.webp");
-            room170.chatcatch("makeScore");
+            invoker.invokeCurrent("chatcatch", "makeScore");
             break;
         case "fashion28": //cheerleader
             nav.kill();
             nav.bg("170_stage/fashion28.webp");
-            room170.chatcatch("makeScore");
+            invoker.invokeCurrent("chatcatch", "makeScore");
             var xcoord1 = [359, 653, 894, 1195, 1453];
             if (cl.hasoutfit("cheerleaderOptional") === null) {
                 var cheerLevel = levels.get("cheer").l;
@@ -502,13 +502,13 @@ room170.chatcatch = function (callback) {
                 chat(800, 170);
             }
             else {
-                room170.chatcatch("makeScore");
+                invoker.invokeCurrent("chatcatch", "makeScore");
             }
             break;
         case "fashion28-s": //stripper
             nav.kill();
             nav.bg("170_stage/fashion28.webp");
-            room170.chatcatch("makeScore");
+            invoker.invokeCurrent("chatcatch", "makeScore");
             var xcoord1s = [359, 653, 894, 1195, 1453];
             if (cl.hasoutfit("braAndPantiesIgnored") === null) {
                 var stripLevel = levels.get("stripper").l;
@@ -546,7 +546,7 @@ room170.chatcatch = function (callback) {
                 chat(800, 170);
             }
             else {
-                room170.chatcatch("makeScore");
+                invoker.invokeCurrent("chatcatch", "makeScore");
             }
             break;
         case "fashion28-w":
@@ -592,7 +592,7 @@ room170.chatcatch = function (callback) {
         case "fashion29":
             nav.kill();
             nav.bg("170_stage/fashion29.webp");
-            room170.chatcatch("makeScore");
+            invoker.invokeCurrent("chatcatch", "makeScore");
             break;
         case "fashion35":
             nav.kill();
@@ -2103,3 +2103,5 @@ room170.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(170, room170);

--- a/scripts/room/room171.js
+++ b/scripts/room/room171.js
@@ -63,7 +63,7 @@ room171.main = function () {
             }, 171);
         }
     }
-    room171.btnclick("fuckers");
+    invoker.invokeCurrent("btnclick", "fuckers");
     if (gv.get("pinkGloryHole") === 0) {
         nav.button({
             "type": "img",
@@ -249,13 +249,13 @@ room171.btnclick = function (name) {
             else {
                 nav.bg("171_gh/face_t5.jpg");
             }
-            room171.btnclick("drawButtons");
+            invoker.invokeCurrent("btnclick", "drawButtons");
             break;
         case "cam1":
             nav.killall();
             g.internal.cam = name;
-            room171.btnclick("cumRoom");
-            room171.btnclick("fuckers");
+            invoker.invokeCurrent("btnclick", "cumRoom");
+            invoker.invokeCurrent("btnclick", "fuckers");
             if (g.internal.fuckers[2] !== null) {
                 nav.button({
                     "type": "img",
@@ -289,7 +289,7 @@ room171.btnclick = function (name) {
                     "image": "171_gh/zl" + g.rand(0, 3) + ".png",
                 }, 171);
             }
-            room171.btnclick("drawButtons");
+            invoker.invokeCurrent("btnclick", "drawButtons");
             break;
         case "cam2":
             nav.killall();
@@ -317,7 +317,7 @@ room171.btnclick = function (name) {
                     "image": "171_gh/gif" + g.internal.fuckersDick[g.internal.fuckers[2]] + ".gif",
                 }, 171);
             }
-            room171.btnclick("drawButtons");
+            invoker.invokeCurrent("btnclick", "drawButtons");
             break;
         case "cam3":
             nav.killall();
@@ -328,7 +328,7 @@ room171.btnclick = function (name) {
             else {
                 nav.bg("171_gh/gix.jpg");
             }
-            room171.btnclick("drawButtons");
+            invoker.invokeCurrent("btnclick", "drawButtons");
             break;
         case "nextCock":
             if (gv.get("energy") < 33) {
@@ -348,7 +348,7 @@ room171.btnclick = function (name) {
                         g.internal.fuckers.push(null);
                     }
                 }
-                room171.btnclick(g.internal.cam);
+                invoker.invokeCurrent("btnclick", g.internal.cam);
             }
             break;
         case "takeit":
@@ -395,7 +395,7 @@ room171.btnclick = function (name) {
                 default: chat(999, 171); break;
             }
             g.internal.fuckers[2] = null;
-            room171.btnclick(g.internal.cam);
+            invoker.invokeCurrent("btnclick", g.internal.cam);
             break;
         default:
             break;
@@ -405,7 +405,7 @@ room171.btnclick = function (name) {
 room171.chatcatch = function (callback) {
     switch (callback) {
         case "cumRoom":
-            room171.btnclick("cam1");
+            invoker.invokeCurrent("btnclick", "cam1");
             break;
         case "reset":
             char.room(171);
@@ -575,3 +575,5 @@ room171.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(171, room171);

--- a/scripts/room/room172.js
+++ b/scripts/room/room172.js
@@ -62,7 +62,7 @@ room172.chatcatch = function (callback) {
         case "goAgain":
             cl.c.chastity = null;
             cl.nude();
-            room172.chatcatch("selection");
+            invoker.invokeCurrent("chatcatch", "selection");
             return;
         case "selection":
             nav.killall();
@@ -182,26 +182,26 @@ room172.chatcatch = function (callback) {
         case "xtieEnd0":
             levels.anal(1, false, "n", false, "black");
             gv.mod("energy", -9999);
-            room172.chatcatch("snuggle");
+            invoker.invokeCurrent("chatcatch", "snuggle");
             return;
         case "xtieEnd1":
             levels.anal(3, false, "n", false, "black");
             gv.mod("energy", -9999);
-            room172.chatcatch("snuggle");
+            invoker.invokeCurrent("chatcatch", "snuggle");
             return;
         case "xtieEnd2":
             levels.anal(5, false, "n", false, "black");
             gv.mod("energy", -9999);
-            room172.chatcatch("snuggle");
+            invoker.invokeCurrent("chatcatch", "snuggle");
             return;
         case "xtieEnd3":
             levels.anal(6, false, "n", false, "black");
             gv.mod("energy", -9999);
-            room172.chatcatch("snuggle");
+            invoker.invokeCurrent("chatcatch", "snuggle");
             return;
         case "xhorend":
             gv.mod("energy", -9999);
-            room172.chatcatch("snuggle");
+            invoker.invokeCurrent("chatcatch", "snuggle");
             return;
         case "snuggle":
             nav.bg("172_punishblack/snuggle0.jpg");
@@ -856,3 +856,5 @@ room172.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(172, room172);

--- a/scripts/room/room173.js
+++ b/scripts/room/room173.js
@@ -1,6 +1,7 @@
 ﻿//trash
 var room173 = {};
 room173.main = function () {
+    var navList = [203];
     if (missy.get("trashSearchCounter") === 0) {
         nav.bg("173_trash/bg0.jpg");
         chat(0, 173);
@@ -17,6 +18,7 @@ room173.main = function () {
         }, 173);
     }
     missy.mod("trashSearchCounter", 1);
+    nav.buildnav(navList);
 };
 
 room173.btnclick = function (name) {
@@ -52,7 +54,7 @@ room173.btnclick = function (name) {
                         break;
                 }
             }
-            room173.btnclick("next");
+            invoker.invokeCurrent("btnclick", "next");
             break;
         case "next":
             if (g.internal.i === g.internal.a.length) {
@@ -81,14 +83,14 @@ room173.btnclick = function (name) {
             if (thisEntrySave.s)
                 levels.mod("pi", 4);
             g.internal.i++;
-            room173.btnclick("next");
+            invoker.invokeCurrent("btnclick", "next");
             break;
         case "trash":
             var thisEntryTrash = g.internal.a[g.internal.i];
             if (!thisEntryTrash.s)
                 levels.mod("pi", 4);
             g.internal.i++;
-            room173.btnclick("next");
+            invoker.invokeCurrent("btnclick", "next");
             break;
         case "eat":
             if (levels.get("cum").l < 4)
@@ -125,7 +127,7 @@ room173.chatcatch = function (callback) {
         case "next":
             nav.bg("173_trash/bag.jpg");
             g.internal.i++;
-            room173.btnclick("next");
+            invoker.invokeCurrent("btnclick", "next");
             break;
         case "lunch":
             missy.didJob(7, 1, null);
@@ -201,3 +203,5 @@ room173.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(173, room173);

--- a/scripts/room/room174.js
+++ b/scripts/room/room174.js
@@ -2107,3 +2107,5 @@ room174.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(174, room174);

--- a/scripts/room/room175.js
+++ b/scripts/room/room175.js
@@ -876,3 +876,5 @@ room175.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(175, room175);

--- a/scripts/room/room176.js
+++ b/scripts/room/room176.js
@@ -35,7 +35,7 @@ room176.btnclick = function (name) {
             chat(34, 176);
             break;
         case "blackmailFail":
-            room176.chatcatch("oral20");
+            invoker.invokeCurrent("chatcatch", "oral20");
             chat(35, 176);
             break;
         case "kiss":
@@ -107,36 +107,36 @@ room176.btnclick = function (name) {
                 g.internal.chatid = 1002;
                 g.internal.love++;
             }
-            room176.btnclick("drawNext");
+            invoker.invokeCurrent("btnclick", "drawNext");
             break;
         case "pphole":
             g.internal.chatid = 1000;
-            room176.btnclick("drawNext");
+            invoker.invokeCurrent("btnclick", "drawNext");
             break;
         case "pussy":
             if (g.internal.love === 1) {
                 g.internal.love++;
             }
             g.internal.chatid = 1003;
-            room176.btnclick("drawNext");
+            invoker.invokeCurrent("btnclick", "drawNext");
             break;
         case "pussylips":
             if (g.internal.love === 1) {
                 g.internal.love++;
             }
             g.internal.chatid = 1003;
-            room176.btnclick("drawNext");
+            invoker.invokeCurrent("btnclick", "drawNext");
             break;
         case "asshole":
             g.internal.chatid = 1001;
-            room176.btnclick("drawNext");
+            invoker.invokeCurrent("btnclick", "drawNext");
             break;
         case "leg":
             if (g.internal.love < 1) {
                 g.internal.love++;
             }
             g.internal.chatid = 1004;
-            room176.btnclick("drawNext");
+            invoker.invokeCurrent("btnclick", "drawNext");
             break;
         case "drawNext":
             nav.killall();
@@ -174,6 +174,8 @@ room176.btnclick = function (name) {
             break;
     }
 };
+
+invoker.registerRoom(176, room176);
 
 room176.chatcatch = function (callback) {
     switch (callback) {

--- a/scripts/room/room177.js
+++ b/scripts/room/room177.js
@@ -524,3 +524,5 @@ room177.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(177, room177);

--- a/scripts/room/room178.js
+++ b/scripts/room/room178.js
@@ -406,3 +406,5 @@ room178.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(178, room178);

--- a/scripts/room/room180.js
+++ b/scripts/room/room180.js
@@ -1051,3 +1051,5 @@ room180.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(180, room180);

--- a/scripts/room/room181.js
+++ b/scripts/room/room181.js
@@ -1323,3 +1323,5 @@ room181.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(181, room181);

--- a/scripts/room/room182.js
+++ b/scripts/room/room182.js
@@ -354,7 +354,7 @@ room182.chatcatch = function (callback) {
                 '<div id="room182_energy_line" style="background: #20C000; border-radius: 20px; width:100%; height: 100%;" class="resize-height rl-bar"></div>' +
                 '</div>';
             $('#room-buttons').append(line);
-            room182.chatcatch("t1_setenergy");
+            invoker.invokeCurrent("chatcatch", "t1_setenergy");
             break;
         case "t1_setenergy":
             var thisEnergy = gv.get("energy");
@@ -367,7 +367,7 @@ room182.chatcatch = function (callback) {
         case "t1_29":
             gv.mod("energy", -15);
             nav.bg("182_test/" + callback + ".jpg");
-            room182.chatcatch("t1_setenergy");
+            invoker.invokeCurrent("chatcatch", "t1_setenergy");
             if (gv.get("energy") > 0) {
                 chat(58, 182);
                 nav.bg("182_test/" + callback + ".jpg");
@@ -380,7 +380,7 @@ room182.chatcatch = function (callback) {
             break;
         case "t1_31":
             gv.mod("energy", -20);
-            room182.chatcatch("t1_setenergy");
+            invoker.invokeCurrent("chatcatch", "t1_setenergy");
             if (gv.get("energy") > 0) {
                 chat(60, 182);
                 nav.bg("182_test/" + callback + ".jpg");
@@ -393,7 +393,7 @@ room182.chatcatch = function (callback) {
             break;
         case "t1_33":
             gv.mod("energy", -5);
-            room182.chatcatch("t1_setenergy");
+            invoker.invokeCurrent("chatcatch", "t1_setenergy");
             if (gv.get("energy") > 0) {
                 chat(62, 182);
                 nav.bg("182_test/" + callback + ".jpg");
@@ -406,7 +406,7 @@ room182.chatcatch = function (callback) {
             break;
         case "t1_35":
             gv.mod("energy", -10);
-            room182.chatcatch("t1_setenergy");
+            invoker.invokeCurrent("chatcatch", "t1_setenergy");
             if (gv.get("energy") > 0) {
                 chat(64, 182);
                 nav.bg("182_test/" + callback + ".jpg");
@@ -419,7 +419,7 @@ room182.chatcatch = function (callback) {
             break;
         case "t1_37":
             gv.mod("energy", -17);
-            room182.chatcatch("t1_setenergy");
+            invoker.invokeCurrent("chatcatch", "t1_setenergy");
             if (gv.get("energy") > 0) {
                 chat(66, 182);
                 nav.bg("182_test/" + callback + ".jpg");
@@ -432,7 +432,7 @@ room182.chatcatch = function (callback) {
             break;
         case "t1_38":
             gv.mod("energy", -17 );
-            room182.chatcatch("t1_setenergy");
+            invoker.invokeCurrent("chatcatch", "t1_setenergy");
             if (gv.get("energy") > 0) {
                 chat(67, 182);
                 nav.bg("182_test/" + callback + ".jpg");
@@ -445,7 +445,7 @@ room182.chatcatch = function (callback) {
             break;
         case "t1_39":
             gv.mod("energy", -16);
-            room182.chatcatch("t1_setenergy");
+            invoker.invokeCurrent("chatcatch", "t1_setenergy");
             if (gv.get("energy") > 0) {
                 chat(68, 182);
                 nav.bg("182_test/" + callback + ".jpg");
@@ -537,6 +537,8 @@ room182.chatcatch = function (callback) {
             break;
     }
 };
+
+invoker.registerRoom(182, room182);
 
 room182.chat = function (chatID) {
     if (chatID === 1000) {

--- a/scripts/room/room183.js
+++ b/scripts/room/room183.js
@@ -480,3 +480,5 @@ room183.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(183, room183);

--- a/scripts/room/room184.js
+++ b/scripts/room/room184.js
@@ -111,3 +111,5 @@ room184.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(184, room184);

--- a/scripts/room/room185.js
+++ b/scripts/room/room185.js
@@ -130,3 +130,5 @@ room185.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(185, room185);

--- a/scripts/room/room186.js
+++ b/scripts/room/room186.js
@@ -253,3 +253,5 @@ room186.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(186, room186);

--- a/scripts/room/room187.js
+++ b/scripts/room/room187.js
@@ -240,3 +240,5 @@ room187.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(187, room187);

--- a/scripts/room/room193.js
+++ b/scripts/room/room193.js
@@ -288,14 +288,14 @@ room193.btnclick = function (name) {
             char.addtime(61);
             g.popUpNoticeBottom("An hour passes");
             g.internal.step++;
-            room193.btnclick("pic");
+            invoker.invokeCurrent("btnclick", "pic");
             break;
         case "ppic":
             char.addtime(61);
             g.internal.pictures.push(g.internal.events[g.internal.step]);
             g.internal.step++;
             g.internal.totalPics++;
-            room193.btnclick("pic");
+            invoker.invokeCurrent("btnclick", "pic");
             break;
         case "pantyLockpickFail":
             chat(22, 193);
@@ -393,7 +393,7 @@ room193.chatcatch = function (callback) {
             break;
         case "pic0":
             char.settime(13, 30);
-            room193.btnclick("pic");
+            invoker.invokeCurrent("btnclick", "pic");
             break;
         case "picSetup":
             nav.bg("193_afternoon/pic" + g.internal.bg + "_0.webp");
@@ -442,6 +442,8 @@ room193.chatcatch = function (callback) {
             break;
     }
 };
+
+invoker.registerRoom(193, room193);
 
 room193.chat = function (chatID) {
     if (chatID === 900) {

--- a/scripts/room/room195.js
+++ b/scripts/room/room195.js
@@ -104,7 +104,7 @@ room195.chatcatch = function (callback) {
         case "iteration1":
             g.internal.iteration = 1;
             g.internal.key = 7;
-            room195.chatcatch("lock0");
+            invoker.invokeCurrent("chatcatch", "lock0");
             break;
         case "iteration2":
             nav.killall();
@@ -261,3 +261,5 @@ room195.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(195, room195);

--- a/scripts/room/room196.js
+++ b/scripts/room/room196.js
@@ -35,7 +35,7 @@ room196.chatcatch = function (callback) {
                 chat(999, 196);
             }
             else {
-                room196.chatcatch("checkBeforeComplete");
+                invoker.invokeCurrent("chatcatch", "checkBeforeComplete");
             }
             break;
         case "truepay":
@@ -128,6 +128,8 @@ room196.chatcatch = function (callback) {
             break;
     }
 };
+
+invoker.registerRoom(196, room196);
 
 room196.chat = function (chatID) {
     if (chatID === 999) {

--- a/scripts/room/room197.js
+++ b/scripts/room/room197.js
@@ -777,3 +777,5 @@ room197.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(197, room197);

--- a/scripts/room/room198.js
+++ b/scripts/room/room198.js
@@ -326,3 +326,5 @@ room198.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(198, room198);

--- a/scripts/room/room199.js
+++ b/scripts/room/room199.js
@@ -258,3 +258,5 @@ room199.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(199, room199);

--- a/scripts/room/room200.js
+++ b/scripts/room/room200.js
@@ -155,7 +155,7 @@ room200.btnclick = function (name) {
                 char.room(223);
             }
             else
-                room200.chatcatch("selectJob");
+                invoker.invokeCurrent("chatcatch", "selectJob");
         break;
         case "job_0":
         case "job_1":
@@ -179,7 +179,7 @@ room200.btnclick = function (name) {
             else {
                 nav.bg("200_frontOffice/bg.jpg");
                 nav.killall();
-                room200.chatcatch(g.internal.activeCase.callback);
+                invoker.invokeCurrent("chatcatch", g.internal.activeCase.callback);
             }
             break;
         case "case_beaver_end_good":
@@ -334,7 +334,7 @@ room200.chatcatch = function (callback) {
             missy.mod("mood", 20);
             levels.mod("pi", 100);
             missy.caseComplete(5);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_booth_complete_bad":
             missy.caseComplete(5);
@@ -347,14 +347,14 @@ room200.chatcatch = function (callback) {
             break;
         case "case_lostgirl2":
             pic.add("case_lostgirl");
-            room200.chatcatch("case_afterExplaniation");
+            invoker.invokeCurrent("chatcatch", "case_afterExplaniation");
             break;
         case "case_lostgirl_goodend":
             gv.mod("money", 250);
             missy.mod("mood", 20);
             levels.mod("pi", 100);
             missy.caseComplete(6);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_lostgirl_badend":
             missy.caseComplete(6);
@@ -374,7 +374,7 @@ room200.chatcatch = function (callback) {
             levels.mod("pi", 100);
             inv.use("missyusb");
             missy.caseComplete(4);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_trash":
             nav.killall();
@@ -398,7 +398,7 @@ room200.chatcatch = function (callback) {
             break;
         case "case_elijah_start":
             pic.add("case_elijah");
-            room200.chatcatch("case_afterExplaniation");
+            invoker.invokeCurrent("chatcatch", "case_afterExplaniation");
             break;
         case "case_elijah_origin_endBad":
             missy.mod("mood", -40);
@@ -409,14 +409,14 @@ room200.chatcatch = function (callback) {
             gv.mod("money", 100);
             missy.mod("mood", 20);
             missy.caseComplete(15);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_elijah_complete":
             gv.mod("money", 150);
             missy.mod("mood", 20);
             missy.caseComplete(13);
             future.add("case_elijah_complete", 3);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_elijah_completeBad":
             missy.mod("mood", -40);
@@ -428,14 +428,14 @@ room200.chatcatch = function (callback) {
             chat(164, 200);
             break;
         case "case_elijah_boyfriend_start":
-            room200.chatcatch("case_afterExplaniation");
+            invoker.invokeCurrent("chatcatch", "case_afterExplaniation");
             break;
         case "case_elijah_boyfriend_bad":
             sc.startMission("elijah", "elijah");
             sc.startMissionTask("elijah", "elijah", 0);
             missy.set("activeCaseComplete", 0);
             missy.caseComplete(21);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_elijah_boyfriend_good":
             sc.completeMission("elijah", "betray");
@@ -444,7 +444,7 @@ room200.chatcatch = function (callback) {
             gv.mod("money", 350);
             missy.mod("mood", 20);
             missy.caseComplete(21);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_beaver":
             nav.bg("200_frontOffice/case_beaver0.jpg");
@@ -455,7 +455,7 @@ room200.chatcatch = function (callback) {
                 chat(38, 200);
             }
             else {
-                room200.chatcatch("case_afterExplaniation");
+                invoker.invokeCurrent("chatcatch", "case_afterExplaniation");
             }
             break;
         case "case_trash_lockedup":
@@ -469,7 +469,7 @@ room200.chatcatch = function (callback) {
             gv.mod("money", 200);
             missy.mod("mood", 20);
             missy.caseComplete(8);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_trash_badend":
             missy.mod("mood", -50);
@@ -498,7 +498,7 @@ room200.chatcatch = function (callback) {
             gv.mod("money", 75);
             missy.mod("mood", 20);
             missy.caseComplete(9);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_shopping":
             chat(58, 200);
@@ -527,12 +527,12 @@ room200.chatcatch = function (callback) {
             gv.mod("money", 250);
             missy.mod("mood", 20);
             missy.caseComplete(12);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_complete_end":
             if (g.gethourdecimal() < 10) {
                 g.internal = { caseList: missy.getcases(), activeCase: null };
-                room200.chatcatch("selectJob");
+                invoker.invokeCurrent("chatcatch", "selectJob");
             }
             else if (g.dt.getDay === 5)
                 char.room(196);
@@ -598,7 +598,7 @@ room200.chatcatch = function (callback) {
             chat(26, 200);
             break;
         case "missyBtnClick":
-            room200.btnclick("missy");
+            invoker.invokeCurrent("btnclick", "missy");
             break;
         case "bimbopantiesWearing":
             if (cl.c.panties === "bi")
@@ -625,7 +625,7 @@ room200.chatcatch = function (callback) {
             sc.startMission("holly", "case");
             sc.startMission("molly", "case");
             sc.startMission("dolly", "case");
-            room200.chatcatch("case_afterExplaniation");
+            invoker.invokeCurrent("chatcatch", "case_afterExplaniation");
             break;
         case "case_beaver_end0":
             nav.bg("200_frontOffice/case_beaver0.jpg");
@@ -671,7 +671,7 @@ room200.chatcatch = function (callback) {
             sc.startMission("jeffery", "work");
             sc.modSecret("jeffery", 100);
 
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_beaver_end_bad":
             missy.mod("mood", -40);
@@ -716,12 +716,12 @@ room200.chatcatch = function (callback) {
             chat(128, 200);
             break;
         case "case_farm_start":
-            room200.chatcatch("case_afterExplaniation");
+            invoker.invokeCurrent("chatcatch", "case_afterExplaniation");
             break;
         case "case_farm_badend":
             missy.set("activeCaseComplete", 0);
             missy.caseComplete(19);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_sewer":
             nav.kill();
@@ -729,13 +729,13 @@ room200.chatcatch = function (callback) {
             chat(160, 200);
             break;
         case "case_sewer_start":
-            room200.chatcatch("case_afterExplaniation");
+            invoker.invokeCurrent("chatcatch", "case_afterExplaniation");
             break;
         case "case_sewer_end":
             cl.add("dress", "robe");
             gv.mod("money", 250);
             missy.caseComplete(20);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_cult":
             chat(172, 200);
@@ -746,40 +746,40 @@ room200.chatcatch = function (callback) {
             break;
         case "case_saveralph_start":
             future.add("case_saveralph", 1);
-            room200.chatcatch("case_afterExplaniation");
+            invoker.invokeCurrent("chatcatch", "case_afterExplaniation");
             break;
         case "case_saveralph_goodend":
             gv.mod("money", 50);
             missy.mod("mood", 100);
             missy.caseComplete(7);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_saveralph_badend":
             missy.mod("mood", -50);
             missy.caseComplete(7);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_canival_end":
             gv.mod("money", 500);
             missy.mod("mood", 100);
             missy.caseComplete(18);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_dam_start":
             inv.addMulti("soda", 3);
             future.add("case_dam", 6 - g.dt.getDay() - 1);
             gv.set("mapopen", true);
-            room200.chatcatch("case_afterExplaniation");
+            invoker.invokeCurrent("chatcatch", "case_afterExplaniation");
             break;
         case "case_cult_start":
-            room200.chatcatch("case_afterExplaniation");
+            invoker.invokeCurrent("chatcatch", "case_afterExplaniation");
             break;
         case "case_dam_end":
             future.kill("case_dam");
             gv.mod("money", 100);
             missy.mod("mood", 100);
             missy.caseComplete(16);
-            room200.chatcatch("case_complete_end");
+            invoker.invokeCurrent("chatcatch", "case_complete_end");
             break;
         case "case_dam_end_bad":
             future.kill("case_dam");
@@ -799,7 +799,7 @@ room200.chatcatch = function (callback) {
                 chat(157, 200);
             }
             else {
-                room200.chatcatch("case_ranchEnd");
+                invoker.invokeCurrent("chatcatch", "case_ranchEnd");
             }
             break;
         case "case_ranchEnd":
@@ -819,7 +819,7 @@ room200.chatcatch = function (callback) {
             } 
             g.map.jars = JSON.parse(future.st[future.st.findIndex(item => item.name.includes("emptyjar"))].name);
             g.map.hole = parseInt(future.st.find(i => i.name.includes("room329hole_"))?.name.replace("room329hole_", "") ?? "-1");
-            room329.btnclick("stall_backDraw");
+            invoker.invoke(329, "btnclick", "stall_backDraw");
             $.each(g.map.jars, function (i, v) {
                 if (v.t > 0)
                     inv.addMulti(v.n, v.t);
@@ -828,6 +828,8 @@ room200.chatcatch = function (callback) {
             break;
     };
 };
+
+invoker.registerRoom(200, room200);
 
 room200.chat = function (chatID) {
     if (chatID === 999) {

--- a/scripts/room/room201.js
+++ b/scripts/room/room201.js
@@ -164,3 +164,5 @@ room201.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(201, room201);

--- a/scripts/room/room202.js
+++ b/scripts/room/room202.js
@@ -1052,3 +1052,5 @@ room202.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(202, room202);

--- a/scripts/room/room203.js
+++ b/scripts/room/room203.js
@@ -58,6 +58,8 @@ room203.main = function () {
     }
 };
 
+invoker.registerRoom(203, room203);
+
 room203.btnclick = function (name) {
     
     switch (name) {

--- a/scripts/room/room204.js
+++ b/scripts/room/room204.js
@@ -40,7 +40,7 @@ room204.countdown = function (timer) {
             g.roomTimeout = setTimeout(function () { room204.countdown(timer) }, 1000);
         }
         else {
-            room204.chatcatch("endgame");
+            invoker.invokeCurrent("chatcatch", "endgame");
         }
     }
 };
@@ -59,7 +59,7 @@ room204.btnclick = function (name) {
             $('.room-btn[data-name=' + name + ']').addClass("room-204fail");
         }
         if (g.pass.length === 0) {
-            room204.chatcatch("endgame");
+            invoker.invokeCurrent("chatcatch", "endgame");
             ////gv.mod("money", 60);
             ////g.roomTimeout = null;
             ////if (sc.getstep("missy") === 5)
@@ -95,6 +95,8 @@ room204.btnclick = function (name) {
         }
     }
 };
+
+invoker.registerRoom(204, room204);
 
 room204.startGame = function () {
     var thisArousal = gv.get("arousal");

--- a/scripts/room/room205.js
+++ b/scripts/room/room205.js
@@ -340,3 +340,5 @@ room205.chat = function (chatID) {
         return [];
 };
 
+invoker.registerRoom(205, room205);
+

--- a/scripts/room/room206.js
+++ b/scripts/room/room206.js
@@ -118,7 +118,7 @@ room206.main = function () {
             ]
         },
     ]
-    room206.chatcatch("questions");
+    invoker.invokeCurrent("chatcatch", "questions");
     $('#room_footer').hide();
 };
 
@@ -140,7 +140,7 @@ room206.chatcatch = function (callback) {
                 if (g.pass.q < g.internal.length) {
                     $('#q206').html((g.pass.q === 0 ? "" : g.pass.q.toString() + ". ") + g.internal[g.pass.q].t);
                     $.each(g.internal[g.pass.q].b, function (i, v) {
-                        $('#q206').append('<div><button style="background:none; border:none; margin-top:10px; display:block; margin-left:20px;" class="q206-btn" data-a="' + i + '">' +
+                        $('#q206').append('<div><button style="background:none; border:none; margin-top:10px; display:block; margin-left:20px;" class="q206-btn room-nativeChoice" data-a="' + i + '">' +
                             '<img src="./images/room/206_questions/' + v.t + '" style="height: ' + (100 * g.ratio) + 'px; width: ' + (800 * g.ratio) + 'px;" />' +
                             '</button> </div>');
                     });
@@ -149,7 +149,7 @@ room206.chatcatch = function (callback) {
                         var thisEntry = parseInt($(this).data('a'));
                         g.internal[g.pass.q].b[thisEntry].a = true;
                         g.pass.q++;
-                        room206.chatcatch("questions");
+                        invoker.invokeCurrent("chatcatch", "questions");
                     });
                 }
                 else {
@@ -534,6 +534,8 @@ room206.chatcatch = function (callback) {
         }
     });
 };
+
+invoker.registerRoom(206, room206);
 
 room206.chat = function (chatID) {
     var cArray = [

--- a/scripts/room/room207.js
+++ b/scripts/room/room207.js
@@ -218,3 +218,5 @@ room207.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(207, room207);

--- a/scripts/room/room208.js
+++ b/scripts/room/room208.js
@@ -35,18 +35,18 @@ room208.btnclick = function (name) {
                 m = 3;
             nav.modbutton(m + "t", "208_red/t" + m + "_1.png", null, null);
             g.internal.step = m;
-            g.roomTimeout = setTimeout(function () { room208.btnclick("tj") }, g.internal.timex);
+            g.roomTimeout = setTimeout(function () { invoker.invokeCurrent("btnclick", "tj"); }, g.internal.timex);
             break;
         case "tj":
             nav.modbutton(g.internal.step + "t", "208_red/t0.png", null, null);
-            g.roomTimeout = setTimeout(function () { room208.btnclick("tk") }, 200);
+            g.roomTimeout = setTimeout(function () { invoker.invokeCurrent("btnclick", "tk"); }, 200);
             break;
         case "tk":
-            g.roomTimeout = setTimeout(function () { room208.btnclick("th") }, (Math.random() * 900) + 300);
-            room208.btnclick("thit");
+            g.roomTimeout = setTimeout(function () { invoker.invokeCurrent("btnclick", "th"); }, (Math.random() * 900) + 300);
+            invoker.invokeCurrent("btnclick", "thit");
             break;
         case "tpause":
-            g.roomTimeout = setTimeout(function () { room208.btnclick("th") }, (Math.random() * 900) + 300);
+            g.roomTimeout = setTimeout(function () { invoker.invokeCurrent("btnclick", "th"); }, (Math.random() * 900) + 300);
             break;
         case "1t":
         case "2t":
@@ -64,18 +64,18 @@ room208.btnclick = function (name) {
                     g.internal.step = 0;
                     g.internal.bh;
                     clearTimeout(g.roomTimeout);
-                    g.roomTimeout = setTimeout(function () { room208.btnclick("tpause") }, 500);
+                    g.roomTimeout = setTimeout(function () { invoker.invokeCurrent("btnclick", "tpause"); }, 500);
                 }
                 else {
                     clearTimeout(g.roomTimeout);
                     clearTimeout(g.roomTimeout2);
                     g.pass.second = true;
-                    room208.chatcatch("reset");
+                    invoker.invokeCurrent("chatcatch", "reset");
                     chat(21, 208);
                 }
             }
             else if (g.internal.bh) {
-                room208.btnclick("thit");
+                invoker.invokeCurrent("btnclick", "thit");
             }
             break;
         case "thit":
@@ -85,7 +85,7 @@ room208.btnclick = function (name) {
             if (energyx < 2) {
                 clearTimeout(g.roomTimeout);
                 clearTimeout(g.roomTimeout2);
-                room208.chatcatch("reset");
+                invoker.invokeCurrent("chatcatch", "reset");
                 chat(22, 208);
             }
             else {
@@ -94,7 +94,7 @@ room208.btnclick = function (name) {
                 var topx = 1017 - heightx;
                 $(".room-img[data-name='tb']").css({ "top": (topx * g.ratio) + "px", "height": (heightx * g.ratio) + "px" });
                 nav.modbutton("tballs", "208_red/ts1.png", null, null);
-                g.roomTimeout2 = setTimeout(function () { room208.btnclick("tResetbutton") }, 500);
+                g.roomTimeout2 = setTimeout(function () { invoker.invokeCurrent("btnclick", "tResetbutton"); }, 500);
             }
             break;
         case "tResetbutton":
@@ -165,7 +165,7 @@ room208.btnclick = function (name) {
             }
 
             else {
-                g.roomTimeout = setTimeout(function () { room208.btnclick("jerkIncrease"); }, 20);
+                g.roomTimeout = setTimeout(function () { invoker.invokeCurrent("btnclick", "jerkIncrease"); }, 20);
             }
             break;
         case "jerkStart":
@@ -205,7 +205,7 @@ room208.btnclick = function (name) {
                 "height": 1080,
                 "image": "208_red/jerk.gif"
             }, 208);
-            room208.btnclick("jerkIncrease");
+            invoker.invokeCurrent("btnclick", "jerkIncrease");
             break;
         case "jerkStop":
             clearTimeout(g.roomTimeout);
@@ -213,7 +213,7 @@ room208.btnclick = function (name) {
                 g.internal.n++;
                 if (g.internal.n < 3) {
                     chat(27, 208);
-                    room208.btnclick("jerkReset");
+                    invoker.invokeCurrent("btnclick", "jerkReset");
                 }
                 else {
                     g.pass.third = true;
@@ -222,7 +222,7 @@ room208.btnclick = function (name) {
             }
             else {
                 chat(28, 208);
-                room208.btnclick("jerkReset");
+                invoker.invokeCurrent("btnclick", "jerkReset");
             }
 
 
@@ -265,7 +265,7 @@ room208.chatcatch = function (callback) {
         case "feet2a":
             g.pass.h1 = true;
             g.internal = "foot";
-            room208.chatcatch("feet2");
+            invoker.invokeCurrent("chatcatch", "feet2");
             break;
         case "feet2":
             nav.killall();
@@ -403,7 +403,7 @@ room208.chatcatch = function (callback) {
         case "t4a":
             g.pass.h2 = true;
             g.pass.hard2 = true;
-            room208.chatcatch("t4");
+            invoker.invokeCurrent("chatcatch", "t4");
             break;
         case "t4":
             nav.bg("208_red/t4.jpg");
@@ -479,7 +479,7 @@ room208.chatcatch = function (callback) {
                 "image": "208_red/tb.jpg"
             }, 208);
             //$('#room-buttons').append('<img src="./images/room/' + thisImage + '" class="' + classes + '" data-name="' + btn.name + '" data-room="' + roomNum + '" title="' + (("title" in btn) ? btn.title : "") + charAttr + '" style="width:' + btnWidth + 'px; height:' + btnHeight + 'px; top:' + top + 'px; left:' + left + 'px;" />');
-            g.roomTimeout = setTimeout(function () { room208.btnclick("th") }, (Math.random() * 500) + 500);
+            g.roomTimeout = setTimeout(function () { invoker.invokeCurrent("btnclick", "th"); }, (Math.random() * 500) + 500);
             break;
         case "tri1":
             $('.room-left').hide();
@@ -517,12 +517,12 @@ room208.chatcatch = function (callback) {
             break;
         case "jerk0":
             g.internal = { n: 0, i: 0, c: 0, t: 0, h: 0, easy: true };
-            room208.chatcatch("jerk");
+            invoker.invokeCurrent("chatcatch", "jerk");
             break;
         case "jerk1":
             g.internal = { n: 0, i: 0, c: 0, t: 0, h: 0, easy: false };
             g.pass.hard3 = true;
-            room208.chatcatch("jerk");
+            invoker.invokeCurrent("chatcatch", "jerk");
             break;
         case "jerk":
             nav.killall();
@@ -625,6 +625,8 @@ room208.chatcatch = function (callback) {
             break;
     }
 };
+
+invoker.registerRoom(208, room208);
 
 room208.chat = function (chatID) {
     var cArray = [

--- a/scripts/room/room209.js
+++ b/scripts/room/room209.js
@@ -419,3 +419,5 @@ room209.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(209, room209);

--- a/scripts/room/room210.js
+++ b/scripts/room/room210.js
@@ -194,3 +194,5 @@ room210.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(210, room210);

--- a/scripts/room/room211.js
+++ b/scripts/room/room211.js
@@ -94,7 +94,7 @@ room211.main = function () {
             nav.bg("211_meeting/change.jpg");
         }
         else
-            room211.btnclick("drawGroups");
+            invoker.invokeCurrent("btnclick", "drawGroups");
     }
     else if (sissy.st[10].ach) {
         if (cl.c.shirt !== "sq") {
@@ -108,7 +108,7 @@ room211.main = function () {
             return;
         }
         else
-            room211.btnclick("drawGroups");
+            invoker.invokeCurrent("btnclick", "drawGroups");
     }
     else {
         nav.bg("211_meeting/filled.jpg");
@@ -490,8 +490,8 @@ room211.chatcatch = function (callback) {
             char.room(203);
             break;
         case "initviewtrainee":
-            room211.btnclick("initviewtrainee");
-            room211.btnclick("drawGroups");
+            invoker.invokeCurrent("btnclick", "initviewtrainee");
+            invoker.invokeCurrent("btnclick", "drawGroups");
             break;
         case "moveit":
             g.pass = "moveitMoveIt";
@@ -945,3 +945,5 @@ room211.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(211, room211);

--- a/scripts/room/room212.js
+++ b/scripts/room/room212.js
@@ -41,7 +41,7 @@ room212.main = function () {
             chat(0, 212);
             break;
         default:
-            room212.btnclick("resetview");
+            invoker.invokeCurrent("btnclick", "resetview");
             chat(9, 212);
             break;
     }
@@ -91,7 +91,7 @@ room212.btnclick = function (name) {
             break;
         case "sportyCock1":
             sc.modLevel("sporty", 20, 3);
-            room212.btnclick("resetview");
+            invoker.invokeCurrent("btnclick", "resetview");
             chat(1001, 212);
             break;
         case "resetview":
@@ -142,7 +142,7 @@ room212.btnclick = function (name) {
             else {
                 nav.killbutton("nextCock");
                 nav.killbutton("snacks");
-                room212.chatcatch("d" + g.rand(0, 4));
+                invoker.invokeCurrent("chatcatch", "d" + g.rand(0, 4));
             }
             g.internal.counter++;
             break;
@@ -222,10 +222,10 @@ room212.chatcatch = function (callback) {
             break;
         
         case "sportyCock0":
-            room212.chatcatch("s" + g.internal.num);
+            invoker.invokeCurrent("chatcatch", "s" + g.internal.num);
             break;
         case "nextCock":
-            room212.btnclick("resetview");
+            invoker.invokeCurrent("btnclick", "resetview");
             nav.wait("nextCock");
             break;
         case "start":
@@ -242,7 +242,7 @@ room212.chatcatch = function (callback) {
             sc.select("sporty", "212_gloryhole/icon_sporty.png", 1);
             break;
         case "resetview":
-            room212.btnclick("resetview");
+            invoker.invokeCurrent("btnclick", "resetview");
             break;
         case "endEvent":
             cl.undo();
@@ -395,3 +395,5 @@ room212.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(212, room212);

--- a/scripts/room/room213.js
+++ b/scripts/room/room213.js
@@ -77,7 +77,7 @@ room213.btnclick = function (name) {
                 sc.completeMissionTask("p", "pink", 2);
                 nav.killall();
                 nav.bg("213_pink/bgc.jpg");
-                room213.btnclick("drawCloseupBgChar");
+                invoker.invokeCurrent("btnclick", "drawCloseupBgChar");
 
                 if (missy.get("pinkEntrance") === 0) {
                     nav.button({
@@ -95,7 +95,7 @@ room213.btnclick = function (name) {
             else {
                 nav.killall();
                 nav.bg("213_pink/bgc.jpg");
-                room213.btnclick("drawCloseupBgChar");
+                invoker.invokeCurrent("btnclick", "drawCloseupBgChar");
                 nav.button({
                     "type": "img",
                     "name": "g",
@@ -154,7 +154,7 @@ room213.chatcatch = function (callback) {
             }, 213);
             break;
         case "g1":
-            room213.btnclick("drawCloseupBgChar");
+            invoker.invokeCurrent("btnclick", "drawCloseupBgChar");
             nav.killbutton("g");
             nav.button({
                 "type": "img",
@@ -169,7 +169,7 @@ room213.chatcatch = function (callback) {
             break;
         case "_0":
             nav.killall();
-            room213.btnclick("drawCloseupBgChar");
+            invoker.invokeCurrent("btnclick", "drawCloseupBgChar");
             if (sc.getMissionTask("spanky", "shop", 1).notStarted) {
                 sc.completeMissionTask("spanky", "shop", 1);
                 nav.button({
@@ -184,7 +184,7 @@ room213.chatcatch = function (callback) {
                 chat(36, 213);
             }
             else {
-                room213.chatcatch("_0_" + g.rand(0, 3));
+                invoker.invokeCurrent("chatcatch", "_0_" + g.rand(0, 3));
             }
             return;
         case "_0_0":
@@ -257,8 +257,8 @@ room213.chatcatch = function (callback) {
             break;
         case "_1":
             nav.killall();
-            room213.btnclick("drawCloseupBgChar");
-            room213.chatcatch("_1_" + g.rand(0, 3));
+            invoker.invokeCurrent("btnclick", "drawCloseupBgChar");
+            invoker.invokeCurrent("chatcatch", "_1_" + g.rand(0, 3));
             break;
         case "_1_0":
             nav.button({
@@ -299,8 +299,8 @@ room213.chatcatch = function (callback) {
         case "_2":
             nav.killall();
             nav.bg("213_pink/bgc.jpg");
-            room213.btnclick("drawCloseupBgChar");
-            room213.chatcatch("_2_" + g.rand(0, 3));
+            invoker.invokeCurrent("btnclick", "drawCloseupBgChar");
+            invoker.invokeCurrent("chatcatch", "_2_" + g.rand(0, 3));
             break;
         case "_2_0":
             nav.button({
@@ -371,7 +371,7 @@ room213.chatcatch = function (callback) {
         case "_3":
             nav.killall();
             nav.bg("213_pink/bgc.jpg");
-            room213.btnclick("drawCloseupBgChar");
+            invoker.invokeCurrent("btnclick", "drawCloseupBgChar");
             gv.mod("energy", -33);
             gv.mod("money", 25);
             gv.mod("pink", 1);
@@ -439,7 +439,7 @@ room213.chatcatch = function (callback) {
                         "title": "Free Use Slut"
                     }, 171);
                 }
-            room171.btnclick("fuckers");
+            invoker.invoke(171, "btnclick", "fuckers");
             nav.button({
                 "type": "btn",
                 "name": "p",
@@ -904,3 +904,5 @@ room213.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(213, room213);

--- a/scripts/room/room214.js
+++ b/scripts/room/room214.js
@@ -275,3 +275,5 @@ room214.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(214, room214);

--- a/scripts/room/room215.js
+++ b/scripts/room/room215.js
@@ -482,3 +482,5 @@ room215.chat = function (chatID) {
     else
         return [];
 }; 
+
+invoker.registerRoom(215, room215);

--- a/scripts/room/room216.js
+++ b/scripts/room/room216.js
@@ -7,7 +7,7 @@ room216.main = function () {
         chat(0, 216);
     }
     else {
-        room216.chatcatch("cumRoom");
+        invoker.invokeCurrent("chatcatch", "cumRoom");
         if (g.internal
             && sc.getMissionTask("zoey", "friends", 2).complete
             && sc.getMissionTask("zoey", "cheating", 3).notStarted) {
@@ -295,3 +295,5 @@ room216.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(216, room216);

--- a/scripts/room/room217.js
+++ b/scripts/room/room217.js
@@ -37,7 +37,7 @@ room217.chatcatch = function (callback) {
             break;
         case "disrobeVoluntary":
             levels.mod("sub", 20);
-            room217.chatcatch("disrobe");
+            invoker.invokeCurrent("chatcatch", "disrobe");
             break;
         case "disrobe":
             nav.bg("217_punish/punishStart.jpg");
@@ -88,7 +88,7 @@ room217.chatcatch = function (callback) {
             break;
         case "punishmentEndDress":
             cl.undo();
-            room217.chatcatch("punishmentEnd");
+            invoker.invokeCurrent("chatcatch", "punishmentEnd");
             break;
         case "punishmentEndCheckEvent":
             if (g.pass === "lic") {
@@ -355,3 +355,5 @@ room217.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(217, room217);

--- a/scripts/room/room218.js
+++ b/scripts/room/room218.js
@@ -264,3 +264,5 @@ room218.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(218, room218);

--- a/scripts/room/room219.js
+++ b/scripts/room/room219.js
@@ -8,7 +8,7 @@ room219.main = function () {
         chat(0, 219);
     }
     else {
-        room219.btnclick("home");
+        invoker.invokeCurrent("btnclick", "home");
     }
 };
 
@@ -67,10 +67,10 @@ room219.btnclick = function (name) {
                     "image": missy.st[18].c === 0 ? "file6.png" : "file6Unlock.png"
                 },
             ];
-            room219.btnclick("makeScreen");
+            invoker.invokeCurrent("btnclick", "makeScreen");
             break;
         case "home":
-            room219.chatcatch("start");
+            invoker.invokeCurrent("chatcatch", "start");
             break;
         case "hypno1":
             nav.killall();
@@ -87,7 +87,7 @@ room219.btnclick = function (name) {
             g.roomTimeout = setTimeout(function () {
                 levels.mod("sub", 50);
                 chat(6, 219);
-                room219.btnclick("hypnoComplete");
+                invoker.invokeCurrent("btnclick", "hypnoComplete");
             }, 7000);
             break;
         case "hypno2":
@@ -132,7 +132,7 @@ room219.btnclick = function (name) {
             }
             g.roomTimeout = setTimeout(function () {
                 chat(hchatid, 219);
-                room219.btnclick("hypnoComplete");
+                invoker.invokeCurrent("btnclick", "hypnoComplete");
             }, 3000);
             break;
         case "hypno5":
@@ -155,7 +155,7 @@ room219.btnclick = function (name) {
                 }
                 g.roomTimeout = setTimeout(function () {
                     chat(12, 219);
-                    room219.btnclick("hypnoComplete");
+                    invoker.invokeCurrent("btnclick", "hypnoComplete");
                 }, 3000);
             }
             else {
@@ -172,7 +172,7 @@ room219.btnclick = function (name) {
                 g.popUpNotice("You cock got smaller. ");
                 g.roomTimeout = setTimeout(function () {
                     chat(13, 219);
-                    room219.btnclick("hypnoComplete");
+                    invoker.invokeCurrent("btnclick", "hypnoComplete");
                 }, 6000);
             }
             break;
@@ -218,7 +218,7 @@ room219.chatcatch = function (callback) {
                     "image": "records.png"
                 },
             ];
-            room219.btnclick("makeScreen");
+            invoker.invokeCurrent("btnclick", "makeScreen");
             break;
         case "widescreen":
             if (missy.get("uniform") > 2)
@@ -228,7 +228,7 @@ room219.chatcatch = function (callback) {
             break;
         case "missyHate":
             missy.mod("mood", -10);
-            room219.chatcatch("start");
+            invoker.invokeCurrent("chatcatch", "start");
             break;
         case "snapout":
             nav.killall();
@@ -395,3 +395,5 @@ room219.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(219, room219);

--- a/scripts/room/room220.js
+++ b/scripts/room/room220.js
@@ -231,3 +231,5 @@ room220.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(220, room220);

--- a/scripts/room/room221.js
+++ b/scripts/room/room221.js
@@ -120,21 +120,21 @@ room221.btnclick = function (name) {
                 { n: "notes", i: "notes.png" },
                 { n: "pics", i: "pics.png" }
             ];
-            room221.btnclick("drawScreen");
+            invoker.invokeCurrent("btnclick", "drawScreen");
             break;
         case "notes":
             g.internal = {
                 b: "main",
                 i: "notes.jpg"
             };
-            room221.btnclick("drawBG");
+            invoker.invokeCurrent("btnclick", "drawBG");
             break;
         case "sch":
             g.internal = {
                 b: "main",
                 i: "sch.jpg"
             };
-            room221.btnclick("drawBG");
+            invoker.invokeCurrent("btnclick", "drawBG");
             $.each(g.pass.events, function (i, v) {
                 nav.t({
                     type: "img",
@@ -161,7 +161,7 @@ room221.btnclick = function (name) {
                 { n: "pic9", i: "img9.png" },
                 { n: "pic10", i: "img10.png" },
             ];
-            room221.btnclick("drawScreen");
+            invoker.invokeCurrent("btnclick", "drawScreen");
             break;
         case "pic1":
         case "pic2":
@@ -177,7 +177,7 @@ room221.btnclick = function (name) {
                 b: "pics",
                 i: name + ".jpg"
             };
-            room221.btnclick("drawBG");
+            invoker.invokeCurrent("btnclick", "drawBG");
             break;
         case "passtime":
             nav.killall();
@@ -192,7 +192,7 @@ room221.btnclick = function (name) {
                     chat(22, 221);
                 }
                 else {
-                    room221.btnclick(g.pass.events[0].btnclick);
+                    invoker.invokeCurrent("btnclick", g.pass.events[0].btnclick);
                 }
 
             }
@@ -328,7 +328,7 @@ room221.chatcatch = function (callback) {
                 "height": 233,
                 "image": "221_recip/passtime.png"
             }, 221);
-            room221.btnclick("main");
+            invoker.invokeCurrent("btnclick", "main");
             break;
         case "lunch":
             missy.didJob(3, 1, null);
@@ -378,12 +378,14 @@ room221.chatcatch = function (callback) {
             g.pass.t++;
             if (g.pass.events.length > 0)
                 g.pass.events.splice(0, 1);
-            room221.chatcatch("start");
+            invoker.invokeCurrent("chatcatch", "start");
             break;
         default:
             break;
     }
 };
+
+invoker.registerRoom(221, room221);
 
 room221.chat = function (chatID) {
     if (chatID === 999) {

--- a/scripts/room/room222.js
+++ b/scripts/room/room222.js
@@ -119,7 +119,7 @@ room222.btnclick = function (name) {
             chat(30, 222);
             break;
         case "case-2-records":
-            room222.chatcatch("case-2-records");
+            invoker.invokeCurrent("chatcatch", "case-2-records");
             break;
         case "case-3-1":
             nav.killall();
@@ -190,7 +190,7 @@ room222.chatcatch = function (callback) {
             break;
         case "case0-end":
             levels.mod("pi", 20); 
-            room222.chatcatch("lunch");
+            invoker.invokeCurrent("chatcatch", "lunch");
             break;
         case "case0-2-bj":
             if (cl.appearance() < 2)
@@ -710,3 +710,5 @@ room222.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(222, room222);

--- a/scripts/room/room223.js
+++ b/scripts/room/room223.js
@@ -434,3 +434,5 @@ room223.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(223, room223);

--- a/scripts/room/room224.js
+++ b/scripts/room/room224.js
@@ -27,7 +27,7 @@ room224.btnclick = function (name) {
     switch (name) {
         case "skip":
             nav.kill();
-            room224.chatcatch("endlunch");
+            invoker.invokeCurrent("chatcatch", "endlunch");
             break;
         case "punish":
             nav.killall();
@@ -35,7 +35,7 @@ room224.btnclick = function (name) {
             chat(1, 224);
             break;
         case "mom":
-            room224.btnclick("drawbg");
+            invoker.invokeCurrent("btnclick", "drawbg");
             nav.button({
                 "type": "img",
                 "name": "fg",
@@ -48,7 +48,7 @@ room224.btnclick = function (name) {
             chat(1000, 224);
             break;
         case "janice":
-            room224.btnclick("drawbg");
+            invoker.invokeCurrent("btnclick", "drawbg");
             nav.button({
                 "type": "img",
                 "name": "fg",
@@ -61,7 +61,7 @@ room224.btnclick = function (name) {
             chat(999, 224);
             break;
         case "elijah":
-            room224.btnclick("drawbg");
+            invoker.invokeCurrent("btnclick", "drawbg");
             nav.button({
                 "type": "img",
                 "name": "fg",
@@ -74,11 +74,11 @@ room224.btnclick = function (name) {
             chat(998, 224);
             break;
         case "zoey":
-            room224.btnclick("drawbg");
+            invoker.invokeCurrent("btnclick", "drawbg");
             chat(5, 224);
             break;
         case "envy":
-            room224.btnclick("drawbg");
+            invoker.invokeCurrent("btnclick", "drawbg");
             nav.button({
                 "type": "img",
                 "name": "fg",
@@ -141,11 +141,11 @@ room224.chatcatch = function (callback) {
             break;
         case "endlunchEnergy":
             gv.mod("energy", 50);
-            room224.chatcatch("endlunch");
+            invoker.invokeCurrent("chatcatch", "endlunch");
             break;
         case "endlunchPunish":
             gv.mod("energy", -20);
-            room224.chatcatch("endlunch");
+            invoker.invokeCurrent("chatcatch", "endlunch");
             break;
         case "standInCorner":
             nav.bg("224_lunch/punish0.jpg");
@@ -153,7 +153,7 @@ room224.chatcatch = function (callback) {
         case "eatpussy":
             nav.kill();
             levels.oral(3, "f", "envy", false);
-            nav.bg("224_lunch/envy1.jpg"); 
+            nav.bg("224_lunch/envy1.webp"); 
             break;
         case "ceciliabj":
             nav.kill();
@@ -412,3 +412,5 @@ room224.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(224, room224);

--- a/scripts/room/room225.js
+++ b/scripts/room/room225.js
@@ -420,3 +420,5 @@ room225.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(225, room225);

--- a/scripts/room/room226.js
+++ b/scripts/room/room226.js
@@ -419,8 +419,8 @@ room226.main = function () {
     else
         setTimeout(function () { $("#room_footer").hide(); }, 200);
 
-    room226.btnclick("drawMap");
-    room226.btnclick("midSave");
+    invoker.invokeCurrent("btnclick", "drawMap");
+    invoker.invokeCurrent("btnclick", "midSave");
 }; 
 
 room226.btnclick = function (name) {
@@ -607,15 +607,15 @@ room226.btnclick = function (name) {
             g.map.id = g.map.l[g.map.id].l;
             g.map.l[g.map.id].v = true;
             gv.mod("energy", -2);
-            room226.btnclick("drawMap");
-            room226.btnclick("midSave");
+            invoker.invokeCurrent("btnclick", "drawMap");
+            invoker.invokeCurrent("btnclick", "midSave");
             break;
         case "right":
             g.map.id = g.map.l[g.map.id].r;
             g.map.l[g.map.id].v = true;
             gv.mod("energy", -2);
-            room226.btnclick("drawMap");
-            room226.btnclick("midSave");
+            invoker.invokeCurrent("btnclick", "drawMap");
+            invoker.invokeCurrent("btnclick", "midSave");
             break;
         case "back":
             if (g.map.id === 0) {
@@ -625,16 +625,16 @@ room226.btnclick = function (name) {
             else {
                 g.map.id = g.map.l[g.map.id].b;
                 gv.mod("energy", -2);
-                room226.btnclick("drawMap");
-                room226.btnclick("midSave");
+                invoker.invokeCurrent("btnclick", "drawMap");
+                invoker.invokeCurrent("btnclick", "midSave");
             }
             break;
         case "backRoom":
             nav.killbutton("redbox");
             nav.killbutton("backRoom");
             g.map.id = 0;
-            room226.btnclick("drawMap");
-            room226.btnclick("midSave");
+            invoker.invokeCurrent("btnclick", "drawMap");
+            invoker.invokeCurrent("btnclick", "midSave");
             break;
         case "midSave":
             var mi;
@@ -694,7 +694,7 @@ room226.chatcatch = function (callback) {
             nav.bg("225_sewer/slime5.jpg");
             break;
         case "slimereset":
-            room226.btnclick("drawMap");
+            invoker.invokeCurrent("btnclick", "drawMap");
             gv.mod("fuckPussy", 1);
             cl.doCum(false);
             break;
@@ -871,3 +871,5 @@ room226.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(226, room226);

--- a/scripts/room/room227.js
+++ b/scripts/room/room227.js
@@ -75,7 +75,7 @@ room227.btnclick = function (name) {
             tEnemy.changeEnergy(energyGains, null, null);
             g.popUpNoticeBottom("You gained " + energyGains + " energy. ");
             g.roomTimeout = setTimeout(function () {
-                room227.chatcatch("counterAction");
+                invoker.invokeCurrent("chatcatch", "counterAction");
             }, g.fight.fighttimer);
             break;
         case "lb_blockkick":
@@ -129,7 +129,7 @@ room227.btnclick = function (name) {
             }
             tEnemy.drawEnemy();
             g.roomTimeout = setTimeout(function () {
-                room227.chatcatch("main");
+                invoker.invokeCurrent("chatcatch", "main");
             }, g.fight.fighttimer);
             break;
         case "lb_slut":
@@ -152,11 +152,7 @@ room227.btnclick = function (name) {
                     //g.fight.e[0].p = "bjpose";
                     //tEnemy.drawEnemy();
                     //tEnemy.changeEnergy(null, -10, { t: "grapple", me: false });
-                    //g.roomTimeout = setTimeout(function () {
-                    //    tEnemy.drawChar("bjpose");
-                    //    room227.chatcatch("main-tain");
-                    //}, g.fight.fighttimer);
-                    room227.btnclick("lb_submitbj");
+                    invoker.invokeCurrent("btnclick", "lb_submitbj");
                 }, g.fight.fightsex);
             }
             else {
@@ -166,7 +162,7 @@ room227.btnclick = function (name) {
                 tEnemy.changeEnergy(null, -10, { t: "grapple", me: false });
                 g.roomTimeout = setTimeout(function () {
                     tEnemy.drawChar("bjpose");
-                    room227.chatcatch("main-tain");
+                    invoker.invokeCurrent("chatcatch", "main-tain");
                 }, g.fight.fightsex);
             }
             break;
@@ -180,7 +176,7 @@ room227.btnclick = function (name) {
                 g.fight.e[0].p = "strip";
                 tEnemy.drawEnemy();
                 g.roomTimeout = setTimeout(function () {
-                    room227.btnclick("lb_submitass");
+                    invoker.invokeCurrent("btnclick", "lb_submitass");
                 }, g.fight.fightsex);
             }
             else {
@@ -190,7 +186,7 @@ room227.btnclick = function (name) {
                 tEnemy.changeEnergy(null, -10, { t: "grapple", me: false });
                 g.roomTimeout = setTimeout(function () {
                     tEnemy.drawChar("asspose");
-                    room227.chatcatch("main-tain");
+                    invoker.invokeCurrent("chatcatch", "main-tain");
                 }, g.fight.fightsex);
             }
             break;
@@ -200,7 +196,7 @@ room227.btnclick = function (name) {
             tEnemy.drawButtonList("close");
             tEnemy.drawChar("stripclothes");
             g.roomTimeout = setTimeout(function () {
-                room227.chatcatch("main");
+                invoker.invokeCurrent("chatcatch", "main");
             }, g.fight.fightsex);
             break;
         case "lb_teabag":
@@ -211,7 +207,7 @@ room227.btnclick = function (name) {
             tEnemy.drawEnemy();
             tEnemy.changeEnergy(null, -10, { t: "grapple", me: true });
             g.roomTimeout = setTimeout(function () {
-                room227.chatcatch("counterAction");
+                invoker.invokeCurrent("chatcatch", "counterAction");
             }, g.fight.fightsex);
                         break;
         case "lb_steal":
@@ -223,7 +219,7 @@ room227.btnclick = function (name) {
             g.fight.e[0].clothingLevel--;
             tEnemy.changeEnergy(null, null, { t: "steal", me: true });
             g.roomTimeout = setTimeout(function () {
-                room227.chatcatch("counterAction");
+                invoker.invokeCurrent("chatcatch", "counterAction");
             }, g.fight.fightsex);
             break;
         case "box0":
@@ -269,7 +265,7 @@ room227.btnclick = function (name) {
                 }
                 tEnemy.drawEnemy();
                 g.roomTimeout2 = setTimeout(function () {
-                    room227.chatcatch("counterAction");
+                    invoker.invokeCurrent("chatcatch", "counterAction");
                 }, g.fight.fighttimer);
             }, g.fight.fighttimer);
             break;
@@ -310,35 +306,35 @@ room227.btnclick = function (name) {
             break;
         case "lb_domfacefuck":
             g.internal = tEnemy.getDomEnemy(name);
-            room227.btnclick("drawDom");
+            invoker.invokeCurrent("btnclick", "drawDom");
             break;
         case "lb_domfist":
             g.internal = tEnemy.getDomEnemy(name);
-            room227.btnclick("drawDom");
+            invoker.invokeCurrent("btnclick", "drawDom");
             break;
         case "lb_domPowerbottom":
             g.internal = tEnemy.getDomEnemy(name);
-            room227.btnclick("drawDom");
+            invoker.invokeCurrent("btnclick", "drawDom");
             break;
         case "lb_domFoot":
             g.internal = tEnemy.getDomEnemy(name);
-            room227.btnclick("drawDom");
+            invoker.invokeCurrent("btnclick", "drawDom");
             break;
         case "lb_domFuckem":
             g.internal = tEnemy.getDomEnemy(name);
-            room227.btnclick("drawDom");
+            invoker.invokeCurrent("btnclick", "drawDom");
             break;
         case "lb_handjob":
             g.internal = tEnemy.getDomEnemy(name);
-            room227.btnclick("drawDom");
+            invoker.invokeCurrent("btnclick", "drawDom");
             break;
         case "lb_domUseMouth":
             g.internal = tEnemy.getDomEnemy(name);
-            room227.btnclick("drawDom");
+            invoker.invokeCurrent("btnclick", "drawDom");
             break;
         case "lb_domEatPussy":
             g.internal = tEnemy.getDomEnemy(name);
-            room227.btnclick("drawDom");
+            invoker.invokeCurrent("btnclick", "drawDom");
             break;
         case "lb_grappleSingleleg":
         case "lb_grappleLapeldrag":
@@ -363,7 +359,7 @@ room227.btnclick = function (name) {
                 g.fight.e[0].p = "block";
                 tEnemy.drawEnemy();
                 g.roomTimeout2 = setTimeout(function () {
-                    room227.chatcatch("counterAction");
+                    invoker.invokeCurrent("chatcatch", "counterAction");
                 }, g.fight.fighttimer);
             }
             break;
@@ -506,3 +502,5 @@ room227.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(227, room227);

--- a/scripts/room/room228.js
+++ b/scripts/room/room228.js
@@ -94,3 +94,5 @@ room228.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(228, room228);

--- a/scripts/room/room250.js
+++ b/scripts/room/room250.js
@@ -406,3 +406,5 @@ room250.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(250, room250);

--- a/scripts/room/room251.js
+++ b/scripts/room/room251.js
@@ -498,3 +498,5 @@ room251.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(251, room251);

--- a/scripts/room/room252.js
+++ b/scripts/room/room252.js
@@ -42,7 +42,7 @@ room252.main = function () {
             g.internal.custList.push(custList[j]);
             custList.splice(j, 1);
         }
-        room252.btnclick("customer");
+        invoker.invokeCurrent("btnclick", "customer");
     }
 };
 
@@ -105,7 +105,7 @@ room252.btnclick = function (name) {
                 }
                 else {
                     lev.sort((a, b) => a.l - b.l);
-                    room252.btnclick(lev[0].n);
+                    invoker.invokeCurrent("btnclick", lev[0].n);
                     return;
                 }
             }
@@ -150,7 +150,7 @@ room252.btnclick = function (name) {
                 sc.select("gift", "252_waitress/icon_gift.png", 11);
             }
             else {
-                room252.btnclick("talk1");
+                invoker.invokeCurrent("btnclick", "talk1");
             }
             break;
         case "dolly":
@@ -162,7 +162,7 @@ room252.btnclick = function (name) {
                 sc.select("gift", "252_waitress/icon_gift.png", 11);
             }
             else {
-                room252.btnclick("talk1");
+                invoker.invokeCurrent("btnclick", "talk1");
             }
             break;
         case "molly":
@@ -174,7 +174,7 @@ room252.btnclick = function (name) {
                 sc.select("gift", "252_waitress/icon_gift.png", 11);
             }
             else {
-                room252.btnclick("talk1");
+                invoker.invokeCurrent("btnclick", "talk1");
             }
             break;
         case "gift":
@@ -331,7 +331,7 @@ room252.btnclick = function (name) {
             else {
                 gv.mod("money", 100);
                 levels.anal(4, false, "m", true, "!missyguardnight");
-                room252.btnclick("chat");
+                invoker.invokeCurrent("btnclick", "chat");
             }
             g.internal.eventpointer++;
             break;
@@ -342,7 +342,7 @@ room252.btnclick = function (name) {
             else {
                 gv.mod("money", 100);
                 levels.oral(3, "m", "!man", true);
-                room252.btnclick("chat");
+                invoker.invokeCurrent("btnclick", "chat");
             }
             if (g.internal !== null)
                 g.internal.eventpointer++;
@@ -395,25 +395,25 @@ room252.chatcatch = function (callback) {
             char.room(252);
             break;
         case "notip":
-            room252.btnclick("chat");
+            invoker.invokeCurrent("btnclick", "chat");
             break;
         case "badtip":
             var badtip = (2 * cl.appearance()) + 3;
             gv.mod("money", g.rand(1, badtip));
-            room252.btnclick("chat");
+            invoker.invokeCurrent("btnclick", "chat");
             break;
         case "goodtip":
             var goodtip = (3 * cl.appearance()) + 12;
             gv.mod("money", g.rand(12, goodtip));
-            room252.btnclick("chat");
+            invoker.invokeCurrent("btnclick", "chat");
             break;
         case "success":
             sc.modLevel(g.internal.girl, 100, 3);
             sc.completeMissionTask(g.internal.girl, "case", g.internal.taskstep);
-            room252.btnclick("customer");
+            invoker.invokeCurrent("btnclick", "customer");
             break;
         case "fail":
-            room252.btnclick("customer");
+            invoker.invokeCurrent("btnclick", "customer");
             break;
         case "jones0":
             nav.killall();
@@ -466,12 +466,14 @@ room252.chatcatch = function (callback) {
             nav.next("wait8");
             break;
         case "customer":
-            room252.btnclick("customer");
+            invoker.invokeCurrent("btnclick", "customer");
             break;
         default:
             break;
     }
 };
+
+invoker.registerRoom(252, room252);
 
 room252.chat = function (chatID) {
     let txt, btn, food;

--- a/scripts/room/room300.js
+++ b/scripts/room/room300.js
@@ -760,3 +760,5 @@ room300.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(300, room300);

--- a/scripts/room/room301.js
+++ b/scripts/room/room301.js
@@ -15,19 +15,19 @@ room301.main = function () {
         var meetStep = sc.taskGetStep("envy", "meet");
         switch (meetStep) {
             case 1:
-                room301.chatcatch("drawbg");
+                invoker.invokeCurrent("chatcatch", "drawbg");
                 chat(0, 301);
                 break;
             case 2:
-                room301.chatcatch("drawbg");
+                invoker.invokeCurrent("chatcatch", "drawbg");
                 chat(10, 301);
                 break;
             case 3:
-                room301.chatcatch("drawbg");
+                invoker.invokeCurrent("chatcatch", "drawbg");
                 chat(21, 301);
                 break;
             case 4:
-                room301.chatcatch("drawbg");
+                invoker.invokeCurrent("chatcatch", "drawbg");
                 chat(32, 301);
                 break;
 
@@ -37,38 +37,38 @@ room301.main = function () {
     else if (sc.getMission("envy", "hypno").inProgress) {
         switch (sc.taskGetStep("envy", "hypno")) {
             case 1:
-                room301.chatcatch("drawbg");
-                room301.chatcatch("drawEnvySitting");
+                invoker.invokeCurrent("chatcatch", "drawbg");
+                invoker.invokeCurrent("chatcatch", "drawEnvySitting");
                 chat(46, 301);
                 break;
             case 2:
-                room301.chatcatch("drawbg");
-                room301.chatcatch("drawEnvySitting");
+                invoker.invokeCurrent("chatcatch", "drawbg");
+                invoker.invokeCurrent("chatcatch", "drawEnvySitting");
                 chat(50, 301);
                 break;
             case 3:
-                room301.chatcatch("drawbg");
-                room301.chatcatch("drawEnvySitting");
+                invoker.invokeCurrent("chatcatch", "drawbg");
+                invoker.invokeCurrent("chatcatch", "drawEnvySitting");
                 chat(52, 301);
                 break;
             case 4:
-                room301.chatcatch("drawbg");
-                room301.chatcatch("drawEnvySitting");
+                invoker.invokeCurrent("chatcatch", "drawbg");
+                invoker.invokeCurrent("chatcatch", "drawEnvySitting");
                 chat(54, 301);
                 break;
             case 5:
-                room301.chatcatch("drawbg");
-                room301.chatcatch("drawEnvySitting");
+                invoker.invokeCurrent("chatcatch", "drawbg");
+                invoker.invokeCurrent("chatcatch", "drawEnvySitting");
                 chat(57, 301);
                 break;
             case 6:
-                room301.chatcatch("drawbg");
-                room301.chatcatch("drawEnvySitting");
+                invoker.invokeCurrent("chatcatch", "drawbg");
+                invoker.invokeCurrent("chatcatch", "drawEnvySitting");
                 chat(67, 301);
                 break;
             case 7:
-                room301.chatcatch("drawbg");
-                room301.chatcatch("drawEnvySitting");
+                invoker.invokeCurrent("chatcatch", "drawbg");
+                invoker.invokeCurrent("chatcatch", "drawEnvySitting");
                 chat(74, 301);
                 break;
             case 8:
@@ -101,11 +101,11 @@ room301.main = function () {
         var gfstep = sc.taskGetStep("envy", "gf");
         switch (gfstep) {
             case 1:
-                room301.chatcatch("drawEnvySitting");
+                invoker.invokeCurrent("chatcatch", "drawEnvySitting");
                 chat(127, 301);
                 break;
             case 4:
-                room301.chatcatch("drawEnvySitting");
+                invoker.invokeCurrent("chatcatch", "drawEnvySitting");
                 chat(130, 301);
                 break;
             case 5:
@@ -136,8 +136,8 @@ room301.btnclick = function (name) {
             //var envyStepTouchbg = sc.getstep("envy");
             //if (envyStepTouchbg < 10) {
                 nav.killall();
-                room301.chatcatch("drawbggame");
-                room301.chatcatch("drawEnvySitting");
+                invoker.invokeCurrent("chatcatch", "drawbggame");
+                invoker.invokeCurrent("chatcatch", "drawEnvySitting");
                 chat(33, 301);
             //}
             //else {
@@ -313,7 +313,7 @@ room301.chatcatch = function (callback) {
             nav.bg("301_living/startwars.jpg");
             break;
         case "startwars1":
-            room301.chatcatch("drawEnvySitting");
+                invoker.invokeCurrent("chatcatch", "drawEnvySitting");
             nav.bg("301_living/startwars1.jpg");
             break;
         case "envy2":
@@ -359,19 +359,19 @@ room301.chatcatch = function (callback) {
             break;
         case "t0":
             g.internal.t = 0;
-            room301.chatcatch("incrementMovie");
+            invoker.invokeCurrent("chatcatch", "incrementMovie");
             break;
         case "t1":
             g.internal.t++;
-            room301.chatcatch("incrementMovie");
+            invoker.invokeCurrent("chatcatch", "incrementMovie");
             break;
         case "incrementMovie":
             g.internal.m++;
             if (g.internal.t > 4) {
-                room301.chatcatch("movie2");
+                invoker.invokeCurrent("chatcatch", "movie2");
             }
             if (g.internal.m > 10) {
-                room301.chatcatch("movie2");
+                invoker.invokeCurrent("chatcatch", "movie2");
             }
             else {
                 switch (g.internal.t) {
@@ -482,8 +482,8 @@ room301.chatcatch = function (callback) {
             break;
         case "boardgameset":
             nav.killall();
-            room301.chatcatch("drawEnvySitting");
-            room301.chatcatch("drawbggame");
+            invoker.invokeCurrent("chatcatch", "drawEnvySitting");
+            invoker.invokeCurrent("chatcatch", "drawbggame");
             break;
         case "boardgameend":
             daily.set("envy");
@@ -617,8 +617,8 @@ room301.chatcatch = function (callback) {
             break;
         case "hypnoLoop1":
             nav.killall();
-            room301.chatcatch("drawbg");
-            room301.chatcatch("drawEnvySitting");
+            invoker.invokeCurrent("chatcatch", "drawbg");
+            invoker.invokeCurrent("chatcatch", "drawEnvySitting");
             break;
         case "drawEnvySitting":
             var envyImg = "sit0.png";
@@ -2373,3 +2373,5 @@ room301.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(301, room301);

--- a/scripts/room/room302.js
+++ b/scripts/room/room302.js
@@ -53,3 +53,5 @@ room302.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(302, room302);

--- a/scripts/room/room303.js
+++ b/scripts/room/room303.js
@@ -211,3 +211,5 @@ room303.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(303, room303);

--- a/scripts/room/room304.js
+++ b/scripts/room/room304.js
@@ -2,7 +2,7 @@
 var room304 = {};
 room304.main = function () {
     if (g.internal === "202hallway") {
-        room304.btnclick("drawHallway");
+        invoker.invokeCurrent("btnclick", "drawHallway");
     }
     else {
         var btnList = [{
@@ -42,7 +42,7 @@ room304.btnclick = function (name) {
             }
             break;
         case "livingroomdoor":
-            room304.btnclick("drawHallway");
+            invoker.invokeCurrent("btnclick", "drawHallway");
             break;
         case "drawHallway":
             g.internal = null;
@@ -437,3 +437,5 @@ room304.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(304, room304);

--- a/scripts/room/room310.js
+++ b/scripts/room/room310.js
@@ -88,3 +88,5 @@ room310.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(310, room310);

--- a/scripts/room/room314.js
+++ b/scripts/room/room314.js
@@ -66,3 +66,5 @@ room314.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(314, room314);

--- a/scripts/room/room315.js
+++ b/scripts/room/room315.js
@@ -526,3 +526,5 @@ room315.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(315, room315);

--- a/scripts/room/room316.js
+++ b/scripts/room/room316.js
@@ -41,7 +41,7 @@ room316.main = function () {
             }
             else if (dogLevel > 6 && g.rand(0, 5) === 0) {
                 displayMenus = false;
-                room316.btnclick("dsex0");
+                invoker.invokeCurrent("btnclick", "dsex0");
             }
         }
 
@@ -110,7 +110,7 @@ room316.main = function () {
                 chat(114, 316);
             }
             else if (cl.hasoutfit("nude") === null) {
-                room316.chatcatch("picklock1");
+                invoker.invokeCurrent("chatcatch", "picklock1");
                 return;
             }
             else {
@@ -168,7 +168,7 @@ room316.main = function () {
                 nav.button(v, 316);
             });
             nav.buildnav(navList);
-            room316.btnclick("buildMenu");
+            invoker.invokeCurrent("btnclick", "buildMenu");
         }
     }
     else {
@@ -233,7 +233,7 @@ room316.main = function () {
             tv: false,
             webcam: webcam
         };
-        room316.btnclick("buildMenuCuck");
+        invoker.invokeCurrent("btnclick", "buildMenuCuck");
     }
         //else if (sc.getMission("janice", "cuck").inProgress) {
     //    if (sc.taskGetStep("janice", "dog") === 2) {
@@ -260,7 +260,6 @@ room316.main = function () {
     //            }
     //            else {
     //                g.pass = { money: false, dog: false, pb: false, talk: false, dick: false, datr: false };
-    //                room316.btnclick("buildMenuCuck");
     //            }
     //            break;
     //    }
@@ -290,7 +289,6 @@ room316.main = function () {
     //    }
     //    else {
     //        g.pass = { money: false, dog: false, pb: false, talk: false, dick: false, datr: false, webcam: daily.get("janiceWebcam") };
-    //        room316.btnclick("buildMenuCuck");
     //        return;
     //    } 
     //}
@@ -476,7 +474,7 @@ room316.btnclick = function (name) {
                 char.room(0);
             else {
                 if (dogLevel > 6 && !daily.get("dsex")) {
-                    room316.btnclick("dsex0");
+                    invoker.invokeCurrent("btnclick", "dsex0");
                 }
                 else {
                     chat(800, 316);
@@ -860,11 +858,11 @@ room316.btnclick = function (name) {
             break;
         case "datr_next":
             g.internal.s += 4;
-            room316.btnclick("datr");
+            invoker.invokeCurrent("btnclick", "datr");
             break;
         case "datr_prev":
             g.internal.s -= 4;
-            room316.btnclick("datr");
+            invoker.invokeCurrent("btnclick", "datr");
             break;
         case "datr_mike":
         case "datr_albert": 
@@ -1094,9 +1092,9 @@ room316.chatcatch = function (callback) {
             break;
         case "buildMenu":
             if(sc.getMission("janice", "femdom").notStarted)
-                room316.btnclick("buildMenu");
+                invoker.invokeCurrent("btnclick", "buildMenu");
             else
-                room316.btnclick("buildMenuCuck");
+                invoker.invokeCurrent("btnclick", "buildMenuCuck");
             break;
         case "dsex2":
             if (cl.c.chastity === null)
@@ -1143,7 +1141,7 @@ room316.chatcatch = function (callback) {
                 chat(104, 316);
             }
             else {
-                room316.chatcatch("kiss");
+                invoker.invokeCurrent("chatcatch", "kiss");
                 chat(107, 316);
                 return;
             }
@@ -1183,7 +1181,7 @@ room316.chatcatch = function (callback) {
                 chat(113, 316);
             }
             else {
-                room316.btnclick("buildMenu");
+                invoker.invokeCurrent("btnclick", "buildMenu");
                 //nav.bg("316_livingroom/task4_4.jpg");
                 //daily.set("janice");
                 //chat(134, 316);
@@ -1241,7 +1239,6 @@ room316.chatcatch = function (callback) {
         //    sc.completeMissionTask("janice", "cuck", 3);
         //    char.addtime(15);
         //    g.popUpNotice("You can now choose her date. ");
-        //    room316.btnclick("buildMenuCuck");
         //    break;
         case "bedroom":
             nav.killall();
@@ -1257,12 +1254,12 @@ room316.chatcatch = function (callback) {
             nav.killall();
             nav.bg("316_livingroom/phoneBg.jpg");
             g.internal = { s: 0, d: "" };
-            room316.btnclick("datr");
+            invoker.invokeCurrent("btnclick", "datr");
             break;
         case "datrScroll1":
             nav.killall();
             nav.bg("316_livingroom/phoneBg.jpg");
-            room316.btnclick("datr");
+            invoker.invokeCurrent("btnclick", "datr");
             break;
         case "failJaniceDog":
             sc.completeMission("janice", "dog-x", false);
@@ -3011,3 +3008,5 @@ room316.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(316, room316);

--- a/scripts/room/room317.js
+++ b/scripts/room/room317.js
@@ -114,3 +114,5 @@ room317.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(317, room317);

--- a/scripts/room/room318.js
+++ b/scripts/room/room318.js
@@ -72,7 +72,7 @@ room318.main = function () {
             chat(24, 318);
         }
         else {
-            room318.chatcatch("datr_start");
+            invoker.invokeCurrent("chatcatch", "datr_start");
         }
 
         return;
@@ -263,7 +263,7 @@ room318.btnclick = function (name) {
             g.internal.gamestep++;
             break;
         case "jabari_dog":
-            room318.btnclick("jabari");
+            invoker.invokeCurrent("btnclick", "jabari");
             nav.killbutton("jabari_strip");
             nav.killbutton("jabari_sub");
             nav.killbutton("jabari_pet");
@@ -357,7 +357,7 @@ room318.btnclick = function (name) {
             break;
         case "jabari_strip":
             cl.nude();
-            room318.btnclick("jabari_dog");
+            invoker.invokeCurrent("btnclick", "jabari_dog");
             break;
         case "jabari_sub":
             nav.killbutton("jabari_sub");
@@ -1189,3 +1189,5 @@ room318.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(318, room318);

--- a/scripts/room/room319.js
+++ b/scripts/room/room319.js
@@ -303,3 +303,5 @@ room319.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(319, room319);

--- a/scripts/room/room320.js
+++ b/scripts/room/room320.js
@@ -59,3 +59,5 @@ room320.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(320, room320);

--- a/scripts/room/room321.js
+++ b/scripts/room/room321.js
@@ -101,7 +101,7 @@ room321.main = function () {
                 }
                 else {
                     g.internal.button = "main";
-                    room321.btnclick("buttons");
+                    invoker.invokeCurrent("btnclick", "buttons");
                     nav.bg("321_whorechat/wait_" + gender.pronoun("f") + ".jpg");
                 }
                 break;
@@ -117,7 +117,7 @@ room321.main = function () {
         cl.nude();
         nav.bg("321_whorechat/wait_" + gender.pronoun("m") + ".jpg");
         g.internal.button = "main";
-        room321.btnclick("buttons");
+        invoker.invokeCurrent("btnclick", "buttons");
     }
     g.roomTimeout = setTimeout(function () { room321.gameloop(); }, 800);
 };
@@ -273,7 +273,7 @@ room321.btnclick = function (name) {
             gv.mod("arousal", 35);
             if (gv.get("arousal") > 95){
                 g.internal.button = "sissygasm";
-                room321.btnclick("buttons");
+                invoker.invokeCurrent("btnclick", "buttons");
                 return;
             }
             else {
@@ -296,7 +296,7 @@ room321.btnclick = function (name) {
                 "image": "321_whorechat/strapfuck2.png"
             }, 321);
             g.internal.button = "quit";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_mainRedraw":
             zcl.kill();
@@ -312,44 +312,44 @@ room321.btnclick = function (name) {
             }, 321);
             nav.bg("321_whorechat/wait_" + gender.pronoun("m") + ".jpg");
             g.internal.button = "main";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_main":
             g.internal.button = "main";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_chat":
             g.internal.button = "chat";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             return;
         case "icon_show":
             g.internal.button = "show";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_chattips":
             g.internal.button = "main";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             nav.bg("321_whorechat/wait_" + gender.pronoun("m") + ".jpg");
             g.internal.money += 2;
             room321.sidechat("tips");
             break;
         case "icon_chatflirt":
             g.internal.button = "main";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             nav.bg("321_whorechat/wait_" + gender.pronoun("m") + ".jpg");
             g.internal.money += 4;
             room321.sidechat("flirt");
             break;
         case "icon_chatInsult":
             g.internal.button = "main";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             nav.bg("321_whorechat/wait_" + gender.pronoun("m") + ".jpg");
             g.internal.money += 4;
             room321.sidechat("insult");
             break;
         case "icon_wait":
             g.internal.button = "main";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             nav.bg("321_whorechat/wait_" + gender.pronoun("f") + ".jpg");
             room321.sidechat(null);
             break;
@@ -373,7 +373,7 @@ room321.btnclick = function (name) {
                 "image": "321_whorechat/strapsuck.png"
             }, 321);
             g.internal.button = "getsucked1";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_suckdick":
             g.internal.excitement++;
@@ -383,13 +383,13 @@ room321.btnclick = function (name) {
                 g.internal.button = "getsucked1";
             else
                 g.internal.button = "suckdick2";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_suckdick2":
             g.internal.excitement++;
             nav.bg("321_whorechat/bj1.jpg");
             g.internal.button = "suckdick3";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_suckdick3":
             g.internal.excitement++;
@@ -398,7 +398,7 @@ room321.btnclick = function (name) {
             levels.gotbj("f", "janice");
             room321.sidechat("suckeddick");
             g.internal.button = "quit";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_anal":
             nav.bg("321_whorechat/anal1.jpg");
@@ -434,7 +434,7 @@ room321.btnclick = function (name) {
                 }, 321);
                 room321.sidechat(null);
                 g.internal.button = "fuckcum";
-                room321.btnclick("buttons");
+                invoker.invokeCurrent("btnclick", "buttons");
             }
             break;
         case "icon_fuckcum":
@@ -443,7 +443,7 @@ room321.btnclick = function (name) {
             nav.bg("321_whorechat/fuckcum.jpg");
             sc.modLevel("janice", 50);
             g.internal.button = "quit";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_eatpussy":
             gv.mod("arousal", 15);
@@ -456,7 +456,7 @@ room321.btnclick = function (name) {
             if (g.internal.excitement < 30)
                 g.internal.excitement += 2;
             g.internal.button = "main";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "icon_quit":
             cl.undo();
@@ -497,7 +497,7 @@ room321.chatcatch = function (callback) {
                 cl.nude();
                 nav.bg("321_whorechat/wait_" + gender.pronoun("m") + ".jpg");
                 g.internal.button = "main";
-                room321.btnclick("buttons");
+                invoker.invokeCurrent("btnclick", "buttons");
             }
             else {
                 nav.bg("321_whorechat/chastity.jpg");
@@ -506,7 +506,7 @@ room321.chatcatch = function (callback) {
             }
             break;
         case "fuck":
-            room321.btnclick("icon_fuck");
+            invoker.invokeCurrent("btnclick", "icon_fuck");
             break;
         case "femdom_makeup":
             nav.bg("321_whorechat/femdom_makeup.jpg");
@@ -526,7 +526,7 @@ room321.chatcatch = function (callback) {
             zcl.kill();
             nav.bg("321_whorechat/eatpussy_" + gender.pronoun("f") + ".jpg");
             g.internal.button = "femdom0";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "femdom_message0":
             room321.sidechat("femdom_message0");
@@ -597,10 +597,10 @@ room321.chatcatch = function (callback) {
                 "image": "321_whorechat/strapfuck1.png"
             }, 321);
             g.internal.button = "strap";
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "leave":
-            room321.btnclick("icon_quit");
+            invoker.invokeCurrent("btnclick", "icon_quit");
             break;
         case "room316":
             clearTimeout(g.roomTimeout);
@@ -608,7 +608,7 @@ room321.chatcatch = function (callback) {
             char.room(316);
             break;
         case "begin":
-            room321.btnclick("buttons");
+            invoker.invokeCurrent("btnclick", "buttons");
             break;
         case "doggy1":
         case "doggy2":
@@ -1150,3 +1150,5 @@ room321.sidechat = function (metalk) {
         }, 321);
     }
 };
+
+invoker.registerRoom(321, room321);

--- a/scripts/room/room322.js
+++ b/scripts/room/room322.js
@@ -32,7 +32,7 @@ room322.main = function () {
         }
     }
     else {
-        room322.btnclick("livingroom");
+        invoker.invokeCurrent("btnclick", "livingroom");
     }
 };
 
@@ -74,14 +74,14 @@ room322.btnclick = function (name) {
         case "livingroom":
             char.addtime(3);
             nav.kill();
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             if (cl.stinky()) {
                 nav.bg("322_dog/livingroom.webp");
                 chat(115, 322);
             }
             else if (g.gethourdecimal() > 20) {
                 if (daily.get("janicePhoneGangbang")) {
-                    room322.btnclick("f0");
+                    invoker.invokeCurrent("btnclick", "f0");
                     return;
                 }
                 var janiceRand = gv.get("janiceRand");
@@ -115,10 +115,10 @@ room322.btnclick = function (name) {
                             chat(24, 322);
                             break;
                         case 1:
-                            room322.btnclick("waiter0")
+                            invoker.invokeCurrent("btnclick", "waiter0")
                             break;
                         case 2:
-                            room322.btnclick("pl0")
+                            invoker.invokeCurrent("btnclick", "pl0")
                             break;
                     }
                     gv.mod("janiceAfternoon", 1);
@@ -131,10 +131,10 @@ room322.btnclick = function (name) {
                             chat(24, 322);
                             break;
                         case 1:
-                            room322.btnclick("waiter0");
+                            invoker.invokeCurrent("btnclick", "waiter0");
                             break;
                         case 2:
-                            room322.btnclick("pl0");
+                            invoker.invokeCurrent("btnclick", "pl0");
                             break;
                         case 3:
                             chat(110, 322);
@@ -204,7 +204,7 @@ room322.btnclick = function (name) {
             break;
         case "dogbed":
             nav.kill();
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             var dogbedchast = cl.c.chastity === null ? "_n" : "_c";
             nav.bg("322_dog/dogbed" + dogbedchast + ".webp");
             sc.select("nap2", "322_dog/icon_nap2.webp", 0);
@@ -218,10 +218,10 @@ room322.btnclick = function (name) {
                 daily.set("doggybeds");
                 sc.modLevel("dog", 50, 10);
             }
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             char.addtime(120);
             g.roomTimeout = setTimeout(function () {
-                room322.btnclick("livingroom");
+                invoker.invokeCurrent("btnclick", "livingroom");
             }, 2000);
             break;
         case "nap4":
@@ -230,10 +230,10 @@ room322.btnclick = function (name) {
                 daily.set("doggybeds");
                 sc.modLevel("dog", 50, 10);
             }
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             char.addtime(240);
             g.roomTimeout = setTimeout(function () {
-                room322.btnclick("livingroom");
+                invoker.invokeCurrent("btnclick", "livingroom");
             }, 2000);
             break;
         case "napAll":
@@ -242,15 +242,15 @@ room322.btnclick = function (name) {
                 daily.set("doggybeds");
                 sc.modLevel("dog", 50, 10);
             }
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             char.settime(19, 56);
             g.roomTimeout = setTimeout(function () {
-                room322.btnclick("livingroom");
+                invoker.invokeCurrent("btnclick", "livingroom");
             }, 2000);
             break;
         case "backyard":
             nav.kill();
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             nav.bg("319_backyard/bg.jpg");
             sc.select("yardrun", "322_dog/icon_yardRun.webp", 0);
             sc.select("yardlay", "322_dog/icon_yardLay.webp", 1);
@@ -259,7 +259,7 @@ room322.btnclick = function (name) {
             break;
         case "yardpee":
             nav.kill();
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             if (gv.get("bladder") > 0) {
                 gv.mod("bladder", -1)
                 let ypchastity = cl.c.chastity === null ? "_n" : "_c";
@@ -270,7 +270,7 @@ room322.btnclick = function (name) {
                 else {
                     nav.bg("322_dog/yardpeelaugh" + ypchastity + ".webp");
                     sc.modLevel("janice", 3, 9);
-                    room322.btnclick("progressbar");
+                    invoker.invokeCurrent("btnclick", "progressbar");
                     chat(8, 322);
                 }
             }
@@ -280,17 +280,17 @@ room322.btnclick = function (name) {
             break;
         case "yardlay":
             nav.kill();
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             gv.mod("energy", 30);
             nav.bg("322_dog/yard_layinsun.webp");
             char.addtime(180);
             g.roomTimeout = setTimeout(function () {
-                room322.btnclick("backyard");
+                invoker.invokeCurrent("btnclick", "backyard");
             }, 2000);
             break;
         case "yardrun":
             nav.kill();
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             if (sc.getLevel("dog") > 6 && g.rand(0, 2) === 0 && !daily.get("dogYardFuck")) {
                 daily.set("dogYardFuck");
                 nav.bg("322_dog/yardPlay0.webp");
@@ -307,7 +307,7 @@ room322.btnclick = function (name) {
                 else
                     nav.bg("322_dog/yardPlay0.webp");
                 g.roomTimeout = setTimeout(function () {
-                    room322.btnclick("backyard");
+                    invoker.invokeCurrent("btnclick", "backyard");
                 }, 2000);
             }
             else {
@@ -317,7 +317,7 @@ room322.btnclick = function (name) {
         case "kitchen":
             char.addtime(30);
             nav.kill();
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             nav.bg("317_janiceKitchen/kitchen.jpg");
             sc.select("livingroom", "322_dog/icon_living.webp", 0);
             sc.select("backyard", "322_dog/icon_backyard.webp", 1);
@@ -333,7 +333,7 @@ room322.btnclick = function (name) {
             break;
         case "feet":
             nav.kill();
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             sc.select("couch", "322_dog/icon_couch.webp", 0);
             sc.select("nap2x", "322_dog/icon_nap2.webp", 1);
             sc.select("nap4x", "322_dog/icon_nap4.webp", 2);
@@ -345,7 +345,7 @@ room322.btnclick = function (name) {
             nav.kill();
             gv.mod("energy", -20);
             gv.mod("janiceAnnoyance", 60);
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             char.addtime(15);
             nav.bg("322_dog/couch.webp");
             chat(6, 322);
@@ -358,9 +358,9 @@ room322.btnclick = function (name) {
                 daily.set("naplay");
                 sc.modLevel("janice", 5, 9);
             }
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             g.roomTimeout = setTimeout(function () {
-                room322.btnclick("livingroom");
+                invoker.invokeCurrent("btnclick", "livingroom");
             }, 2000);
             break;
         case "nap4x":
@@ -371,9 +371,9 @@ room322.btnclick = function (name) {
                 daily.set("naplay");
                 sc.modLevel("janice", 5, 9);
             }
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             g.roomTimeout = setTimeout(function () {
-                room322.btnclick("livingroom");
+                invoker.invokeCurrent("btnclick", "livingroom");
             }, 2000);
             break;
         case "napAllx":
@@ -384,17 +384,17 @@ room322.btnclick = function (name) {
                 daily.set("naplay");
                 sc.modLevel("janice", 5, 9);
             }
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             g.roomTimeout = setTimeout(function () {
-                room322.btnclick("livingroom");
+                invoker.invokeCurrent("btnclick", "livingroom");
             }, 2000);
             break;
         case "nuzzle":
             nav.kill();
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             if (gv.get("janiceAnnoyance") > 98) {
                 gv.mod("janiceAnnoyance", 10);
-                room322.btnclick("progressbar");
+                invoker.invokeCurrent("btnclick", "progressbar");
                 nav.bg("322_dog/shoo.webp");
                 char.addtime(30);
                 chat(67, 322);
@@ -407,28 +407,28 @@ room322.btnclick = function (name) {
                 switch (g.rand(0, 4)) {
                     case 0:
                         gv.mod("janiceAnnoyance", 40);
-                        room322.btnclick("progressbar");
+                        invoker.invokeCurrent("btnclick", "progressbar");
                         nav.bg("322_dog/shoo.webp");
                         char.addtime(30);
                         chat(67, 322);
                         break;
                     case 1:
                         gv.mod("janiceAnnoyance", 26);
-                        room322.btnclick("progressbar");
+                        invoker.invokeCurrent("btnclick", "progressbar");
                         nav.bg("322_dog/shoo.webp");
                         char.addtime(30);
                         chat(68, 322);
                         break;
                     case 2:
                         gv.mod("janiceAnnoyance", 26);
-                        room322.btnclick("progressbar");
+                        invoker.invokeCurrent("btnclick", "progressbar");
                         nav.bg("322_dog/t0.webp");
                         char.addtime(30);
                         chat(76, 322);
                         break;
                     case 3:
                         gv.mod("janiceAnnoyance", 26);
-                        room322.btnclick("progressbar");
+                        invoker.invokeCurrent("btnclick", "progressbar");
                         nav.bg("322_dog/shoo.webp");
                         char.addtime(30);
                         chat(103, 322);
@@ -445,7 +445,7 @@ room322.btnclick = function (name) {
             }
             else {
                 nav.kill();
-                room322.btnclick("progressbar");
+                invoker.invokeCurrent("btnclick", "progressbar");
                 nav.bg("322_dog/kitchen.webp");
                 chat(1, 322);
             }
@@ -454,13 +454,13 @@ room322.btnclick = function (name) {
             daily.set("room322Eat");
             nav.killbutton("feed2");
             sc.modLevel("janice", 3, 9);
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             gv.mod("bladder", .8);
             chat(4, 322);
             break;
         case "yardfuck":
             if (g.internal > 7) {
-                room322.btnclick("backyard");
+                invoker.invokeCurrent("btnclick", "backyard");
                 return;
             }
             else
@@ -502,7 +502,7 @@ room322.btnclick = function (name) {
             chat(111, 322);
             break;
         case "sphone":
-            room322.btnclick("phoneDraw");
+            invoker.invokeCurrent("btnclick", "phoneDraw");
             break;
         case "phoneDraw":
             nav.kill();
@@ -773,7 +773,7 @@ room322.btnclick = function (name) {
 room322.chatcatch = function (callback) {
     switch (callback) {
         case "backyard":
-            room322.btnclick(callback);
+            invoker.invokeCurrent("btnclick", callback);
             break;
         case "livingroom":
             char.room(322);
@@ -824,7 +824,7 @@ room322.chatcatch = function (callback) {
         case "pl1":
         case "f0":
             nav.kill();
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             nav.bg("322_dog/" + callback + ".webp");
             break;
         case "waiter4":
@@ -862,11 +862,11 @@ room322.chatcatch = function (callback) {
         case "kitchenbad":
             nav.bg("322_dog/" + callback + ".webp");
             gv.mod("janiceAnnoyance", 75);
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             daily.set("room322EatBad")
             break;
         case "kitchen":
-            room322.btnclick(callback);
+            invoker.invokeCurrent("btnclick", callback);
             break;
         case "kitchenEat":
             nav.bg("322_dog/kitchen_bowl.webp");
@@ -889,7 +889,7 @@ room322.chatcatch = function (callback) {
                 case 0:
                     nav.bg("322_dog/walk0.webp");
                     sc.modLevel("janice", 3, 9);
-                    room322.btnclick("progressbar");
+                    invoker.invokeCurrent("btnclick", "progressbar");
                     sc.modLevel("janice", 4, 9);
                     chat(13, 322);
                     break;
@@ -910,7 +910,7 @@ room322.chatcatch = function (callback) {
                 case 2:
                     nav.kill();
                     sc.modLevel("janice", 5, 9);
-                    room322.btnclick("progressbar");
+                    invoker.invokeCurrent("btnclick", "progressbar");
                     if (sc.getMissionTask("janice", "random", 0).notStarted) {
                         sc.completeMissionTask("janice", "random", 0);
                         nav.bg("322_dog/park1_0.webp");
@@ -937,7 +937,7 @@ room322.chatcatch = function (callback) {
             break;
         case "bed":
             nav.kill();
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             nav.bg("322_dog/e10.webp");
             var asldkfjaslkdjf = sc.getLevelDetails("janice");
             if (asldkfjaslkdjf.c > 65 || asldkfjaslkdjf.l > 9) {
@@ -962,7 +962,7 @@ room322.chatcatch = function (callback) {
             levels.oral(4, "m", "dog", true, "dog");
             sc.modLevel("janice", 7, 9);
             char.addtime(90);
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             break;
         case "ds5a":
             nav.bg("322_dog/ds5a.webp");
@@ -971,30 +971,30 @@ room322.chatcatch = function (callback) {
             sc.modLevel("janice", 2, 9);
             gv.mod("janiceAnnoyance", 50);
             char.addtime(90);
-            room322.btnclick("progressbar");
+            invoker.invokeCurrent("btnclick", "progressbar");
             break;
         case "backyardannoy":
             gv.mod("janiceAnnoyance", 30);
-            room322.btnclick("progressbar");
-            room322.btnclick("backyard");
+            invoker.invokeCurrent("btnclick", "progressbar");
+            invoker.invokeCurrent("btnclick", "backyard");
             break;
         case "livingroomannoy":
             gv.mod("janiceAnnoyance", 30);
-            room322.btnclick("livingroom");
+            invoker.invokeCurrent("btnclick", "livingroom");
             break;
         case "tEnd":
             sc.modLevel("janice", 5, 9);
             gv.mod("energy", 25);
-            room322.btnclick("livingroom");
+            invoker.invokeCurrent("btnclick", "livingroom");
             break;
         case "tEndbad":
             gv.mod("janiceAnnoyance", 100);
-            room322.btnclick("livingroom");
+            invoker.invokeCurrent("btnclick", "livingroom");
             break;
         case "ppend":
             levels.mod("piss", 20);
             gv.mod("janiceAnnoyance", 85);
-            room322.btnclick("livingroom");
+            invoker.invokeCurrent("btnclick", "livingroom");
             break;
         case "f3":
             g.internal = 4;
@@ -1004,12 +1004,12 @@ room322.chatcatch = function (callback) {
         case "f11":
             sc.modLevel("janice", 100, 9);
             levels.swallowCum("m", "!bbc");
-            room322.chatcatch("bed");
+            invoker.invokeCurrent("chatcatch", "bed");
             break;
         case "k_end":
             gv.mod("energy", -30);
             sc.modLevel("janice", 2, 9);
-            room322.btnclick("livingroom");
+            invoker.invokeCurrent("btnclick", "livingroom");
             break;
         case "reset":
             char.room(322);
@@ -2061,3 +2061,5 @@ room322.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(322, room322);

--- a/scripts/room/room325.js
+++ b/scripts/room/room325.js
@@ -899,3 +899,5 @@ room325.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(325, room325);

--- a/scripts/room/room326.js
+++ b/scripts/room/room326.js
@@ -357,7 +357,7 @@ room326.chatcatch = function (callback) {
                 nav.next("horse500");
             }
             else {
-                room326.chatcatch("caught1");
+                invoker.invokeCurrent("chatcatch", "caught1");
                 g.map.anger += 80;
                 chat(33, 326);
             }
@@ -369,7 +369,7 @@ room326.chatcatch = function (callback) {
                 chat(35, 326);
             }
             else {
-                room326.chatcatch("caught1");
+                invoker.invokeCurrent("chatcatch", "caught1");
                 g.map.anger += 80;
                 chat(33, 326);
             }
@@ -385,7 +385,7 @@ room326.chatcatch = function (callback) {
                 chat(29, 326);
             }
             else {
-                room326.chatcatch("caught1");
+                invoker.invokeCurrent("chatcatch", "caught1");
                 g.map.anger += 80;
                 chat(33, 326);
             }
@@ -393,7 +393,7 @@ room326.chatcatch = function (callback) {
         case "horse_end":
             levels.anal(6, true, "m", true, "horse", "horse");
             gv.mod("energy", -30);
-            room326.chatcatch("room329");
+            invoker.invokeCurrent("chatcatch", "room329");
             break;
         case "room329":
             g.map.ppgirldistract = false;
@@ -779,3 +779,5 @@ room326.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(326, room326);

--- a/scripts/room/room327.js
+++ b/scripts/room/room327.js
@@ -296,7 +296,7 @@ room327.chat = function (chatID) {
         gv.set("milk", 0);
         cl.display();
         if (milk < 500) {
-            room328.btnclick("addtrust");
+            invoker.invoke(328, "btnclick", "addtrust");
             g.map.trust += 2;
             return {
                 chatID: 999,
@@ -307,7 +307,7 @@ room327.chat = function (chatID) {
                 ]
             };
         }
-        room328.btnclick("addtrust");
+        invoker.invoke(328, "btnclick", "addtrust");
         return {
             chatID: 999,
             speaker: "thinking",
@@ -638,3 +638,5 @@ room327.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(327, room327);

--- a/scripts/room/room328.js
+++ b/scripts/room/room328.js
@@ -643,7 +643,7 @@ room328.btnclick = function (name) {
             }
             else {
                 g.map.temp = 0;
-                room329.btnclick("stall_backDraw");
+                invoker.invoke(329, "btnclick", "stall_backDraw");
                 sc.select("icon_bedturn", "328_farm/icon_turn.webp", -2);
                 sc.select("icon_sleep", "328_farm/icon_sleep.webp", -1);
                 sc.select("icon_expel", "329_barn/icon_cumfill.webp", 0, 329);
@@ -2188,7 +2188,7 @@ room328.chatcatch = function (callback) {
             nav.bg("328_farm/" + callback + ".webp");
             break;
         case "kinsey7":
-            room329.btnclick("stall_backDraw");
+            invoker.invoke(329, "btnclick", "stall_backDraw");
             break;
         case "kinseyComplete":
             sc.completeMissionTask("kinsey", "ranch", 1);
@@ -2203,7 +2203,7 @@ room328.chatcatch = function (callback) {
             quickFight.init(20, sc.n("!rancher"), "fight_win", "fight_lose", "fight_lose", 328);
             break;
         case "fightescape":
-            room329.chatcatch("escape");
+            invoker.invoke(329, "chatcatch", "escape");
             chat(89, 329);
             break;
         case "fight_lose":
@@ -4419,3 +4419,5 @@ room328.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(328, room328);

--- a/scripts/room/room329.js
+++ b/scripts/room/room329.js
@@ -44,7 +44,7 @@ room329.main = function () {
         chat(94, 329);
     }
     else {
-        room329.chatcatch("menu");
+        invoker.invokeCurrent("chatcatch", "menu");
     }
 };
 
@@ -148,7 +148,7 @@ room329.btnclick = function (name) {
             char.room(329);
             break;
         case "icon_stall":
-            room329.btnclick("stall_backDraw");
+            invoker.invokeCurrent("btnclick", "stall_backDraw");
             sc.select("icon_barn", "328_farm/icon_barn.webp", 0);
             sc.select("icon_expel", "329_barn/icon_cumfill.webp", 1);
             sc.select("icon_cumdrink", "329_barn/icon_cumdrink.webp", 2);
@@ -193,18 +193,18 @@ room329.btnclick = function (name) {
             g.popUpNotice("You drank some piss");
             levels.piss(true, false, false, "m");
             if (g.room === 329)
-                room329.btnclick("icon_stall");
+                invoker.invokeCurrent("btnclick", "icon_stall");
             else
-                room328.btnclick("icon_bedturn"); 
+                invoker.invoke(328, "btnclick", "icon_bedturn"); 
             break;
         case "icon_pissjargirl":
             g.map.jars[2].t--;
             g.popUpNotice("You drank girl's piss");
             levels.piss(true, false, false, "f");
             if (g.room === 329)
-                room329.btnclick("icon_stall");
+                invoker.invokeCurrent("btnclick", "icon_stall");
             else
-                room328.btnclick("icon_bedturn"); 
+                invoker.invoke(328, "btnclick", "icon_bedturn"); 
             break;
         case "icon_cumjar":
             g.map.jars[3].t--;
@@ -213,9 +213,9 @@ room329.btnclick = function (name) {
             levels.mod("xdress", 10);
             levels.mod("cum", 25);
             if (g.room === 329)
-                room329.btnclick("icon_stall");
+                invoker.invokeCurrent("btnclick", "icon_stall");
             else
-                room328.btnclick("icon_bedturn"); 
+                invoker.invoke(328, "btnclick", "icon_bedturn"); 
             break;
         case "icon_dogcumjar":
             g.map.jars[4].t--;
@@ -224,9 +224,9 @@ room329.btnclick = function (name) {
             levels.mod("xdress", 10);
             levels.mod("cum", 25);
             if (g.room === 329)
-                room329.btnclick("icon_stall");
+                invoker.invokeCurrent("btnclick", "icon_stall");
             else
-                room328.btnclick("icon_bedturn"); 
+                invoker.invoke(328, "btnclick", "icon_bedturn"); 
             break;
         case "icon_horsecumjar":
             g.map.jars[5].t--;
@@ -235,9 +235,9 @@ room329.btnclick = function (name) {
             levels.mod("xdress", 10);
             levels.mod("cum", 25);
             if (g.room === 329)
-                room329.btnclick("icon_stall");
+                invoker.invokeCurrent("btnclick", "icon_stall");
             else
-                room328.btnclick("icon_bedturn"); 
+                invoker.invoke(328, "btnclick", "icon_bedturn"); 
             break;
         case "icon_pigcumjar":
             g.map.jars[6].t--;
@@ -246,9 +246,9 @@ room329.btnclick = function (name) {
             levels.mod("xdress", 10);
             levels.mod("cum", 25);
             if(g.room === 329)
-                room329.btnclick("icon_stall");
+                invoker.invokeCurrent("btnclick", "icon_stall");
             else
-                room328.btnclick("icon_bedturn"); 
+                invoker.invoke(328, "btnclick", "icon_bedturn"); 
             break;
         case "icon_expel":
             if (gv.getButtCum().total === 0) {
@@ -302,9 +302,9 @@ room329.btnclick = function (name) {
             gv.clearButtCum();
             levels.mod("xdress", 15);
             if (g.roomID === 328)
-                room328.btnclick("icon_bedturn");
+                invoker.invoke(328, "btnclick", "icon_bedturn");
             else
-                room329.btnclick("icon_stall");
+                invoker.invokeCurrent("btnclick", "icon_stall");
             break;
         case "stall_backDraw":
             nav.kill();
@@ -321,7 +321,7 @@ room329.btnclick = function (name) {
                     "height": 109,
                     "image": "328_farm/sleep_mat.webp"
                 }, 329);
-                room328.btnclick("hole_progress");
+                invoker.invoke(328, "btnclick", "hole_progress");
             }
             for (let i = 0; i < g.map.jars.length; i++) {
                 img329 = inv.get(g.map.jars[i].n).image;
@@ -526,19 +526,19 @@ room329.btnclick = function (name) {
             break;
         case "north":
             g.internal.y++;
-            room329.btnclick("maze");
+            invoker.invokeCurrent("btnclick", "maze");
             break;
         case "south":
             g.internal.y--;
-            room329.btnclick("maze");
+            invoker.invokeCurrent("btnclick", "maze");
             break;
         case "east":
             g.internal.x++;
-            room329.btnclick("maze");
+            invoker.invokeCurrent("btnclick", "maze");
             break;
         case "west":
             g.internal.x--;
-            room329.btnclick("maze");
+            invoker.invokeCurrent("btnclick", "maze");
             break;
         case "exitBarn":
             nav.kill();
@@ -619,12 +619,12 @@ room329.chatcatch = function (callback) {
                 chat(74, 329);
             }
             else {
-                room329.chatcatch("menu");
+                invoker.invokeCurrent("chatcatch", "menu");
             }
             break;
         case "menu":
             nav.kill();
-            room328.btnclick("progressbar");
+            invoker.invoke(328, "btnclick", "progressbar");
             nav.bg("329_barn/bg.webp");
             if (!g.map.ppgirldistract) {
                 nav.button({
@@ -650,11 +650,11 @@ room329.chatcatch = function (callback) {
 
             break;
         case "icon_stall":
-            room329.btnclick("icon_stall");
+            invoker.invokeCurrent("btnclick", "icon_stall");
             break;
         case "finishavclean":
             g.map.avclean = true;
-            room328.chatcatch("addtrust");
+            invoker.invoke(328, "chatcatch", "addtrust");
             char.addtime(30);
             char.room(329);
             break;
@@ -808,7 +808,7 @@ room329.chatcatch = function (callback) {
             };
             nav.kill();
             nav.bg("329_barn/maze_bg.webp");
-            room329.btnclick("maze");
+            invoker.invokeCurrent("btnclick", "maze");
             break;
         case "hole5":
             char.settime(18, 7);
@@ -1952,3 +1952,5 @@ room329.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(329, room329);

--- a/scripts/room/room330.js
+++ b/scripts/room/room330.js
@@ -545,3 +545,5 @@ room330.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(330, room330);

--- a/scripts/room/room350.js
+++ b/scripts/room/room350.js
@@ -1025,3 +1025,5 @@ room350.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(350, room350);

--- a/scripts/room/room351.js
+++ b/scripts/room/room351.js
@@ -172,3 +172,5 @@ room351.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(351, room351);

--- a/scripts/room/room352.js
+++ b/scripts/room/room352.js
@@ -253,7 +253,7 @@ room352.chatcatch = function (callback) {
             g.internal.fail++;
             if (g.internal.events.length !== 0) 
                 g.internal.events.splice(0, 1);
-            room352.chatcatch("waitroom");
+            invoker.invokeCurrent("chatcatch", "waitroom");
             break;
         case "endRotation":
             
@@ -349,12 +349,12 @@ room352.chatcatch = function (callback) {
             break;
         case "jackit2ass":
             nav.killbutton("mybewbs");
-            room352.chatcatch("jackit2");
+            invoker.invokeCurrent("chatcatch", "jackit2");
             break;
         case "jackit3":
             nav.killall();
             nav.bg("352_jackoff/coldStorage.jpg");
-            room352.chatcatch("prepNextSuccess");
+            invoker.invokeCurrent("chatcatch", "prepNextSuccess");
             break;
         case "prepNextSuccess":
             g.internal.success++;
@@ -777,3 +777,5 @@ room352.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(352, room352);

--- a/scripts/room/room353.js
+++ b/scripts/room/room353.js
@@ -67,7 +67,7 @@ room353.btnclick = function (name) {
         case "icon_ignore":
             nav.killall();
             g.internal.ev.splice(0, 1);
-            room353.chatcatch("newperson");
+            invoker.invokeCurrent("chatcatch", "newperson");
             break;
         case "icon_donateg":
             g.internal.ev.splice(0, 1);
@@ -619,3 +619,5 @@ room353.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(353, room353);

--- a/scripts/room/room354.js
+++ b/scripts/room/room354.js
@@ -360,3 +360,5 @@ room354.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(354, room354);

--- a/scripts/room/room375.js
+++ b/scripts/room/room375.js
@@ -54,3 +54,5 @@ room375.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(375, room375);

--- a/scripts/room/room376.js
+++ b/scripts/room/room376.js
@@ -191,7 +191,7 @@ room376.chatcatch = function (callback) {
             nav.next("cellrape");
             break;
         case "uncower":
-            room376.btnclick("icon_sit");
+            invoker.invokeCurrent("btnclick", "icon_sit");
             break;
         case "sleep":
             nav.kill();
@@ -202,6 +202,8 @@ room376.chatcatch = function (callback) {
             break;
     }
 };
+
+invoker.registerRoom(376, room376);
 
 room376.chat = function (chatID) {
     var cArray = [

--- a/scripts/room/room400.js
+++ b/scripts/room/room400.js
@@ -239,3 +239,5 @@ room400.chat = function (chatID) {
     ];
     return cArray[chatID];
 };
+
+invoker.registerRoom(400, room400);

--- a/scripts/room/room401.js
+++ b/scripts/room/room401.js
@@ -1,12 +1,49 @@
 ﻿//purchase
 var room401 = {};
+room401.currentShop = null;
+room401.restoreExitState = function (targetRoomID) {
+    if (!g.pass || !g.pass.changeClothes || targetRoomID !== g.pass.roomID)
+        return;
+
+    cl.c.shoes = g.pass.shoes;
+    cl.c.socks = g.pass.socks;
+    cl.c.pants = g.pass.pants;
+    cl.c.panties = g.pass.panties;
+    cl.c.bra = g.pass.bra;
+    cl.c.shirt = g.pass.shirt;
+    cl.c.dress = g.pass.dress;
+    cl.c.swimsuit = g.pass.swimsuit;
+    cl.c.pj = g.pass.pj;
+    cl.display();
+
+    if (targetRoomID === 402)
+        g.internal = "purchased";
+};
+room401.clothingTypeLabel = function (item) {
+    switch (item.type) {
+        case "shoes":
+            return "Footwear";
+        case "socks":
+            return "Legwear";
+        case "bra":
+        case "panties":
+            return "Underwear";
+        case "swimsuit":
+            return "Swimwear";
+        case "pj":
+            return "Sleepwear";
+        default:
+            return item.type.charAt(0).toUpperCase() + item.type.slice(1);
+    }
+};
 room401.main = function () {
     $('#room-buttons').html('<div id="wardrobe_body">' +
         '<div class="wardrobe-line"></div>' +
         '<div class="wardrobe-line" id="wardrobe-line-buy"></div></div>');
     $('#wardrobe_body').css({ 'width': (1920 * g.ratio) + 'px', 'top': (100 * g.ratio) + 'px' });
     g.internal = 0;
-    var switchName = g.pass;
+    var switchName = typeof g.pass === "string" ? g.pass : room401.currentShop;
+    room401.currentShop = switchName;
 
     if (switchName === "bra")
         navList = [402];
@@ -31,28 +68,6 @@ room401.main = function () {
         g.pass.dress = cl.c.dress;
         g.pass.swimsuit = cl.c.swimsuit;
         g.pass.pj = cl.c.pj;
-        
-        var changeRoomID = 400;
-        //if (switchName === "bra" && sc.getstep("jada") < 2)
-        //    changeRoomID = 402;
-        $.each(g.rooms, function (j, u) {
-
-            if (u.roomID === changeRoomID) {
-                nav.button({
-                    "type": "zbtn",
-                    "name": "roomChange",
-                    "left": 350,
-                    "top": 980,
-                    "width": 200,
-                    "height": 75,
-                    "image": "navBtn/" + u.btn 
-                }, 401);
-                return false;
-            }
-        });
-        setTimeout(function () {
-            $("#room_footer").hide();
-        }, 200);
     }
 
     switch (switchName) {
@@ -62,7 +77,6 @@ room401.main = function () {
             room401.makeInv(["b"], qdress.st[3].ach, 1);
             break;
         case "saucy":
-            navList = [];
             g.pass.roomID = 400;
             g.pass.changeClothes = true;
             nav.bg("401_purchase/saucy.jpg", "401_purchase/saucy.jpg");
@@ -72,7 +86,6 @@ room401.main = function () {
             room401.makeClothing("swimsuit", "f");
             break;
         case "shoe":
-            navList = [];
             g.pass.roomID = 400;
             g.pass.changeClothes = true;
             cl.c.shoes = null;
@@ -84,7 +97,6 @@ room401.main = function () {
             room401.makeClothing("socks", "f");
             break;
         case "mens":
-            navList = [];
             g.pass.roomID = 400;
             g.pass.changeClothes = true;
             nav.bg("401_purchase/mens.jpg", "401_purchase/mens.jpg");
@@ -193,7 +205,7 @@ room401.main = function () {
         
         $('#menu_displayIcon').html('<img src="./images/inv/' + thisItem.image + '"/>');
         $("#menu_displayCost").html("$" + thisItem.cost);
-        $("#menu_displayName").html(thisItem.display);
+        $("#menu_displayName").html(inv.displayName(thisItem));
         $('#menu_displayType').html(inv.gett(thisItem.type));
         $("#menu_displayDesc").html(thisItem.desc);
         //$("#menu_displayInfo").html("info");
@@ -211,7 +223,7 @@ room401.main = function () {
             $('#menu_displayAction').hide();
             $('#menu_displayInfo').html("Too Girly");
         }
-        else if (thisItem.entry && thisItem.count === null) {
+        else if (thisItem.entry && inv.isSinglePurchase(thisItem)) {
             $('#menu_displayAction').hide();
             $('#menu_displayInfo').html("Already Purchased");
         }
@@ -222,7 +234,7 @@ room401.main = function () {
         else {
             $('#menu_displayAction').show();
             $('#menu_displayInfo').html("");
-            if (thisItem.count === null) {
+            if (inv.isSinglePurchase(thisItem)) {
                 $("#menu_displayCountLine").hide();
             }
             else {
@@ -242,7 +254,7 @@ room401.main = function () {
         $('#menu_displayIcon').html('<img src="./images/room/8_wardrobe/icons/' + cli.img + '"/>');
         $("#menu_displayCost").html("$" + cli.price);
         $("#menu_displayName").html(cli.display);
-        $('#menu_displayType').html(cli.type.charAt(0).toUpperCase() + cli.type.slice(1));
+        $('#menu_displayType').html(room401.clothingTypeLabel(cli));
         $("#menu_displayDesc").html((cli.sex === "m" ? "Boy" : "Girly") + " - " + cl.set[cli.daring + 1].name);
         //$("#menu_displayInfo").html("info");
         $("#menu_displayAction").html("BUY - $" + cli.price);
@@ -397,7 +409,8 @@ room401.makeInv = function (typeArray, canbuy, priceMult = 1) {
     for (j = 0; j < typeArray.length; j++) {
         var type = typeArray[j];
         for (i = 0; i < inv.master.length; i++) {
-            if ((inv.master[i].type === type && !(inv.master[i].entry && inv.master[i].count === null)) && inv.master[i].cost > 0) {
+            if (inv.master[i].type === type && inv.master[i].cost > 0) {
+                var isOwnedSingle = inv.master[i].entry && inv.isSinglePurchase(inv.master[i]);
                 if (inv.master[i].name === "razor") {
                     if (sissy.st[1].ach || gv.get("magman")) {
                         $('#menu-bg_' + g.internal).html('<img src="./images/inv/' + inv.master[i].image + '" data-name="' + inv.master[i].name + '" data-canbuy="' + canbuy + '" class="store-inv" title="' + inv.master[i].display + '"/>');
@@ -425,6 +438,10 @@ room401.makeInv = function (typeArray, canbuy, priceMult = 1) {
                     $('#menu-bg_' + g.internal).append('<img class="click-thru" src="./images/inv/tooGirly.png"/>');
                     $('#menu-bg_' + g.internal).append('<div>$' + Math.floor(inv.master[i].cost * priceMult) + '</div>');
                 }
+                else if (isOwnedSingle) {
+                    $('#menu-bg_' + g.internal).html('<img src="./images/inv/' + inv.master[i].image + '" data-canbuy="' + canbuy + '" data-name="' + inv.master[i].name + '" class="store-inv"  title="' + inv.displayName(inv.master[i]) + '"/>');
+                    $('#menu-bg_' + g.internal).append('<img class="click-thru" src="./images/inv/owned.png"/>');
+                }
                 else {
                     $('#menu-bg_' + g.internal).html('<img src="./images/inv/' + inv.master[i].image + '" data-canbuy="' + canbuy + '" data-name="' + inv.master[i].name + '" class="store-inv"  title="' + inv.master[i].display + '"/>');
                     $('#menu-bg_' + g.internal).append('<div>$' + Math.floor(inv.master[i].cost * priceMult) + '</div>');
@@ -439,19 +456,7 @@ room401.makeInv = function (typeArray, canbuy, priceMult = 1) {
 room401.btnclick = function (name) {
     switch (name) {
         case "roomChange":
-            cl.c.shoes = g.pass.shoes;
-            cl.c.socks = g.pass.socks;
-            cl.c.pants = g.pass.pants;
-            cl.c.panties = g.pass.panties;
-            cl.c.bra = g.pass.bra;
-            cl.c.shirt = g.pass.shirt;
-            cl.c.dress = g.pass.dress;
-            cl.c.swimsuit = g.pass.swimsuit;
-            cl.c.pj = g.pass.pj;
-            cl.display();
-            $("#room_footer").show();
-            if (g.pass.roomID === 402)
-                g.internal = "purchased";
+            room401.restoreExitState(g.pass.roomID);
             char.room(g.pass.roomID);
             break;
         default:
@@ -488,3 +493,5 @@ room401.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(401, room401);

--- a/scripts/room/room402.js
+++ b/scripts/room/room402.js
@@ -277,3 +277,5 @@ room402.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(402, room402);

--- a/scripts/room/room403.js
+++ b/scripts/room/room403.js
@@ -884,3 +884,5 @@ room403.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(403, room403);

--- a/scripts/room/room404.js
+++ b/scripts/room/room404.js
@@ -165,3 +165,5 @@ room404.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(404, room404);

--- a/scripts/room/room405.js
+++ b/scripts/room/room405.js
@@ -77,7 +77,7 @@ room405.chatcatch = function (callback) {
                 if ($(this).data('type') === "cancel")
                     char.room(405);
                 else
-                    room405.btnclick($(this).data('type'));
+                    invoker.invokeCurrent("btnclick", $(this).data('type'));
             });
             break;
         case "dye":
@@ -115,7 +115,7 @@ room405.chatcatch = function (callback) {
                             return;
                         }
                     }
-                    room405.btnclick(thisType);
+                    invoker.invokeCurrent("btnclick", thisType);
 
                 }
             });
@@ -144,7 +144,7 @@ room405.chatcatch = function (callback) {
                 if ($(this).data('type') === "cancel")
                     char.room(405);
                 else
-                    room405.btnclick($(this).data('type'));
+                    invoker.invokeCurrent("btnclick", $(this).data('type'));
             });
             break;
         default:
@@ -214,3 +214,5 @@ room405.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(405, room405);

--- a/scripts/room/room406.js
+++ b/scripts/room/room406.js
@@ -61,7 +61,7 @@ room406.btnclick = function (name) {
         case "hazel":
         case "lightblue":
         case "purple":
-            room406.btnclick("cancel");
+            invoker.invokeCurrent("btnclick", "cancel");
             gv.mod("money", -40);
             cl.c.eyes = name;
             cl.display();
@@ -194,3 +194,5 @@ room406.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(406, room406);

--- a/scripts/room/room407.js
+++ b/scripts/room/room407.js
@@ -54,7 +54,7 @@ room407.btnclick = function (name) {
         case "makeup_orange":
         case "makeup_white":
             g.internal.m = name.replace("makeup_", "");
-            room407.btnclick("eyeshadow");
+            invoker.invokeCurrent("btnclick", "eyeshadow");
             break;
         case "eyeshadow":
             nav.killall();
@@ -75,7 +75,7 @@ room407.btnclick = function (name) {
         case "eyeliner_blue":
         case "eyeliner_rainbow":
             g.internal.e = name.replace("eyeliner_", "");
-            room407.btnclick("lipstick")
+            invoker.invokeCurrent("btnclick", "lipstick")
             break;
         case "lipstick":
             nav.killall();
@@ -130,13 +130,15 @@ room407.chatcatch = function (callback) {
                 nav.bg("407_makeup/bg2.jpg");
                 g.internal = { l: null, e: null, m: "n" };
                 
-                room407.btnclick("makeup");
+                invoker.invokeCurrent("btnclick", "makeup");
             }
             break;
         default:
             break;
     }
 };
+
+invoker.registerRoom(407, room407);
 
 room407.chat = function (chatID) {
     var cArray = [

--- a/scripts/room/room408.js
+++ b/scripts/room/room408.js
@@ -130,11 +130,11 @@ room408.btnclick = function (name) {
                 "height": 979,
                 "image": "408_tattoo/stormy.png",
             }, 408);
-            room408.btnclick("stormy");
+            invoker.invokeCurrent("btnclick", "stormy");
             break;
         case "tattoo_cancel":
             nav.kill();
-            room408.btnclick("tattooStart");
+            invoker.invokeCurrent("btnclick", "tattooStart");
             break;
         case "tattoo_kill":
             nav.killbutton("has_tattoo");
@@ -147,7 +147,7 @@ room408.btnclick = function (name) {
             nav.killbutton("tattoo_cancel");
             return;
         case "tattoo_womb":
-            room408.btnclick("tattoo_kill");
+            invoker.invokeCurrent("btnclick", "tattoo_kill");
             zcl.displayMain(50, 1200, .14, "nude", false);
             sc.select("womb_trans", "408_tattoo/icon_womb_trans.png", 0);
             sc.select("womb_qos", "408_tattoo/icon_womb_qos.png", 2);
@@ -157,7 +157,7 @@ room408.btnclick = function (name) {
             sc.selectCancel("tattoo_cancel", 10);
             break;
         case "tattoo_ut":
-            room408.btnclick("tattoo_kill");
+            invoker.invokeCurrent("btnclick", "tattoo_kill");
             zcl.displayMain(50, 1200, .14, "nude", false);
             sc.select("ut_rose", "408_tattoo/icon_ut_rose.png", 0);
             sc.select("ut_kiss", "408_tattoo/icon_ut_kiss.png", 2);
@@ -166,7 +166,7 @@ room408.btnclick = function (name) {
             sc.selectCancel("tattoo_cancel", 8);
             break;
         case "tattoo_butt":
-            room408.btnclick("tattoo_kill");
+            invoker.invokeCurrent("btnclick", "tattoo_kill");
             zcl.displayMain(50, 1200, .14, "nude", true);
             sc.select("butt_paws", "408_tattoo/icon_butt_paws.png", 0);
             sc.select("butt_sperm", "408_tattoo/icon_butt_sperm.png", 2);
@@ -175,7 +175,7 @@ room408.btnclick = function (name) {
             sc.selectCancel("tattoo_cancel", 8);
             break;
         case "tattoo_tramp":
-            room408.btnclick("tattoo_kill");
+            invoker.invokeCurrent("btnclick", "tattoo_kill");
             zcl.displayMain(50, 1200, .14, "nude", true);
             sc.select("tramp_butterfly", "408_tattoo/icon_tramp_butterfly.png", 0);
             sc.select("tramp_design", "408_tattoo/icon_tramp_design.png", 2);
@@ -186,7 +186,7 @@ room408.btnclick = function (name) {
             sc.selectCancel("tattoo_cancel", 12);
             break;
         case "tattoo_back":
-            room408.btnclick("tattoo_kill");
+            invoker.invokeCurrent("btnclick", "tattoo_kill");
             zcl.displayMain(50, 1200, .14, "nude", true);
             sc.select("back_butterfly", "408_tattoo/icon_back_butterfly.png", 0);
             sc.select("back_rose", "408_tattoo/icon_back_rose.png", 2);
@@ -208,7 +208,7 @@ room408.btnclick = function (name) {
                 b: false,
                 s: 1
             };
-            room408.btnclick("getit1");
+            invoker.invokeCurrent("btnclick", "getit1");
             break;
         case "tramp_butterfly":
         case "tramp_design":
@@ -229,7 +229,7 @@ room408.btnclick = function (name) {
                 b: true,
                 s: 1
             };
-            room408.btnclick("getit1");
+            invoker.invokeCurrent("btnclick", "getit1");
             break;
         case "getit1":
             nav.kill();
@@ -275,20 +275,20 @@ room408.btnclick = function (name) {
         case "tattoo_cancel_back":
             nav.kill();
             if (g.internal.t.startsWith("womb_"))
-                 room408.btnclick("tattoo_womb");
+                 invoker.invokeCurrent("btnclick", "tattoo_womb");
             else if (g.internal.t.startsWith("ut_"))
-                room408.btnclick("tattoo_ut");
+                invoker.invokeCurrent("btnclick", "tattoo_ut");
             else if (g.internal.t.startsWith("back_"))
-                room408.btnclick("tattoo_back");
+                invoker.invokeCurrent("btnclick", "tattoo_back");
             else if (g.internal.t.startsWith("tramp_"))
-                room408.btnclick("tattoo_tramp");
+                invoker.invokeCurrent("btnclick", "tattoo_tramp");
             else if (g.internal.t.startsWith("butt_"))
-                room408.btnclick("tattoo_butt");
+                invoker.invokeCurrent("btnclick", "tattoo_butt");
 
             g.internal = null;
             break;
         case "tattooStartNo":
-            room408.btnclick("selectCancel");
+            invoker.invokeCurrent("btnclick", "selectCancel");
             chat(41, 408);
             break;
         case "pStart":
@@ -323,7 +323,7 @@ room408.chatcatch = function (callback) {
             char.room(0);
             break;
         case "reset":
-            room408.btnclick("door");
+            invoker.invokeCurrent("btnclick", "door");
             break;
         case "nipple":
             g.pass = "nipple";
@@ -399,7 +399,7 @@ room408.chatcatch = function (callback) {
                 b: false,
                 s: 1
             };
-            room408.btnclick("getit2");
+            invoker.invokeCurrent("btnclick", "getit2");
             break;
         case "elijah_case_end":
             missy.set("activeCaseComplete", 1);
@@ -1153,3 +1153,5 @@ room408.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(408, room408);

--- a/scripts/room/room450.js
+++ b/scripts/room/room450.js
@@ -13,7 +13,7 @@ room450.main = function () {
         chat(84, 450);
     }
     else if (g.pass === "lolaPark" || g.pass === "lolaPark2") {
-        room450.btnclick(g.pass);
+        invoker.invokeCurrent("btnclick", g.pass);
         g.pass = null;
     }
     else {
@@ -72,7 +72,7 @@ room450.main = function () {
             }
             else {
                 if (daily.get("parkNight")) {
-                    room450.chatcatch("enterPark");
+                    invoker.invokeCurrent("chatcatch", "enterPark");
                 }
                 else {
                     daily.set("parkNight");
@@ -1296,3 +1296,5 @@ room450.chat = function(chatID){
     ];
     return cArray[chatID];
 }
+
+invoker.registerRoom(450, room450);

--- a/scripts/room/room451.js
+++ b/scripts/room/room451.js
@@ -245,7 +245,7 @@ room451.btnclick = function (name) {
                     if (gv.get("energy") < 20)
                         chat(63, 451);
                     else
-                        room451.chatcatch("suck1");
+                        invoker.invokeCurrent("chatcatch", "suck1");
                 }
             }
             else
@@ -326,12 +326,12 @@ room451.btnclick = function (name) {
             break;
         case "gc3":
             if (g.pass === 1) {
-                nav.bg("451_parkMensRoom/gc4.jpg");
+                nav.bg("451_parkMensRoom/trash/gc4.jpg");
                 chat(20, 451);
                 g.pass = 2;
             }
             else if (g.pass === 2) {
-                nav.bg("451_parkMensRoom/gc5.jpg");
+                nav.bg("451_parkMensRoom/trash/gc5.jpg");
                 nav.button({
                     "type": "btn",
                     "name": "gc3",
@@ -339,13 +339,13 @@ room451.btnclick = function (name) {
                     "top": 0,
                     "width": 992,
                     "height": 1080,
-                    "image": "451_parkMensRoom/gc5.png"
+                    "image": "451_parkMensRoom/trash/gc5.png"
                 }, 451);
                 g.pass = 3;
             }
             else if (g.pass === 3) {
                 nav.killall();
-                nav.bg("451_parkMensRoom/gc6.jpg");
+                nav.bg("451_parkMensRoom/trash/gc6.jpg");
                 chat(21, 451);
             }
             break;
@@ -355,12 +355,12 @@ room451.btnclick = function (name) {
                 g.sissy[17].ach = true;
             }
             else if (g.sissy[17].ach) {
-                nav.bg("451_parkMensRoom/gbgcock.jpg");
+                nav.bg("451_parkMensRoom/trash/gbgcock.jpg");
                 chat(46, 451);
             }
             else {
                 nav.killall();
-                nav.bg("451_parkMensRoom/gbgcockx.jpg");
+                nav.bg("451_parkMensRoom/trash/gbgcockx.jpg");
                 chat(45, 451);
             }
             
@@ -390,7 +390,7 @@ room451.btnclick = function (name) {
             break;
         case "gh_pass":
             char.addtime(60);
-            room451.btnclick("stall1");
+            invoker.invokeCurrent("btnclick", "stall1");
             break;
         case "suck2":
             nav.killbutton("gh_pass");
@@ -615,22 +615,22 @@ room451.chatcatch = function (callback) {
             break;
         case "gc7":
             nav.killall();
-            nav.bg("451_parkMensRoom/gc7.jpg");
+            nav.bg("451_parkMensRoom/trash/gc7.jpg");
             break;
         case "gc8_swollow":
-            nav.bg("451_parkMensRoom/gc6.jpg");
+            nav.bg("451_parkMensRoom/trash/gc6.jpg");
             break;
         case "gc8_swollow1":
             gv.mod("giveOralMale", 1);
             gv.mod("loadSwollowed", 1);
-            nav.bg("451_parkMensRoom/gc8_swollow1.jpg");
+            nav.bg("451_parkMensRoom/trash/gc8_swollow1.jpg");
             break;
         case "gc8_face":
             gv.mod("giveOralMale", 1);
             gv.mod("loadSpit", 1);
             cl.c.cumface = true;
             cl.display();
-            nav.bg("451_parkMensRoom/gc8_face.jpg");
+            nav.bg("451_parkMensRoom/trash/gc8_face.jpg");
             break;
         case "endgc1":
             char.addtime(60);
@@ -751,11 +751,11 @@ room451.chatcatch = function (callback) {
             break;
         case "gloryholeEmpty":
             char.addtime (30);
-            room451.btnclick("stall1");
+            invoker.invokeCurrent("btnclick", "stall1");
             break;
         case "resetStall1":
             g.pass = "";
-            room451.btnclick("stall1");
+            invoker.invokeCurrent("btnclick", "stall1");
             break;
         case "suckit1":
             nav.killall();
@@ -777,12 +777,12 @@ room451.chatcatch = function (callback) {
             gv.mod("money", 20);
             gv.mod("giveOralMale", 1);
             char.addtime(60);
-            room451.btnclick("stall1");
+            invoker.invokeCurrent("btnclick", "stall1");
             break;
         case "suckit5":
             gv.mod("giveOralMale", 1);
             char.addtime(60);
-            room451.btnclick("stall1");
+            invoker.invokeCurrent("btnclick", "stall1");
             break;
         case "anal1":
             cl.nude();
@@ -822,13 +822,13 @@ room451.chatcatch = function (callback) {
             gv.mod("receiveAnalMale", 1);
             gv.mod("creamPied", 1);
             char.addtime(60);
-            room451.btnclick("stall1");
+            invoker.invokeCurrent("btnclick", "stall1");
             break;
         case "ass4":
             gv.mod("receiveAnalMale", 1);
             gv.mod("creamPied", 1);
             char.addtime(60);
-            room451.btnclick("stall1");
+            invoker.invokeCurrent("btnclick", "stall1");
             break;
         case "duo1":
             nav.killall();
@@ -873,12 +873,14 @@ room451.chatcatch = function (callback) {
             sc.select("gh_anal", "451_parkMensRoom/icon_anal.png", 11);
             break;
         case "resetRoom":
-            room451.btnclick("stall1");
+            invoker.invokeCurrent("btnclick", "stall1");
             break;
         default:
             break;
     }
 };
+
+invoker.registerRoom(451, room451);
 
 room451.chat = function (chatID) {
     if (chatID === 999) {

--- a/scripts/room/room452.js
+++ b/scripts/room/room452.js
@@ -234,3 +234,5 @@ room452.chat = function (chatID) {
     ];
     return cArray[chatID];
 };
+
+invoker.registerRoom(452, room452);

--- a/scripts/room/room453.js
+++ b/scripts/room/room453.js
@@ -159,3 +159,5 @@ room453.chat = function(chatID){
 
     return cArray[chatID];
 }
+
+invoker.registerRoom(453, room453);

--- a/scripts/room/room454.js
+++ b/scripts/room/room454.js
@@ -422,3 +422,5 @@ room454.chat = function(chatID){
 
     return cArray[chatID];
 }
+
+invoker.registerRoom(454, room454);

--- a/scripts/room/room455.js
+++ b/scripts/room/room455.js
@@ -72,3 +72,5 @@ room455.chat = function (chatID) {
         };
     }
 };
+
+invoker.registerRoom(455, room455);

--- a/scripts/room/room456.js
+++ b/scripts/room/room456.js
@@ -11,7 +11,6 @@ room456.main = function () {
     //}
     //else {
     //    sc.setstep("cop", 2);
-    //    room456.chatcatch("morning");
     //}
 };
 
@@ -29,7 +28,7 @@ room456.btnclick = function (name) {
                 "top": 0,
                 "width": 1186,
                 "height": 1080,
-                "image": "456_bench/head.gif"
+                "image": "450_park/head.gif"
             }, 456);
             break;
         case "cop3":
@@ -80,22 +79,22 @@ room456.chatcatch = function (callback) {
             break;
         case "cop4":
             nav.killbutton("cop3");
-            nav.bg("456_bench/cop4.jpg");
+            nav.bg("450_park/cop4.jpg");
             break;
         case "cop5":
-            nav.bg("456_bench/cop5.jpg");
+            nav.bg("450_park/cop5.jpg");
             break;
         case "cop6":
-            nav.bg("456_bench/cop6.jpg");
+            nav.bg("450_park/cop6.jpg");
             break;
         case "cop7":
-            nav.bg("456_bench/cop7.jpg");
+            nav.bg("450_park/cop7.jpg");
             break;
         case "cop8":
             nav.bg("456_bench/jack.gif");
             break;
         case "cop9":
-            nav.bg("456_bench/cop9.jpg");
+            nav.bg("450_park/cop9.jpg");
             break;
         case "cop10":
             nav.bg("456_bench/cop1.jpg");
@@ -420,3 +419,5 @@ room456.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(456, room456);

--- a/scripts/room/room460.js
+++ b/scripts/room/room460.js
@@ -149,3 +149,5 @@ room460.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(460, room460);

--- a/scripts/room/room461.js
+++ b/scripts/room/room461.js
@@ -854,3 +854,5 @@ room461.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(461, room461);

--- a/scripts/room/room475.js
+++ b/scripts/room/room475.js
@@ -145,6 +145,8 @@ room475.main = function () {
     }
 };
 
+invoker.registerRoom(475, room475);
+
 room475.btnclick = function (name) {
     switch (name) {
         case "north":

--- a/scripts/room/room476.js
+++ b/scripts/room/room476.js
@@ -94,7 +94,7 @@ room476.btnclick = function (name) {
             }
             break;
         case "cry":
-            room476.btnclick("killRope");
+            invoker.invokeCurrent("btnclick", "killRope");
             nav.button({
                 "type": "btn",
                 "name": "cross_other",
@@ -111,7 +111,7 @@ room476.btnclick = function (name) {
             chat(17, 476);
             break;
         case "help":
-            room476.btnclick("killRope");
+            invoker.invokeCurrent("btnclick", "killRope");
             nav.button({
                 "type": "btn",
                 "name": "cross_other",
@@ -139,11 +139,11 @@ room476.btnclick = function (name) {
                 chat(18, 476);
             }
             else {
-                room476.chatcatch("cross_inc");
+                invoker.invokeCurrent("chatcatch", "cross_inc");
             }
             break;
         case "free":
-            room476.btnclick("killRope");
+            invoker.invokeCurrent("btnclick", "killRope");
             var points = Math.floor((levels.get("strength").l * (gv.get("energy") / 100)) * 3);
             if (points < 15)
                 points = 15;
@@ -160,17 +160,17 @@ room476.btnclick = function (name) {
             break;
         case "rest1":
             gv.mod("energy", 10);
-            room476.chatcatch("cross_inc");
+            invoker.invokeCurrent("chatcatch", "cross_inc");
             break;
         case "rest3":
             gv.mod("energy", 35);
             char.addtime(120);
-            room476.chatcatch("cross_inc");
+            invoker.invokeCurrent("chatcatch", "cross_inc");
             break;
         case "rest8":
             gv.mod("energy", 120);
             char.addtime(420);
-            room476.chatcatch("cross_inc");
+            invoker.invokeCurrent("chatcatch", "cross_inc");
             break;
         case "killRope":
             nav.killbutton("cry");
@@ -564,7 +564,7 @@ room476.chatcatch = function (callback) {
             char.room(476);
             break;
         case "bg_night_cult_sg":
-            room476.btnclick("sybian");
+            invoker.invokeCurrent("btnclick", "sybian");
             break;
         case "cross":
             gv.mod("cultcabin", 1);
@@ -645,11 +645,11 @@ room476.chatcatch = function (callback) {
             }
             break;
         case "cross_inc":
-            room476.btnclick("killRope");
+            invoker.invokeCurrent("btnclick", "killRope");
             nav.killbutton("cross_other");
             char.addtime(60);
             if (g.isNight()) {
-                room476.chatcatch("nextEvent");
+                invoker.invokeCurrent("chatcatch", "nextEvent");
                 return;
             }
             sc.select("cry", "476_cabin/icon_cry.png", 1);
@@ -804,6 +804,8 @@ room476.chatcatch = function (callback) {
             break;
     }
 };
+
+invoker.registerRoom(476, room476);
 
 room476.chat = function (chatID) {
     if (chatID === 999) {

--- a/scripts/room/room477.js
+++ b/scripts/room/room477.js
@@ -74,7 +74,7 @@ room477.btnclick = function (name) {
                 chat(17, 477);
             }
             else
-                room477.btnclick("drawSelect");
+                invoker.invokeCurrent("btnclick", "drawSelect");
             break;
         case "drawSelect":
             sc.select("wardrobe", "316_livingroom/icon_wardrobe.png", 0);
@@ -140,7 +140,7 @@ room477.btnclick = function (name) {
 room477.chatcatch = function (callback) {
     switch (callback) {
         case "drawSelect":
-            room477.btnclick("drawSelect");
+            invoker.invokeCurrent("btnclick", "drawSelect");
             break;
         case "goToPark":
             char.room(450);
@@ -175,7 +175,7 @@ room477.chatcatch = function (callback) {
         case "s2":
             nav.killall();
             g.internal = ["l1", "l2", "l3", "l4", "l5", "l6"];
-            room477.chatcatch("drawBoxes");
+            invoker.invokeCurrent("chatcatch", "drawBoxes");
             break;
         case "drawBoxes":
             nav.bg('477_cottage/interior.jpg');
@@ -252,7 +252,7 @@ room477.chatcatch = function (callback) {
             break;
         case "resetsearch":
             if (g.internal.length > 2) {
-                room477.chatcatch("drawBoxes");
+                invoker.invokeCurrent("chatcatch", "drawBoxes");
             }
             else {
                 nav.bg("477_cottage/c0.jpg");
@@ -682,3 +682,5 @@ room477.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(477, room477);

--- a/scripts/room/room478.js
+++ b/scripts/room/room478.js
@@ -839,3 +839,5 @@ room478.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(478, room478);

--- a/scripts/room/room479.js
+++ b/scripts/room/room479.js
@@ -247,7 +247,7 @@ room479.chatcatch = function (callback) {
             char.room(479);
             break;
         case "increment":
-            room480.chatcatch("incrementtod");
+            invoker.invoke(480, "chatcatch", "incrementtod");
             char.room(479);
             break;
         case "amputee0":
@@ -828,3 +828,5 @@ room479.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(479, room479);

--- a/scripts/room/room480.js
+++ b/scripts/room/room480.js
@@ -25,7 +25,7 @@ room480.main = function () {
     }
     g.internal = { arrive: g.dt, talkList: new Array(), amputee: 0, secretPath: 0, tod: 1, single: null };
 
-    room480.chatcatch("settod");
+    invoker.invokeCurrent("chatcatch", "settod");
     if (sc.getstep("a") === 0) {
         char.addDays(1);
         char.settime(11, 27);
@@ -138,7 +138,7 @@ room480.chatcatch = function (callback) {
                 char.settime(23, Math.floor(Math.random() * 59));
             else 
                 char.settime(7, 0);
-            room480.chatcatch("settod");
+            invoker.invokeCurrent("chatcatch", "settod");
             break;
         case "settod":
             var hour = g.gethourdecimal();
@@ -176,7 +176,7 @@ room480.chatcatch = function (callback) {
         case "cg3":
             if (!g.internal.talkList.includes("vag"))
                 g.internal.talkList.push("vag");
-            room480.chatcatch("incrementtod");
+            invoker.invokeCurrent("chatcatch", "incrementtod");
             char.room(480);
             break;
         case "reset":
@@ -186,6 +186,8 @@ room480.chatcatch = function (callback) {
             break;
     }
 };
+
+invoker.registerRoom(480, room480);
 
 room480.chat = function (chatID) {
     if (chatID === 999) {

--- a/scripts/room/room481.js
+++ b/scripts/room/room481.js
@@ -98,3 +98,5 @@ room481.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(481, room481);

--- a/scripts/room/room482.js
+++ b/scripts/room/room482.js
@@ -372,3 +372,5 @@ room482.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(482, room482);

--- a/scripts/room/room483.js
+++ b/scripts/room/room483.js
@@ -4,7 +4,7 @@ var room483 = {};
 room483.main = function () {
     if (g.pass === 483 && cl.isLewd()) {
         g.pass = null;
-        room483.btnclick("enter");
+        invoker.invokeCurrent("btnclick", "enter");
         return;
     }
     g.pass = null;
@@ -56,7 +56,7 @@ room483.btnclick = function (name) {
             }
             break;
         case "approach":
-            room483.btnclick("killbtn");
+            invoker.invokeCurrent("btnclick", "killbtn");
             nav.button({
                 "type": "img",
                 "name": "grr",
@@ -69,7 +69,7 @@ room483.btnclick = function (name) {
             chat(3, 483);
             break;
         case "beta":
-            room483.btnclick("killbtn");
+            invoker.invokeCurrent("btnclick", "killbtn");
             if (levels.get("beast").l < 5) {
                 chat(5, 483);
             }
@@ -301,3 +301,5 @@ room483.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(483, room483);

--- a/scripts/room/room484.js
+++ b/scripts/room/room484.js
@@ -388,3 +388,5 @@ room484.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(484, room484);

--- a/scripts/room/room485.js
+++ b/scripts/room/room485.js
@@ -17,11 +17,11 @@ room485.btnclick = function (name) {
     }
     else if (name === "qnext") {
         g.pass += 40;
-        room485.chatcatch("sell");
+        invoker.invokeCurrent("chatcatch", "sell");
     }
     else if (name === "qprev") {
         g.pass -= 40;
-        room485.chatcatch("sell");
+        invoker.invokeCurrent("chatcatch", "sell");
     }
     else if (name === "e_up") {
         if (g.internal.count < inv.master[g.internal.i].count) {
@@ -101,8 +101,8 @@ room485.btnclick = function (name) {
                 inv.master[g.internal.i].entry = false;
         }
         gv.mod("money", inv.master[g.internal.i].buy * g.internal.count);
-        room485.chatcatch("sell");
-        room485.btnclick("c_" + g.internal.i);
+        invoker.invokeCurrent("chatcatch", "sell");
+        invoker.invokeCurrent("btnclick", "c_" + g.internal.i);
     }
     else if (name.startsWith("c_")) {
         let c = parseInt(name.replace("c_", ""));
@@ -394,3 +394,5 @@ room485.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(485, room485);

--- a/scripts/room/room486.js
+++ b/scripts/room/room486.js
@@ -85,7 +85,7 @@ room486.main = function () {
             "height": 604,
             "image": "486_game/r_openholder.webp"
         }, 486);
-        room486.btnclick("drawbtns");
+        invoker.invokeCurrent("btnclick", "drawbtns");
         nav.button({
             "type": "img",
             "name": "room0",
@@ -120,8 +120,8 @@ room486.main = function () {
             "height": 604,
             "image": "486_game/r_openholder.webp"
         }, 486);
-        room486.btnclick("drawbtns");
-        room486.btnclick("initroom");
+        invoker.invokeCurrent("btnclick", "drawbtns");
+        invoker.invokeCurrent("btnclick", "initroom");
         if (g.pass.r > 3 && g.pass.r < 12) {
             if (g.pass.r6 !== null) {
                 nav.button({
@@ -274,53 +274,53 @@ room486.btnclick = function (name) {
                 "height": 604,
                 "image": "486_game/r_openholder.webp"
             }, 486);
-            room486.btnclick("drawbtns");
-            room486.btnclick("initroom");
+            invoker.invokeCurrent("btnclick", "drawbtns");
+            invoker.invokeCurrent("btnclick", "initroom");
             switch (g.pass.r) {
                 case 1:
                     if (g.pass.inst &&  !g.pass.greenbutton) {
                         g.pass.inst = false;
-                        room486.chatcatch("room1");
+                        invoker.invokeCurrent("chatcatch", "room1");
                     }
                     break;
                 case 3:
                     if (g.pass.inst && !g.pass.greenbutton) {
                         g.pass.inst = false;
-                        room486.chatcatch("room3");
+                        invoker.invokeCurrent("chatcatch", "room3");
                     }
                     break;
                 case 4:
                     if (g.pass.inst && !g.pass.greenbutton) {
                         g.pass.inst = false;
-                        room486.chatcatch("room4");
+                        invoker.invokeCurrent("chatcatch", "room4");
                     }
                     break;
                 case 5:
                     if (g.pass.inst && !g.pass.greenbutton) {
                         g.pass.inst = false;
-                        room486.chatcatch("room5");
+                        invoker.invokeCurrent("chatcatch", "room5");
                     }
                     break;
                 case 6:
                     if (g.pass.inst && !g.pass.greenbutton) {
                         g.pass.inst = false;
-                        room486.chatcatch("room6");
+                        invoker.invokeCurrent("chatcatch", "room6");
                     }
                     break;
                 case 7:
                     if (g.pass.inst && !g.pass.greenbutton) {
                         g.pass.inst = false;
-                        room486.chatcatch("room7");
+                        invoker.invokeCurrent("chatcatch", "room7");
                     }
                     break;
                 case 8:
                     if (g.pass.inst && !g.pass.greenbutton) {
-                        room486.chatcatch("room8redraw");
+                        invoker.invokeCurrent("chatcatch", "room8redraw");
                     }
                     break;
                 case 9:
                     if (g.pass.inst && !g.pass.greenbutton) {
-                        room486.chatcatch("room9redraw");
+                        invoker.invokeCurrent("chatcatch", "room9redraw");
                     }
                     break;
             }
@@ -651,7 +651,7 @@ room486.btnclick = function (name) {
                     "height": 809,
                     "image": "486_game/room2_" + gender.pronoun("f") + ".webp"
                 }, 486);
-                room486.chatcatch("greenbuttonON");
+                invoker.invokeCurrent("chatcatch", "greenbuttonON");
                 chat(9, 486);
             }
             break;
@@ -659,14 +659,14 @@ room486.btnclick = function (name) {
             nav.killbutton("room3_0");
             nav.killbutton("room3_1");
             zcl.assup(800, 1200, .3, "", false);
-            room486.chatcatch("greenbuttonON");
+            invoker.invokeCurrent("chatcatch", "greenbuttonON");
             g.pass.temp = 0;
             chat(11, 486);
             break;
         case "room3_1":
             nav.killbutton("room3_0");
             nav.killbutton("room3_1");
-            room486.chatcatch("greenbuttonON");
+            invoker.invokeCurrent("chatcatch", "greenbuttonON");
             nav.button({
                 "type": "img",
                 "name": "me",
@@ -697,11 +697,11 @@ room486.btnclick = function (name) {
             break;
         case "room5_0":
             g.pass.r5 = "anal";
-            room486.btnclick("5_2");
+            invoker.invokeCurrent("btnclick", "5_2");
             break;
         case "room5_1":
             g.pass.r5 = "pain";
-            room486.btnclick("5_2");
+            invoker.invokeCurrent("btnclick", "5_2");
             break;
         case "5_2":
             nav.killbutton("room5_0");
@@ -785,7 +785,7 @@ room486.btnclick = function (name) {
                 "height": 229,
                 "image": "486_game/" + name + ".webp"
             }, 486);
-            room486.chatcatch("greenbuttonON");
+            invoker.invokeCurrent("chatcatch", "greenbuttonON");
             chat(10061, 486);
             break;
         case "room7":
@@ -812,7 +812,7 @@ room486.btnclick = function (name) {
                 g.popUpNotice("You have become weaker");
                 chat(25, 486);
             }
-            room486.chatcatch("greenbuttonON");
+            invoker.invokeCurrent("chatcatch", "greenbuttonON");
             break;
         case "room8_1":
             nav.killbutton("room8_0");
@@ -967,10 +967,10 @@ room486.btnclick = function (name) {
         case "icon_room9anal2":
             fame.moanAnimateStop();
             nav.killbutton("icon_room9anal2");
-            room486.btnclick("window_draw");
+            invoker.invokeCurrent("btnclick", "window_draw");
             g.internal.bucket += gv.getButtCum().total;
             gv.clearButtCum();
-            room486.btnclick("room9bucket_draw");
+            invoker.invokeCurrent("btnclick", "room9bucket_draw");
             nav.button({
                 "type": "img",
                 "name": "room9bg",
@@ -985,9 +985,9 @@ room486.btnclick = function (name) {
         case "icon_room9oral2":
             fame.moanAnimateStop();
             nav.killbutton("icon_room9anal2");
-            room486.btnclick("window_draw");
+            invoker.invokeCurrent("btnclick", "window_draw");
             g.internal.bucket++;
-            room486.btnclick("room9bucket_draw");
+            invoker.invokeCurrent("btnclick", "room9bucket_draw");
             nav.button({
                 "type": "img",
                 "name": "room9bg",
@@ -1003,7 +1003,7 @@ room486.btnclick = function (name) {
             if (g.internal.bucket > 6) {
                 g.pass.greenbutton = true;
             }
-            room486.btnclick("redrawroom"); 
+            invoker.invokeCurrent("btnclick", "redrawroom"); 
             break;
         case "room9bucket_draw":
             if (g.internal.bucket > 7) {
@@ -1020,7 +1020,7 @@ room486.btnclick = function (name) {
             }, 486);
             break;
         case "bg-window":
-            room486.btnclick("window_draw");
+            invoker.invokeCurrent("btnclick", "window_draw");
             nav.back("redrawroom");
             break;
         case "window_draw":
@@ -1278,7 +1278,7 @@ room486.chatcatch = function (callback) {
         case "room0":
             nav.modbutton("room0", "486_game/room0_1.webp", null, null);
             g.setTimeout = setTimeout(function () {
-                room486.chatcatch("greenbuttonON");
+                invoker.invokeCurrent("chatcatch", "greenbuttonON");
                 nav.killbutton("room0");
             }, 1200);
             break;
@@ -1357,8 +1357,8 @@ room486.chatcatch = function (callback) {
             }
             break;
         case "room7_3":
-            room486.chatcatch("greenbuttonON");
-            room486.btnclick("redrawroom"); 
+            invoker.invokeCurrent("chatcatch", "greenbuttonON");
+            invoker.invokeCurrent("btnclick", "redrawroom"); 
             gv.mod("energy", -15);
             levels.anal(5, false, "m", false, "!statue");
             levels.oral(5, "m", "!statue", false, null, true);
@@ -1389,7 +1389,7 @@ room486.chatcatch = function (callback) {
             break;
         case "room9":
             g.pass.inst = true;
-            room486.btnclick("redrawroom"); 
+            invoker.invokeCurrent("btnclick", "redrawroom"); 
             break;
         case "room9redraw":
             var room9CockCounter = 0;
@@ -1447,14 +1447,14 @@ room486.chatcatch = function (callback) {
             cl.display();
             nav.killbutton("room10_kill");
             g.pass.greenbutton = true;
-            room486.btnclick("redrawroom");
+            invoker.invokeCurrent("btnclick", "redrawroom");
             break;
         case "room11":
             g.pass.inst = true;
             break;
         case "room11_end":
             g.pass.greenbutton = true;
-            room486.btnclick("redrawroom");
+            invoker.invokeCurrent("btnclick", "redrawroom");
             phone.build("phone_pic");
             break;
         case "room12_4":
@@ -1485,14 +1485,14 @@ room486.chatcatch = function (callback) {
             break;
         case "greenlightRedraw":
             g.pass.greenbutton = true;
-            room486.btnclick("redrawroom");
+            invoker.invokeCurrent("btnclick", "redrawroom");
             break;
         case "greenbuttonON":
             g.pass.greenbutton = true;
-            room486.btnclick("drawbtns");
+            invoker.invokeCurrent("btnclick", "drawbtns");
             break;
         case "redrawroom":
-            room486.btnclick("redrawroom");
+            invoker.invokeCurrent("btnclick", "redrawroom");
             break;
         case "sleep":
             g.pass = 486;
@@ -1504,7 +1504,7 @@ room486.chatcatch = function (callback) {
             char.room(486);
             break;
         case "leave":
-            room486.btnclick("room12_leave");
+            invoker.invokeCurrent("btnclick", "room12_leave");
             break;
         case "redbuttonquit":
             nav.button({
@@ -2343,3 +2343,5 @@ room486.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(486, room486);

--- a/scripts/room/room487.js
+++ b/scripts/room/room487.js
@@ -121,3 +121,5 @@ room487.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(487, room487);

--- a/scripts/room/room488.js
+++ b/scripts/room/room488.js
@@ -176,3 +176,5 @@ room488.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(488, room488);

--- a/scripts/room/room489.js
+++ b/scripts/room/room489.js
@@ -152,3 +152,5 @@ room489.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(489, room489);

--- a/scripts/room/room500.js
+++ b/scripts/room/room500.js
@@ -271,3 +271,5 @@ room500.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(500, room500);

--- a/scripts/room/room501.js
+++ b/scripts/room/room501.js
@@ -108,47 +108,47 @@ room501.btnclick = function (name) {
                 switch (friends) {
                     case 0:
                         nav.killall();
-                        room501.chatcatch("zForward");
+                        invoker.invokeCurrent("chatcatch", "zForward");
                         sc.completeMissionTask("zoey", "friends", 0);
                         daily.set("zoeytalk");
                         chat(0, 501);
                         break;
                     case 1:
                         nav.killall();
-                        room501.chatcatch("zLook");
+                        invoker.invokeCurrent("chatcatch", "zLook");
                         sc.completeMissionTask("zoey", "friends", 1);
                         daily.set("zoeytalk");
                         chat(6, 501);
                         break;
                     case 2:
                         nav.killall();
-                        room501.chatcatch("zLook");
+                        invoker.invokeCurrent("chatcatch", "zLook");
                         chat(8, 501);
                         break;
                     case 3:
                         nav.killall();
-                        room501.chatcatch("zLook");
+                        invoker.invokeCurrent("chatcatch", "zLook");
                         sc.completeMissionTask("zoey", "friends", 3);
                         daily.set("zoey");
                         chat(17, 501);
                         break;
                     case 4:
                         nav.killall();
-                        room501.chatcatch("zLook");
+                        invoker.invokeCurrent("chatcatch", "zLook");
                         sc.completeMissionTask("zoey", "friends", 4);
                         daily.set("zoeytalk");
                         chat(40, 501);
                         break;
                     case 5:
                         nav.killall();
-                        room501.chatcatch("zLook");
+                        invoker.invokeCurrent("chatcatch", "zLook");
                         sc.completeMissionTask("zoey", "friends", 4);
                         daily.set("zoeytalk");
                         chat(64, 501);
                         break;
                     case 6:
                         nav.killall();
-                        room501.chatcatch("zLook");
+                        invoker.invokeCurrent("chatcatch", "zLook");
                         sc.completeMissionTask("zoey", "friends", 4);
                         daily.set("zoeytalk");
                         chat(64, 501);
@@ -158,7 +158,7 @@ room501.btnclick = function (name) {
             else if (sc.getMission("zoey", "cheating").inProgress) {
                 if (!sc.getMissionTask("zoey", "cheating", 0).complete) {
                     nav.killall();
-                    room501.chatcatch("zLook");
+                    invoker.invokeCurrent("chatcatch", "zLook");
                     chat(800, 501);
                 }
             }
@@ -168,27 +168,27 @@ room501.btnclick = function (name) {
                     case -1:
                     case 0:
                         nav.killall();
-                        room501.chatcatch("zLook");
+                        invoker.invokeCurrent("chatcatch", "zLook");
                         chat(98, 501);
                         break;
                     case 1:
                         nav.killall();
-                        room501.chatcatch("zLook");
+                        invoker.invokeCurrent("chatcatch", "zLook");
                         chat(99, 501);
                         break;
                     case 2:
                         nav.killall();
-                        room501.chatcatch("zLook");
+                        invoker.invokeCurrent("chatcatch", "zLook");
                         chat(100, 501);
                         break;
                     case 3:
                         nav.killall();
-                        room501.chatcatch("zLook");
+                        invoker.invokeCurrent("chatcatch", "zLook");
                         chat(101, 501);
                         break;
                     case 4:
                         nav.killall();
-                        room501.chatcatch("zLookx");
+                        invoker.invokeCurrent("chatcatch", "zLookx");
                         chat(102, 501);
                         break;
                 }
@@ -429,7 +429,7 @@ room501.btnclick = function (name) {
             g.internal++;
             break;
         case "cancelPeek":
-            room501.chatcatch("cheating6");
+            invoker.invokeCurrent("chatcatch", "cheating6");
             break;
         case "pussy3":
             if (g.internal === 6) {
@@ -619,7 +619,7 @@ room501.chatcatch = function (callback) {
             break;
         case "vaginaHide":
             nav.killbutton("vagina");
-            room501.chatcatch("zForward");
+            invoker.invokeCurrent("chatcatch", "zForward");
             //scc.love("zoey", -5, 100);
             break;
         case "munchTheTwat":
@@ -677,19 +677,19 @@ room501.chatcatch = function (callback) {
             sc.completeMission("zoey", "friends");
             sc.startMission("zoey", "cheating");
             daily.set("zoey");
-            room501.chatcatch("zLook");
+            invoker.invokeCurrent("chatcatch", "zLook");
             break;
         case "cheat2":
             sc.modLevel("zoey", 20, 5);
             sc.completeMission("zoey", "friends");
             sc.startMission("zoey", "cheating");
             daily.set("zoey");
-            room501.chatcatch("zSuprise");
+            invoker.invokeCurrent("chatcatch", "zSuprise");
             break;
         case "noCheat":
             sc.modLevel("zoey", -50, 999);
             daily.set("zoey");
-            room501.chatcatch("zLook");
+            invoker.invokeCurrent("chatcatch", "zLook");
             break;
         case "chloeLeave":
             daily.set("zoey");
@@ -784,7 +784,7 @@ room501.chatcatch = function (callback) {
         case "5midway":
             g.dt = new Date(g.dt.getFullYear(), g.dt.getMonth(), g.dt.getDate(), 23, 0, 0, 0);
             char.addtime(10);
-            room501.chatcatch("zShock");
+            invoker.invokeCurrent("chatcatch", "zShock");
             break;
         case "phoneRandom":
         case "phone69":
@@ -837,7 +837,7 @@ room501.chatcatch = function (callback) {
             break;
         case "checkLove":
             nav.killall();
-            nav.bg("501_jadaGame/game.jpg");
+            nav.bg("501_jadaGame/501_game.jpg");
             chat(110, 501);
             break;
         case "gameEnd":
@@ -2003,3 +2003,5 @@ room501.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(501, room501);

--- a/scripts/room/room502.js
+++ b/scripts/room/room502.js
@@ -931,3 +931,5 @@ room502.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(502, room502);

--- a/scripts/room/room503.js
+++ b/scripts/room/room503.js
@@ -194,3 +194,5 @@ room503.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(503, room503);

--- a/scripts/room/room525.js
+++ b/scripts/room/room525.js
@@ -77,3 +77,5 @@ room525.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(525, room525);

--- a/scripts/room/room526.js
+++ b/scripts/room/room526.js
@@ -1327,3 +1327,5 @@ room526.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(526, room526);

--- a/scripts/room/room527.js
+++ b/scripts/room/room527.js
@@ -447,3 +447,5 @@ room527.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(527, room527);

--- a/scripts/room/room535.js
+++ b/scripts/room/room535.js
@@ -53,3 +53,5 @@ room535.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(535, room535);

--- a/scripts/room/room550.js
+++ b/scripts/room/room550.js
@@ -14,7 +14,7 @@ room550.main = function () {
         chat(13, 550);
     }
     else if (inv.has("gym")) {
-        char.room(551);
+        char.roomWithoutHistory(551);
     }
     else {
         var btnList = [
@@ -327,3 +327,5 @@ room550.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(550, room550);

--- a/scripts/room/room551.js
+++ b/scripts/room/room551.js
@@ -892,3 +892,5 @@ room551.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(551, room551);

--- a/scripts/room/room552.js
+++ b/scripts/room/room552.js
@@ -165,3 +165,5 @@ room552.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(552, room552);

--- a/scripts/room/room553.js
+++ b/scripts/room/room553.js
@@ -190,3 +190,5 @@ room553.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(553, room553);

--- a/scripts/room/room554.js
+++ b/scripts/room/room554.js
@@ -90,3 +90,5 @@ room554.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(554, room554);

--- a/scripts/room/room555.js
+++ b/scripts/room/room555.js
@@ -11,7 +11,7 @@ room555.main = function () {
         chat(32, 555);
     }
     else if (cl.isLewd()) {
-        room555.chatcatch("drawIcons");
+        invoker.invokeCurrent("chatcatch", "drawIcons");
     }
     else {
         chat(0, 555);
@@ -30,7 +30,8 @@ room555.btnclick = function (name) {
                 "top": 0,
                 "width": 236,
                 "height": 1080,
-                "image": "555_backgym/rope2l.png"
+                "image": "555_backgym/rope2l.png",
+                "spaceAdvance": true
             }, 555);
             nav.button({
                 "type": "btn",
@@ -39,7 +40,8 @@ room555.btnclick = function (name) {
                 "top": 0,
                 "width": 236,
                 "height": 1066,
-                "image": "555_backgym/rope2r.png"
+                "image": "555_backgym/rope2r.png",
+                "spaceAdvance": true
             }, 555);
             if (g.pass === 5)
                 chat(13, 555);
@@ -55,7 +57,8 @@ room555.btnclick = function (name) {
                 "top": 0,
                 "width": 364,
                 "height": 1080,
-                "image": "555_backgym/rope1l.png"
+                "image": "555_backgym/rope1l.png",
+                "spaceAdvance": true
             }, 555);
             nav.button({
                 "type": "btn",
@@ -64,7 +67,8 @@ room555.btnclick = function (name) {
                 "top": 0,
                 "width": 246,
                 "height": 1066,
-                "image": "555_backgym/rope1r.png"
+                "image": "555_backgym/rope1r.png",
+                "spaceAdvance": true
             }, 555);
             break;
         case "thrust":
@@ -77,7 +81,7 @@ room555.btnclick = function (name) {
                 "top": 0,
                 "width": 1599,
                 "height": 1080,
-                "image": "555_backgym/thrust2.png"
+                "image": "555_backgym/thrust2.jpg"
             }, 555);
             break;
         case "thrust1":
@@ -90,7 +94,7 @@ room555.btnclick = function (name) {
                     "top": 0,
                     "width": 1559,
                     "height": 1080,
-                    "image": "555_backgym/thrust3.png"
+                    "image": "555_backgym/thrust3.jpg"
                 }, 555);
                 chat(25, 555);
             }
@@ -103,7 +107,7 @@ room555.btnclick = function (name) {
                     "top": 0,
                     "width": 1559,
                     "height": 1080,
-                    "image": "555_backgym/thrust1.png"
+                    "image": "555_backgym/thrust1.jpg"
                 }, 555);
             }
             break;
@@ -119,7 +123,7 @@ room555.btnclick = function (name) {
             sc.selectCancel("icon_back", 3);
             break;
         case "icon_back":
-            room555.chatcatch("drawIcons");
+            invoker.invokeCurrent("chatcatch", "drawIcons");
             break;
         case "icon_curls":
             if (gv.get("energy") < 75) {
@@ -399,7 +403,8 @@ room555.chatcatch = function (callback) {
                 "top": 0,
                 "width": 364,
                 "height": 1080,
-                "image": "555_backgym/rope1l.png"
+                "image": "555_backgym/rope1l.png",
+                "spaceAdvance": true
             }, 555);
             nav.button({
                 "type": "btn",
@@ -408,7 +413,8 @@ room555.chatcatch = function (callback) {
                 "top": 0,
                 "width": 246,
                 "height": 1066,
-                "image": "555_backgym/rope1r.png"
+                "image": "555_backgym/rope1r.png",
+                "spaceAdvance": true
             }, 555);
             break;
         case "toetouch":
@@ -448,7 +454,7 @@ room555.chatcatch = function (callback) {
             break;
         case "exitLowercum":
             cl.doCum();
-            room555.chatcatch("exitUpper");
+            invoker.invokeCurrent("chatcatch", "exitUpper");
             break;
         case "exitOral":
             levels.mod("strength", 55);
@@ -526,7 +532,7 @@ room555.chatcatch = function (callback) {
                 "top": 0,
                 "width": 1599,
                 "height": 1080,
-                "image": "555_backgym/thrust1.png"
+                "image": "555_backgym/thrust1.jpg"
             }, 555);
             break;
         case "hip5Click":
@@ -539,7 +545,7 @@ room555.chatcatch = function (callback) {
                 "top": 0,
                 "width": 1599,
                 "height": 1080,
-                "image": "555_backgym/thrust1.png"
+                "image": "555_backgym/thrust1.jpg"
             }, 555);
             break;
         case "hip6":
@@ -551,7 +557,7 @@ room555.chatcatch = function (callback) {
                 "top": 0,
                 "width": 1559,
                 "height": 1080,
-                "image": "555_backgym/thrust2.png"
+                "image": "555_backgym/thrust2.jpg"
             }, 555);
             break;
         case "hip7":
@@ -563,7 +569,7 @@ room555.chatcatch = function (callback) {
                 "top": 0,
                 "width": 1559,
                 "height": 1080,
-                "image": "555_backgym/thrust4.png"
+                "image": "555_backgym/thrust4.jpg"
             }, 555);
             break;
         case "hip8":
@@ -597,7 +603,16 @@ room555.chatcatch = function (callback) {
             break;
         case "thrust1":
             g.internal = 0;
-            nav.drawButton("555_backgym/thrust.png", "g_thrust");
+            nav.button({
+                "type": "zbtn",
+                "name": "g_thrust",
+                "left": 1695,
+                "top": 920,
+                "width": 225,
+                "height": 75,
+                "image": "555_backgym/thrust.png",
+                "spaceAdvance": true
+            }, 555);
             break;
         case "thrustPreg":
             levels.fuckpussy("g", "f");
@@ -608,7 +623,7 @@ room555.chatcatch = function (callback) {
                 chat(42, 555);
             }
             else {
-                room555.chatcatch("exitUpper");
+                invoker.invokeCurrent("chatcatch", "exitUpper");
             }
             break;
         case "yoga1":
@@ -618,7 +633,16 @@ room555.chatcatch = function (callback) {
         case "situp":
             nav.bg("555_backgym/situp1_" + gender.pronoun("f") + ".jpg");
             g.internal = 0;
-            nav.drawButton("555_backgym/down.png", "chad_situp");
+            nav.button({
+                "type": "zbtn",
+                "name": "chad_situp",
+                "left": 1695,
+                "top": 920,
+                "width": 225,
+                "height": 75,
+                "image": "555_backgym/down.png",
+                "spaceAdvance": true
+            }, 555);
             break;
         case "squatDown":
             nav.bg("555_backgym/squat1_" + gender.pronoun("m") + ".jpg");
@@ -626,7 +650,16 @@ room555.chatcatch = function (callback) {
         case "squatGo":
             nav.bg("555_backgym/squat0_" + gender.pronoun("f") + ".jpg");
             g.internal = 1;
-            nav.drawButton("555_backgym/down.png", "chad_squats");
+            nav.button({
+                "type": "zbtn",
+                "name": "chad_squats",
+                "left": 1695,
+                "top": 920,
+                "width": 225,
+                "height": 75,
+                "image": "555_backgym/down.png",
+                "spaceAdvance": true
+            }, 555);
             break;
         case "squatEnd":
             levels.mod("fitness", 50);
@@ -1100,7 +1133,7 @@ room555.chat = function (chatID) {
             text: "Allright " + gender.pronoun("faggot") + " sit up and kiss my supior cock. It's the closest to a " +
                 "real man's cock you'll ever get. ",
             button: [
-                { chatID: 54, text: "[Situp]", callback: "situp" },
+                { chatID: 54, text: "[Situp]", callback: "" },
             ]
         },
         {
@@ -1152,3 +1185,5 @@ room555.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(555, room555);

--- a/scripts/room/room556.js
+++ b/scripts/room/room556.js
@@ -341,3 +341,5 @@ room556.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(556, room556);

--- a/scripts/room/room575.js
+++ b/scripts/room/room575.js
@@ -606,3 +606,5 @@ room575.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(575, room575);

--- a/scripts/room/room585.js
+++ b/scripts/room/room585.js
@@ -954,3 +954,5 @@ room585.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(585, room585);

--- a/scripts/room/room586.js
+++ b/scripts/room/room586.js
@@ -473,3 +473,5 @@ room586.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(586, room586);

--- a/scripts/room/room587.js
+++ b/scripts/room/room587.js
@@ -54,3 +54,5 @@ room587.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(587, room587);

--- a/scripts/room/room588.js
+++ b/scripts/room/room588.js
@@ -192,3 +192,5 @@ room588.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(588, room588);

--- a/scripts/room/room589.js
+++ b/scripts/room/room589.js
@@ -92,3 +92,5 @@ room589.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(589, room589);

--- a/scripts/room/room600.js
+++ b/scripts/room/room600.js
@@ -294,3 +294,5 @@ room600.chat = function(chatID){
     ];
     return cArray[chatID];
 };
+
+invoker.registerRoom(600, room600);

--- a/scripts/room/room601.js
+++ b/scripts/room/room601.js
@@ -21,9 +21,9 @@ room601.main = function () {
         rapeCounter: 0,
         rapechar: g.shuffleArray([0, 2, 9, 12, 13]),
     };
-    room601.btnclick("getCustCount");
-    room601.btnclick("btnDefault");
-    room601.btnclick("showExcitement");
+    invoker.invokeCurrent("btnclick", "getCustCount");
+    invoker.invokeCurrent("btnclick", "btnDefault");
+    invoker.invokeCurrent("btnclick", "showExcitement");
 };
 
 room601.btnclick = function (name) {
@@ -240,7 +240,7 @@ room601.btnclick = function (name) {
                 if (cl.c.panties === null)
                     cl.c.panties = g.internal.panties;
 
-                room601.btnclick("fatfrank");
+                invoker.invokeCurrent("btnclick", "fatfrank");
                 chat(1, 601);
                 return;
             }
@@ -251,12 +251,12 @@ room601.btnclick = function (name) {
                 if (cl.c.panties === null)
                     cl.c.panties = g.internal.panties;
 
-                room601.btnclick("fatfrank");
+                invoker.invokeCurrent("btnclick", "fatfrank");
                 chat(0, 601);
                 return;
             }
             nav.kill();
-            room601.btnclick("getCustCount");
+            invoker.invokeCurrent("btnclick", "getCustCount");
 
             char.addtime(12);
             var danceMoney = Math.floor((g.internal.cust + (levels.get("stripper").l * 3) + (g.internal.excitement / 12)) * (g.rand(1, 7) / 1.5));
@@ -330,35 +330,35 @@ room601.btnclick = function (name) {
 
             g.internal.mingleCounter = 0;
             g.internal.danceCounter++;
-            room601.btnclick("showExcitement");
+            invoker.invokeCurrent("btnclick", "showExcitement");
             break;
         case "topless":
             g.internal.danceCounter -= 1;
             cl.c.bra = null;
-            room601.btnclick("dance");
+            invoker.invokeCurrent("btnclick", "dance");
             break;
         case "panties":
             g.internal.danceCounter = -1;
             cl.c.panties = null;
-            room601.btnclick("dance");
+            invoker.invokeCurrent("btnclick", "dance");
             break;
         case "mingle":
             if (g.gethourdecimal() > 3 && g.gethourdecimal() < 17) {
-                room601.btnclick("fatfrank");
+                invoker.invokeCurrent("btnclick", "fatfrank");
                 chat(901, 601);
             }
             else if (g.internal.mingleCounter > 4) {
-                room601.btnclick("fatfrank");
+                invoker.invokeCurrent("btnclick", "fatfrank");
                 chat(12, 601);
             }
             else {
                 nav.kill();
                 nav.bg("601_dance/bg.jpg");
-                room601.btnclick("getCustCount");
-                room601.btnclick("randDance");
+                invoker.invokeCurrent("btnclick", "getCustCount");
+                invoker.invokeCurrent("btnclick", "randDance");
                 zcl.displayMain(100, 500, .15, "clothes", true);
-                room601.btnclick("showExcitement");
-                room601.btnclick("mingleBtn");
+                invoker.invokeCurrent("btnclick", "showExcitement");
+                invoker.invokeCurrent("btnclick", "mingleBtn");
             }
             if (g.internal.sissySchool)
                 g.internal.excitement += 4;
@@ -378,8 +378,8 @@ room601.btnclick = function (name) {
         case "fatfrank":
             nav.killall();
             nav.bg("601_dance/bg.jpg");
-            room601.btnclick("getCustCount");
-            room601.btnclick("randDance");
+            invoker.invokeCurrent("btnclick", "getCustCount");
+            invoker.invokeCurrent("btnclick", "randDance");
             nav.button({
                 "type": "img",
                 "name": "name",
@@ -390,7 +390,7 @@ room601.btnclick = function (name) {
                 "image": "601_dance/fatfrank.png"
             }, 601);
             zcl.displayMain(250, 900, .14, "clothes", true);
-            room601.btnclick("showExcitement");
+            invoker.invokeCurrent("btnclick", "showExcitement");
             break;
         case "bar":
             nav.kill();
@@ -432,7 +432,7 @@ room601.btnclick = function (name) {
             
             if (foundSomeone) {
                 g.internal.private = g.rand(0, 4);
-                room601.btnclick("fatfrank");
+                invoker.invokeCurrent("btnclick", "fatfrank");
                 chat(14, 601);
             }
             else {
@@ -446,7 +446,7 @@ room601.btnclick = function (name) {
             break;
         case "dance1":
             g.internal.danceCounter = 0;
-            room601.btnclick("dance");
+            invoker.invokeCurrent("btnclick", "dance");
             break;
         case "privateBtn":
             if (g.internal.danceCounter > g.internal.privateDances) {
@@ -475,7 +475,7 @@ room601.btnclick = function (name) {
             sc.select("private_hand", "601_dance/icon_hand.png", 2);
             sc.select("private_lick", "601_dance/icon_lick.png", 4);
 
-            room601.btnclick("privateExcitement");
+            invoker.invokeCurrent("btnclick", "privateExcitement");
             break;
         case "privateExcitement":
             nav.killbutton("howcum");
@@ -504,18 +504,18 @@ room601.btnclick = function (name) {
             cl.c.bra = null;
             cl.display();
             zcl.displayMain(-100, 400, .2, "clothes", true);
-            room601.btnclick("privateExcitement");
+            invoker.invokeCurrent("btnclick", "privateExcitement");
             nav.next("privateBtn");
             break;
         case "private_panties":
             nav.kill();
             g.internal.privateExcitement += g.rand(10, 20);
-            room601.btnclick("privateExcitement");
+            invoker.invokeCurrent("btnclick", "privateExcitement");
             nav.bg("601_dance/d" + g.internal.private + ".jpg");
             cl.c.panties = null;
             cl.display();
             zcl.displayMain(-100, 400, .2, "clothes", true);
-            room601.btnclick("privateExcitement");
+            invoker.invokeCurrent("btnclick", "privateExcitement");
             nav.next("privateBtn");
             break;
         case "private_rub":
@@ -547,23 +547,23 @@ room601.btnclick = function (name) {
                 "height": 1080,
                 "image": "601_dance/drub_throb" + privateExcitement + ".webp"
             }, 601);
-            room601.btnclick("private_tipHigh");
+            invoker.invokeCurrent("btnclick", "private_tipHigh");
             if (privateExcitement === 4)
                 nav.next("pivate_cumpants");
             else
                 nav.next("privateBtn");
-            room601.btnclick("privateExcitement");
+            invoker.invokeCurrent("btnclick", "privateExcitement");
             break;
         case "private_hand":
             nav.kill();
             g.internal.danceCounter++;
             if (g.internal.privateExcitement < 50) {
-                room601.btnclick("private_tipLow");
+                invoker.invokeCurrent("btnclick", "private_tipLow");
                 nav.bg("601_dance/handjoblimp.webp");
                 g.internal.privateExcitement += 10;
             }
             else {
-                room601.btnclick("private_tipHigh");
+                invoker.invokeCurrent("btnclick", "private_tipHigh");
                 nav.bg("601_dance/handjob.gif");
                 g.internal.privateExcitement += g.rand(20, 30);
             }
@@ -574,12 +574,12 @@ room601.btnclick = function (name) {
             else {
                 nav.next("privateBtn");
             }
-            room601.btnclick("privateExcitement");
+            invoker.invokeCurrent("btnclick", "privateExcitement");
             break;
         case "private_hand0":
             nav.killbutton("private_hand0");
             nav.bg("601_dance/handjobcum0.webp");
-            room601.btnclick("private_tipHigh");
+            invoker.invokeCurrent("btnclick", "private_tipHigh");
             levels.gavehandjob("m", "!man");
             nav.button({
                 "type": "tongue",
@@ -591,12 +591,12 @@ room601.btnclick = function (name) {
                 "image": "601_dance/handjobcum1.webp"
             }, 601);
             g.internal.privateExcitement = 3;
-            room601.btnclick("privateExcitement");
+            invoker.invokeCurrent("btnclick", "privateExcitement");
             nav.next("private_handend0")
             break;
         case "private_handend0":
             nav.kill();
-            room601.btnclick("privateExcitement");
+            invoker.invokeCurrent("btnclick", "privateExcitement");
             chat(15, 601);
             break;
         case "private_hand1":
@@ -609,18 +609,18 @@ room601.btnclick = function (name) {
             cl.c.privateExcitement = 100;
             cl.c.bra = g.internal.bra;
             cl.c.panties = g.internal.panties;
-            room601.chatcatch("privateEnd");
+            invoker.invokeCurrent("chatcatch", "privateEnd");
             break;
         case "private_lick":
             nav.kill();
             g.internal.danceCounter++;
             if (g.internal.privateExcitement < 70) {
-                room601.btnclick("private_tipLow");
+                invoker.invokeCurrent("btnclick", "private_tipLow");
                 nav.bg("601_dance/lick0.webp");
                 g.internal.privateExcitement += 10;
             }
             else {
-                room601.btnclick("private_tipHigh");
+                invoker.invokeCurrent("btnclick", "private_tipHigh");
                 nav.bg("601_dance/lick1.webp");
                 g.internal.privateExcitement += g.rand(20, 30);
             }
@@ -631,13 +631,13 @@ room601.btnclick = function (name) {
             else {
                 nav.next("privateBtn");
             }
-            room601.btnclick("privateExcitement");
+            invoker.invokeCurrent("btnclick", "privateExcitement");
 
             break;
         case "pivate_cumpants":
             nav.killbutton("pivate_cumpants");
             g.internal.excitement = 3;
-            room601.btnclick("privateExcitement");
+            invoker.invokeCurrent("btnclick", "privateExcitement");
             chat(15, 601);
             break;
         case "private_getDressed":
@@ -648,7 +648,7 @@ room601.btnclick = function (name) {
             g.internal.privateExcitement -= 50;
             cl.display();
             zcl.displayMain(-100, 400, .2, "clothes", true);
-            room601.btnclick("privateBtn");
+            invoker.invokeCurrent("btnclick", "privateBtn");
             break;
         case "private_lap":
             nav.kill();
@@ -701,9 +701,9 @@ room601.btnclick = function (name) {
                     }, 601);
                     break;
             }
-            room601.btnclick("private_tipLow");
+            invoker.invokeCurrent("btnclick", "private_tipLow");
             g.internal.danceCounter++;
-            room601.btnclick("privateExcitement");
+            invoker.invokeCurrent("btnclick", "privateExcitement");
             nav.next("privateBtn");
             break;
         case "private_tipHigh":
@@ -727,7 +727,7 @@ room601.btnclick = function (name) {
             g.internal.danceCounter++;
             break;
         case "finish":
-            room601.btnclick("fatfrank");
+            invoker.invokeCurrent("btnclick", "fatfrank");
             if (g.internal.sissySchool)
                 daily.set("stripper");
             chat(901, 601);
@@ -794,34 +794,34 @@ room601.chatcatch = function (callback) {
         case "chrisPrivateEnd":
             g.internal.money += 150;
             g.popUpNotice("You earned $150");
-            room601.btnclick("mingle");
+            invoker.invokeCurrent("btnclick", "mingle");
             break;
         case "mingle":
             //sc.select("mingle", "601_dance/icon_mingle.png", 8);
             //sc.select("mingle", "601_dance/icon_mingle.png", 10);
             //sc.select("finish", "601_dance/icon_finish.png", 11);
             nav.kill();
-            room601.btnclick("mingle");
+            invoker.invokeCurrent("btnclick", "mingle");
             break;
         case "mingleInc":
             char.addtime(20);
             g.internal.mingleCounter++;
-            room601.btnclick("mingle");
+            invoker.invokeCurrent("btnclick", "mingle");
             break;
         case "excitementInc":
             g.internal.excitement += levels.get("stripper").l + 12;
-            room601.btnclick("showExcitement");
+            invoker.invokeCurrent("btnclick", "showExcitement");
             g.popUpNoticeBottom("Everyone loved that!");
             break;
         case "dance":
             g.internal.danceCounter = 0;
             g.internal.mingleCounter = 0;
-            room601.btnclick("dance");
+            invoker.invokeCurrent("btnclick", "dance");
             break;
         case "mingleStart":
             g.internal.mingleCounter = 0;
             g.internal.danceCounter = 0;
-            room601.btnclick("mingle");
+            invoker.invokeCurrent("btnclick", "mingle");
             break;
         case "private":
             nav.kill();
@@ -831,8 +831,8 @@ room601.chatcatch = function (callback) {
             g.internal.privateMoney = 0;
             g.internal.danceCounter = 0;
             g.internal.privateDances = g.rand(5, 12);
-            room601.btnclick("privateExcitement");
-            room601.btnclick("privateBtn");
+            invoker.invokeCurrent("btnclick", "privateExcitement");
+            invoker.invokeCurrent("btnclick", "privateBtn");
             break;
         case "privateEnd":
             nav.kill();
@@ -874,7 +874,7 @@ room601.chatcatch = function (callback) {
         case "dance1":
             nav.kill();
             nav.bg("601_dance/bg.jpg");
-            room601.btnclick("dance");
+            invoker.invokeCurrent("btnclick", "dance");
             break;
         case "sissyEvent4":
             g.internal.sissySchoolEventCounter = 5;
@@ -1532,3 +1532,5 @@ room601.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(601, room601);

--- a/scripts/room/room602.js
+++ b/scripts/room/room602.js
@@ -235,3 +235,5 @@ room602.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(602, room602);

--- a/scripts/room/room625.js
+++ b/scripts/room/room625.js
@@ -92,7 +92,7 @@ room625.chatcatch = function (callback) {
                 s2: false,
                 s3: false
             };
-            room625.chatcatch("sneak0");
+            invoker.invokeCurrent("chatcatch", "sneak0");
             break;
         case "sneak0":
             nav.kill();
@@ -268,3 +268,5 @@ room625.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(625, room625);

--- a/scripts/room/room626.js
+++ b/scripts/room/room626.js
@@ -233,3 +233,5 @@ room626.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(626, room626);

--- a/scripts/room/room627.js
+++ b/scripts/room/room627.js
@@ -199,3 +199,5 @@ room627.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(627, room627);

--- a/scripts/room/room628.js
+++ b/scripts/room/room628.js
@@ -170,3 +170,5 @@ room628.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(628, room628);

--- a/scripts/room/room650.js
+++ b/scripts/room/room650.js
@@ -1078,3 +1078,5 @@ room650.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(650, room650);

--- a/scripts/room/room651.js
+++ b/scripts/room/room651.js
@@ -269,3 +269,5 @@ room651.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(651, room651);

--- a/scripts/room/room661.js
+++ b/scripts/room/room661.js
@@ -416,3 +416,5 @@ room661.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(661, room661);

--- a/scripts/room/room700.js
+++ b/scripts/room/room700.js
@@ -70,7 +70,7 @@ room700.chatcatch = function (callback) {
         case "follow":
             char.changeMenu("body", false, true);
             nav.killall();
-            nav.bg("701_hospitalroom/rooms.jpg");
+            nav.bg("701_hospitalroom/old- delete/rooms.jpg");
             if (g.internal === "boob")
                 chat(7, 700);
             else
@@ -267,3 +267,5 @@ room700.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(700, room700);

--- a/scripts/room/room701.js
+++ b/scripts/room/room701.js
@@ -131,3 +131,5 @@ room701.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(701, room701);

--- a/scripts/room/room702.js
+++ b/scripts/room/room702.js
@@ -53,3 +53,5 @@ room702.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(702, room702);

--- a/scripts/room/room725.js
+++ b/scripts/room/room725.js
@@ -549,3 +549,5 @@ room725.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(725, room725);

--- a/scripts/room/room726.js
+++ b/scripts/room/room726.js
@@ -1050,3 +1050,5 @@ room726.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(726, room726);

--- a/scripts/room/room727.js
+++ b/scripts/room/room727.js
@@ -730,3 +730,5 @@ room727.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(727, room727);

--- a/scripts/room/room750.js
+++ b/scripts/room/room750.js
@@ -204,7 +204,7 @@ room750.btnclick = function (name) {
             }
             break;
         case "elilay":
-            room750.btnclick("killelibutton");
+            invoker.invokeCurrent("btnclick", "killelibutton");
             char.addtime(20);
             nav.bg("750_homeless/eli2.webp"); 
             sc.select("elitv", "316_livingroom/icon_tv.png", -2);
@@ -214,7 +214,7 @@ room750.btnclick = function (name) {
             nav.modbutton("elitvfg", "750_homeless/elitv" + (g.internal.step % 4) + ".webp", null, null); 
             break;
         case "elisit":
-            room750.btnclick("killelibutton");
+            invoker.invokeCurrent("btnclick", "killelibutton");
             char.addtime(20);
             nav.bg("750_homeless/eli1.webp");
             sc.select("elitv", "316_livingroom/icon_tv.png", -2);
@@ -234,14 +234,14 @@ room750.btnclick = function (name) {
             }
             if (g.internal.horny > 99 && !g.internal.hardonNoticed) {
                 g.internal.hardonNoticed = true;
-                room750.btnclick("elihardon"); 
+                invoker.invokeCurrent("btnclick", "elihardon"); 
                 sc.select("eliRub", "750_homeless/icon_rub.webp", 2);
                 sc.modLevel("elijah", 30, 4);
             }
             else if (g.internal.step > 8) {
-                room750.btnclick("killelibutton");
+                invoker.invokeCurrent("btnclick", "killelibutton");
                 nav.killbutton("elitvfg");
-                room750.btnclick("eliEnd");
+                invoker.invokeCurrent("btnclick", "eliEnd");
             }
             if (g.internal.horny < 0) {
                 g.internal.hardonNoticed = false;
@@ -408,7 +408,7 @@ room750.chatcatch = function (callback) {
                 chat(30, 750);
             }
             else {
-                room750.chatcatch("buy");
+                invoker.invokeCurrent("chatcatch", "buy");
             }
             break;
         case "buy":
@@ -512,6 +512,8 @@ room750.chatcatch = function (callback) {
             break;
     }
 };
+
+invoker.registerRoom(750, room750);
 
 room750.chat = function (chatID) {
     if (chatID === 900) {

--- a/scripts/room/room751.js
+++ b/scripts/room/room751.js
@@ -79,7 +79,7 @@ room751.chatcatch = function (callback) {
             }, 1200);
             break;
         case "select":
-            room751.btnclick("mainMenu");
+            invoker.invokeCurrent("btnclick", "mainMenu");
             break;
         case "fortune1":
             if (gv.get("money") < 5) {
@@ -87,7 +87,7 @@ room751.chatcatch = function (callback) {
                 return;
             }
             gv.mod("money", -5);
-            room751.btnclick("mainMenu");
+            invoker.invokeCurrent("btnclick", "mainMenu");
             break;
         default:
             break;
@@ -231,3 +231,5 @@ room751.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(751, room751);

--- a/scripts/room/room752.js
+++ b/scripts/room/room752.js
@@ -39,7 +39,7 @@ room752.btnclick = function (name) {
             }
             break;
         case "whore_chat":
-            room752.btnclick("whore_cancel");
+            invoker.invokeCurrent("btnclick", "whore_cancel");
             chat(0, 752);
             break;
         case "whore_cancel":
@@ -49,7 +49,7 @@ room752.btnclick = function (name) {
             nav.killbutton("whore_cancel");
             break;
         case "whore_dick":
-            room752.btnclick("whore_cancel");
+            invoker.invokeCurrent("btnclick", "whore_cancel");
             if (cl.c.chastity !== null)
                 chat(1, 752);
             else if (gv.get("money") < 75)
@@ -84,7 +84,7 @@ room752.btnclick = function (name) {
             chat(6, 752);
             break;
         case "whore_locket":
-            room752.btnclick("whore_cancel");
+            invoker.invokeCurrent("btnclick", "whore_cancel");
             if (missy.get("reusableCaseCounter") === 0)
                 chat(7, 752);
             else
@@ -499,3 +499,5 @@ room752.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(752, room752);

--- a/scripts/room/room775.js
+++ b/scripts/room/room775.js
@@ -12,6 +12,7 @@ room775.main = function () {
         }
         else {
             g.roomTimeout = setTimeout(function () {
+                g.roomTimeout = null;
                 nav.bg("775_church/boy.jpg");
                 char.settime(9, 0);
                 g.internal = 0;
@@ -1157,3 +1158,5 @@ room775.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(775, room775);

--- a/scripts/room/room776.js
+++ b/scripts/room/room776.js
@@ -488,3 +488,5 @@ room776.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(776, room776);

--- a/scripts/room/room800.js
+++ b/scripts/room/room800.js
@@ -347,7 +347,7 @@ room800.btnclick = function (name) {
                 "height": 1008,
                 "image": "800_ralph/ralphmom.png"
             }, 800);
-            room800.chatcatch("choices");
+            invoker.invokeCurrent("chatcatch", "choices");
             break;
         case "sissy":
             nav.killbutton("gift");
@@ -1137,3 +1137,5 @@ room800.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(800, room800);

--- a/scripts/room/room801.js
+++ b/scripts/room/room801.js
@@ -1,5 +1,16 @@
 ﻿//Room name
 var room801 = {};
+room801.addDadButton = function (name, image, type = "btn") {
+    nav.button({
+        "type": type,
+        "name": name,
+        "left": 926,
+        "top": 86,
+        "width": 437,
+        "height": 994,
+        "image": image
+    }, 801);
+};
 //after sissy school day 1 > find out Ralph told him mom everything
 //after sissy school > mom buys and brings panties to Ralph
 room801.main = function () {
@@ -10,65 +21,25 @@ room801.main = function () {
             sc.startMission("ralphsdad", "main");
             sc.completeMissionTask("ralphsdad", "main", 0);
             nav.bg("801_ralphlivingroom/dad.webp");
-            nav.button({
-                "type": "btn",
-                "name": "dad",
-                "left": 926,
-                "top": 86,
-                "width": 437,
-                "height": 994,
-                "image": "801_ralphlivingroom/d.webp"
-            }, 801);
+            room801.addDadButton("dad", "801_ralphlivingroom/d.webp");
             chat(0, 801);
         }
         else if (daily.get("room800dad")) {
-            nav.button({
-                "type": "btn",
-                "name": "dad",
-                "left": 926,
-                "top": 86,
-                "width": 437,
-                "height": 994,
-                "image": "801_ralphlivingroom/d.webp"
-            }, 801);
+            room801.addDadButton("dad", "801_ralphlivingroom/d.webp");
         }
         else if (cl.appearance() > 1) {
             daily.set("room800dad");
             if (!sc.getMissionTask("ralphsdad", "main", 1).complete) {
                 if (sc.getMissionTask("ralphsdad", "main", 1).notStarted) {
-                    nav.button({
-                        "type": "btn",
-                        "name": "dadflowers",
-                        "left": 926,
-                        "top": 86,
-                        "width": 437,
-                        "height": 994,
-                        "image": "801_ralphlivingroom/d_f.webp"
-                    }, 801);
+                    room801.addDadButton("dadflowers", "801_ralphlivingroom/d_f.webp");
                 }
                 else {
-                    nav.button({
-                        "type": "btn",
-                        "name": "dadflowers",
-                        "left": 926,
-                        "top": 86,
-                        "width": 437,
-                        "height": 994,
-                        "image": "801_ralphlivingroom/d_r.webp"
-                    }, 801);
+                    room801.addDadButton("dadflowers", "801_ralphlivingroom/d_r.webp");
                 }
             }
             else if (!sc.getMissionTask("ralphsdad", "main", 6).complete) {
                 if (sc.getMissionTask("ralphsdad", "main", 2).notStarted) {
-                    nav.button({
-                        "type": "btn",
-                        "name": "dadbuttgrab",
-                        "left": 926,
-                        "top": 86,
-                        "width": 437,
-                        "height": 994,
-                        "image": "801_ralphlivingroom/d.webp"
-                    }, 801);
+                    room801.addDadButton("dadbuttgrab", "801_ralphlivingroom/d.webp");
                 }
                 else {
                     if (sc.getLevel("ralphsdad") > 4) {
@@ -80,15 +51,7 @@ room801.main = function () {
                     else {
                         switch (sc.getMissionTask("ralphsdad", "main", 2).mStatus % 2) {
                             case 0:
-                                nav.button({
-                                    "type": "btn",
-                                    "name": "daddick",
-                                    "left": 926,
-                                    "top": 86,
-                                    "width": 437,
-                                    "height": 994,
-                                    "image": "801_ralphlivingroom/d_d.webp"
-                                }, 801);
+                                room801.addDadButton("daddick", "801_ralphlivingroom/d_d.webp");
                                 break;
                             case 1:
                                 nav.bg("801_ralphlivingroom/assgrab_bg.webp");
@@ -113,29 +76,13 @@ room801.main = function () {
             }
             else {
                 daily.set("room800dad");
-                nav.button({
-                    "type": "btn",
-                    "name": "daddick",
-                    "left": 926,
-                    "top": 86,
-                    "width": 437,
-                    "height": 994,
-                    "image": "801_ralphlivingroom/d_d.webp"
-                }, 801);
+                room801.addDadButton("daddick", "801_ralphlivingroom/d_d.webp");
                 chat(22, 801);
             }
         }
         else {
             nav.bg("801_ralphlivingroom/dad.webp");
-            nav.button({
-                "type": "btn",
-                "name": "dad",
-                "left": 926,
-                "top": 86,
-                "width": 437,
-                "height": 994,
-                "image": "801_ralphlivingroom/d.webp"
-            }, 801);
+            room801.addDadButton("dad", "801_ralphlivingroom/d.webp");
         }
     }
     if (daily.get("noRoom803"))
@@ -490,3 +437,5 @@ room801.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(801, room801);

--- a/scripts/room/room802.js
+++ b/scripts/room/room802.js
@@ -51,7 +51,7 @@ room802.main = function () {
 room802.btnclick = function (name) {
     switch (name) {
         case "game":
-            room802.btnclick("killbtns");
+            invoker.invokeCurrent("btnclick", "killbtns");
             if (g.gethourdecimal() > 19) {
                 chat(3, 802);
             }
@@ -63,7 +63,7 @@ room802.btnclick = function (name) {
             }
             break;
         case "chat":
-            room802.btnclick("killbtns");
+            invoker.invokeCurrent("btnclick", "killbtns");
             if (sc.getMissionTask("ralph", "room", 0).notStarted) {
                 sc.startMission("ralph", "room");
                 sc.completeMissionTask("ralph", "room", 0);
@@ -75,7 +75,7 @@ room802.btnclick = function (name) {
             else if (sissy.st[0].ach && sc.getMissionTask("ralph", "room", 2).notStarted) {
                 if (cl.isCrossdressing()) {
                     sc.completeMissionTask("ralph", "room", 2, false);
-                    room802.btnclick("chat");
+                    invoker.invokeCurrent("btnclick", "chat");
                     return;
                 }
                 sc.completeMissionTask("ralph", "room", 2);
@@ -84,7 +84,7 @@ room802.btnclick = function (name) {
             else if (sissy.st[10].ach && sc.getMissionTask("ralph", "room", 3).notStarted) {
                 if (sissy.st[21].ach) {
                     sc.completeMissionTask("ralph", "room", 3, false);
-                    room802.btnclick("chat");
+                    invoker.invokeCurrent("btnclick", "chat");
                     return;
                 }
                 sc.completeMissionTask("ralph", "room", 3);
@@ -668,3 +668,5 @@ room802.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(802, room802);

--- a/scripts/room/room803.js
+++ b/scripts/room/room803.js
@@ -187,7 +187,7 @@ room803.btnclick = function (name) {
             }
             break;
         case "cancelHide":
-            room803.chatcatch("closet");
+            invoker.invokeCurrent("chatcatch", "closet");
             break;
         case "keephiding":
             if (g.isNight()) {
@@ -210,7 +210,7 @@ room803.btnclick = function (name) {
             break;
         case "bed_l0":
             g.internal.p += 5;
-            room803.btnclick("bedprogress");
+            invoker.invokeCurrent("btnclick", "bedprogress");
             nav.killbutton("bed_l0");
             
             nav.button({
@@ -231,7 +231,7 @@ room803.btnclick = function (name) {
         case "bed_l1":
             g.internal.p += 5;
             g.internal.pants = false;
-            room803.btnclick("bedprogress");
+            invoker.invokeCurrent("btnclick", "bedprogress");
             nav.killbutton("bed_l1");
             nav.modbutton("bed_n", "803_parentbedroom/bed_n3.webp", null, null);
             clearTimeout(g.roomTimeout);
@@ -241,7 +241,7 @@ room803.btnclick = function (name) {
             break;
         case "bed_p0":
             g.internal.p += 3;
-            room803.btnclick("bedprogress");
+            invoker.invokeCurrent("btnclick", "bedprogress");
             nav.killbutton("bed_p0");
             nav.button({
                 "type": "grab",
@@ -262,7 +262,7 @@ room803.btnclick = function (name) {
         case "bed_p1":
             g.internal.p += 7;
             g.internal.panties = false;
-            room803.btnclick("bedprogress");
+            invoker.invokeCurrent("btnclick", "bedprogress");
             nav.killbutton("bed_p1");
             nav.modbutton("bed_n", "803_parentbedroom/bed_n3.webp", null, null);
             clearTimeout(g.roomTimeout);
@@ -273,7 +273,7 @@ room803.btnclick = function (name) {
         case "bed_s0":
             g.internal.p += 5;
             g.internal.shirt = false;
-            room803.btnclick("bedprogress");
+            invoker.invokeCurrent("btnclick", "bedprogress");
             nav.killbutton("bed_s0");
             nav.modbutton("bed_n", "803_parentbedroom/bed_n3.webp", null, null);
             clearTimeout(g.roomTimeout);
@@ -293,11 +293,11 @@ room803.btnclick = function (name) {
             }, 803);
             if (g.internal.kiss === 0) {
                 g.internal.p += 20;
-                room803.btnclick("bedprogress");
+                invoker.invokeCurrent("btnclick", "bedprogress");
             }
             else {
                 g.internal.p += 10;
-                room803.btnclick("bedprogress");
+                invoker.invokeCurrent("btnclick", "bedprogress");
             }
             nav.next("bed_kill");
             nav.modbutton("bed_n", "803_parentbedroom/bed_n4.webp", null, null);
@@ -319,11 +319,11 @@ room803.btnclick = function (name) {
             }, 803);
             if (g.internal.niplick === 0) {
                 g.internal.p += 10;
-                room803.btnclick("bedprogress");
+                invoker.invokeCurrent("btnclick", "bedprogress");
             }
             else if (g.internal.niplick === 1) {
                 g.internal.p += 3;
-                room803.btnclick("bedprogress");
+                invoker.invokeCurrent("btnclick", "bedprogress");
             }
             nav.next("bed_kill");
             nav.modbutton("bed_n", "803_parentbedroom/bed_n1.webp", null, null);
@@ -345,11 +345,11 @@ room803.btnclick = function (name) {
             }, 803);
             if (g.internal.boobsqueeze === 0) {
                 g.internal.p += 5;
-                room803.btnclick("bedprogress");
+                invoker.invokeCurrent("btnclick", "bedprogress");
             }
             else if (g.internal.boobsqueeze === 1) {
                 g.internal.p += 2;
-                room803.btnclick("bedprogress");
+                invoker.invokeCurrent("btnclick", "bedprogress");
             }
             nav.next("bed_kill");
             nav.modbutton("bed_n", "803_parentbedroom/bed_n1.webp", null, null);
@@ -367,7 +367,7 @@ room803.btnclick = function (name) {
                 }
                 g.internal.twat = 1;
                 g.internal.p += 7;
-                room803.btnclick("bedprogress");
+                invoker.invokeCurrent("btnclick", "bedprogress");
                 if (g.internal.p > 29) {
                     nav.killbutton("bed_twat");
                     nav.button({
@@ -402,7 +402,7 @@ room803.btnclick = function (name) {
                 }
                 g.internal.twat = 2;
                 g.internal.p += 20;
-                room803.btnclick("bedprogress");
+                invoker.invokeCurrent("btnclick", "bedprogress");
                 if (g.internal.p > 95 && !g.internal.shirt && !g.internal.pants && !g.internal.panties) {
                     nav.killbutton("bed_twat");
                     nav.button({
@@ -623,7 +623,7 @@ room803.chatcatch = function (callback) {
                 pants: true,
                 panties: true
             };
-            room803.btnclick("bedprogress");
+            invoker.invokeCurrent("btnclick", "bedprogress");
             nav.bg("803_parentbedroom/bed_bg.webp");
             nav.button({
                 "type": "img",
@@ -1594,3 +1594,5 @@ room803.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(803, room803);

--- a/scripts/room/room804.js
+++ b/scripts/room/room804.js
@@ -187,7 +187,7 @@ room804.chatcatch = function (callback) {
             sc.modLevel("ralphsmom", 51, 3);
             break;
         case "mom":
-            room804.btnclick("mom");
+            invoker.invokeCurrent("btnclick", "mom");
             break;
         case "muffdiveEnd":
             levels.oral(3, "f", "ralphsmom");
@@ -416,3 +416,5 @@ room804.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(804, room804);

--- a/scripts/room/room825.js
+++ b/scripts/room/room825.js
@@ -58,3 +58,5 @@ room825.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(825, room825);

--- a/scripts/room/room875.js
+++ b/scripts/room/room875.js
@@ -811,3 +811,5 @@ room875.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(875, room875);

--- a/scripts/room/room876.js
+++ b/scripts/room/room876.js
@@ -306,7 +306,7 @@ room876.chatcatch = function (callback) {
                 chat(51, 876);
             }
             else {
-                room876.chatcatch("routine1");
+                invoker.invokeCurrent("chatcatch", "routine1");
                 g.internal.alone = true;
                 g.internal.finish = 1;
                 chat(1001, 876);
@@ -338,7 +338,7 @@ room876.chatcatch = function (callback) {
             char.room(0);
             break;
         case "routine2_1":
-            room876.chatcatch("routine2");
+            invoker.invokeCurrent("chatcatch", "routine2");
             chat(1000, 876);
             break;
         case "routine2_3":
@@ -351,7 +351,7 @@ room876.chatcatch = function (callback) {
             char.room(0);
             break;
         case "routine2_1_1":
-            room876.chatcatch("routine2");
+            invoker.invokeCurrent("chatcatch", "routine2");
             g.internal.alone = true;
             g.internal.finish = 3;
             chat(1001, 876);
@@ -411,6 +411,8 @@ room876.chatcatch = function (callback) {
             break;
     }
 };
+
+invoker.registerRoom(876, room876);
 
 room876.chat = function (chatID) {
     if (chatID === 999) {

--- a/scripts/room/room900.js
+++ b/scripts/room/room900.js
@@ -343,3 +343,5 @@ room900.chat = function(chatID){
 
     return cArray[chatID];
 }
+
+invoker.registerRoom(900, room900);

--- a/scripts/room/room901.js
+++ b/scripts/room/room901.js
@@ -328,11 +328,11 @@ room901.chatcatch = function (callback) {
             char.room(901);
             break;
         case "cindyInc1":
-            room901.chatcatch("reset");
+            invoker.invokeCurrent("chatcatch", "reset");
             break;
         case "cindyInc2":
             sc.completeMissionTask("cindy", "fuck", 0);
-            room901.chatcatch("reset");
+            invoker.invokeCurrent("chatcatch", "reset");
             break;
         case "lola-2":
             char.addtime(120);
@@ -431,7 +431,7 @@ room901.chatcatch = function (callback) {
             break;
         case "boy1":
             sc.completeMissionTask("tim", "fuck", 0);
-            room901.chatcatch("reset");
+            invoker.invokeCurrent("chatcatch", "reset");
             break;
         case "leave":
             char.room(0);
@@ -813,3 +813,5 @@ room901.chat = function(chatID){
 
     return cArray[chatID];
 };
+
+invoker.registerRoom(901, room901);

--- a/scripts/room/room902.js
+++ b/scripts/room/room902.js
@@ -510,3 +510,5 @@ room902.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(902, room902);

--- a/scripts/room/room903.js
+++ b/scripts/room/room903.js
@@ -70,3 +70,5 @@ room903.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(903, room903);

--- a/scripts/room/room904.js
+++ b/scripts/room/room904.js
@@ -166,3 +166,5 @@ room904.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(904, room904);

--- a/scripts/room/room905.js
+++ b/scripts/room/room905.js
@@ -304,3 +304,5 @@ room905.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(905, room905);

--- a/scripts/room/room910.js
+++ b/scripts/room/room910.js
@@ -203,3 +203,5 @@ room910.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(910, room910);

--- a/scripts/room/room911.js
+++ b/scripts/room/room911.js
@@ -71,3 +71,5 @@ room911.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(911, room911);

--- a/scripts/room/room949.js
+++ b/scripts/room/room949.js
@@ -146,3 +146,5 @@ room949.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(949, room949);

--- a/scripts/room/room950.js
+++ b/scripts/room/room950.js
@@ -29,7 +29,7 @@ room950.main = function () {
             return;
         }
         else if (cultRank === "Mother Candidate") {
-            room950.btnclick("drawBG");
+            invoker.invokeCurrent("btnclick", "drawBG");
             nav.button({
                 "type": "img",
                 "name": "eatit",
@@ -66,7 +66,7 @@ room950.main = function () {
         }
         let cultLastCleanNumDays = g.diffDatesByDays(cultLastClean, g.dt);
         if (cultLastCleanNumDays > 3) {
-            room950.btnclick("drawBG");
+            invoker.invokeCurrent("btnclick", "drawBG");
             nav.button({
                 "type": "img",
                 "name": "eatit",
@@ -80,7 +80,7 @@ room950.main = function () {
             return;
         }
         if (cultRank === "Sissy") {
-            room950.btnclick("drawBG");
+            invoker.invokeCurrent("btnclick", "drawBG");
             nav.killbutton("clean"); 
             nav.button({
                 "type": "img",
@@ -107,9 +107,9 @@ room950.main = function () {
         case 4: char.settime(19, g.rand(3, 51)); break;
         default: char.settime(23, g.rand(3, 51)); break;
     }
-    room950.btnclick("drawBG");
+    invoker.invokeCurrent("btnclick", "drawBG");
     
-    room950.btnclick("bars");
+    invoker.invokeCurrent("btnclick", "bars");
     
     if (cl.stinky()) {
         nav.kill();
@@ -168,7 +168,7 @@ room950.main = function () {
         }
         else if (g.dt.getDay() === 0 && crank === "Sissy" && !daily.get("priestSissy")) {
             daily.set("priestSissy");
-            room950.btnclick("bars");
+            invoker.invokeCurrent("btnclick", "bars");
             if (daily.get("celldoor_blonde")) {
                 nav.bg("950_cell/door_bg0.webp");
             }
@@ -193,7 +193,7 @@ room950.main = function () {
                 chat(132, 950);
             }
             else {
-                room950.btnclick("drawBG");
+                invoker.invokeCurrent("btnclick", "drawBG");
                 nav.kill();
                 nav.button({
                     "type": "img",
@@ -218,7 +218,7 @@ room950.main = function () {
             }
             return;
         }
-        room950.btnclick("drawBG"); 
+        invoker.invokeCurrent("btnclick", "drawBG"); 
         nav.button({
             "type": "btn",
             "name": "nap",
@@ -386,7 +386,7 @@ room950.btnclick = function (name) {
                 nav.kill();
                 daily.set("cumwall950", false);
                 gv.set("cultLastClean", g.dt);
-                room950.btnclick("drawBG");
+                invoker.invokeCurrent("btnclick", "drawBG");
                 chat(9, 950);
             }
             break;
@@ -568,7 +568,7 @@ room950.btnclick = function (name) {
                 }
                 gv.mod("cultbrick", brickStrength);
                 gv.mod("energy", -60);
-                room950.btnclick("bars");
+                invoker.invokeCurrent("btnclick", "bars");
 
                 if (gv.get("cultbrick") < 100) {
                     nav.bg("950_cell/chisel.jpg");
@@ -633,7 +633,7 @@ room950.btnclick = function (name) {
             break;
         case "icon_call":
             nav.kill();
-            room950.btnclick("bars");
+            invoker.invokeCurrent("btnclick", "bars");
             if (gv.get("cultCumJob") > 1) {
                 nav.bg("950_cell/ubel2.webp"); 
                 sc.select("icon_cultclean", "950_cell/icon_cultclean.webp", 0);
@@ -702,7 +702,7 @@ room950.btnclick = function (name) {
             break;
         case "icon_door":
             nav.kill();
-            room950.btnclick("bars");
+            invoker.invokeCurrent("btnclick", "bars");
             if (daily.get("celldoor_blonde")) {
                 nav.bg("950_cell/door_bg0.webp");
             }
@@ -851,7 +851,7 @@ room950.btnclick = function (name) {
                 nav.killbutton("door_bj");
                 levels.oral(4, "m", "cult", true);
                 sc.modLevel("cult", 20, 10);
-                room950.btnclick("bars");
+                invoker.invokeCurrent("btnclick", "bars");
                 chat(35, 950);
             }
             g.internal++;
@@ -980,7 +980,7 @@ room950.chatcatch = function (callback) {
             gv.clearButtCum();
             break;
         case "increment":
-            room950.btnclick("increment");
+            invoker.invokeCurrent("btnclick", "increment");
             break;
         case "eat0":
             daily.set("food");
@@ -1169,10 +1169,10 @@ room950.chatcatch = function (callback) {
             break;
         case "serve":
             gv.set("cultCumJob", 2);
-            room950.btnclick("icon_call");
+            invoker.invokeCurrent("btnclick", "icon_call");
             break;
         case "priest1":
-            room950.btnclick("drawBG");
+            invoker.invokeCurrent("btnclick", "drawBG");
             nav.kill();
             nav.button({
                 "type": "img",
@@ -2585,3 +2585,5 @@ room950.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(950, room950);

--- a/scripts/room/room951.js
+++ b/scripts/room/room951.js
@@ -377,3 +377,5 @@ room951.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(951, room951);

--- a/scripts/room/room952.js
+++ b/scripts/room/room952.js
@@ -413,7 +413,7 @@ room952.chatcatch = function (callback) {
         case "reset_c2":
         case "reset_c3": 
         case "reset_c1":
-            room952.btnclick(callback.replace("reset_", ""));
+            invoker.invokeCurrent("btnclick", callback.replace("reset_", ""));
             break;
         case "reset":
             char.room(952);
@@ -526,7 +526,7 @@ room952.chatcatch = function (callback) {
         case "butt4":
             sc.completeMissionTask("bodhi", "cult", 5);
             levels.anal(4, true, "f", false, "daria");
-            room952.chatcatch("leave");
+            invoker.invokeCurrent("chatcatch", "leave");
             break;
         case "l0":
             g.pass = 0;
@@ -597,7 +597,7 @@ room952.chatcatch = function (callback) {
             }
             break;
         case "doubleReset":
-            room952.btnclick("c3");
+            invoker.invokeCurrent("btnclick", "c3");
             break;
         case "ralph3":
             nav.kill();
@@ -1732,3 +1732,5 @@ room952.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(952, room952);

--- a/scripts/room/room953.js
+++ b/scripts/room/room953.js
@@ -892,3 +892,5 @@ room953.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(953, room953);

--- a/scripts/room/room954.js
+++ b/scripts/room/room954.js
@@ -1064,3 +1064,5 @@ room954.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(954, room954);

--- a/scripts/room/room955.js
+++ b/scripts/room/room955.js
@@ -19,7 +19,7 @@ room955.main = function () {
             chat(0, 955);
         }
         else {
-            room950.btnclick("bars");
+            invoker.invoke(950, "btnclick", "bars");
             if (daily.get("celldoor_blonde")) {
                 nav.bg("950_cell/door_bg0.webp");
             }
@@ -719,3 +719,5 @@ room955.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(955, room955);

--- a/scripts/room/room956.js
+++ b/scripts/room/room956.js
@@ -1155,3 +1155,5 @@ room956.chat = function (chatID) {
                 { chatID: -1, text: "*Grumble*", callback: "t6" }
             ]
         },*/
+
+invoker.registerRoom(956, room956);

--- a/scripts/room/room957.js
+++ b/scripts/room/room957.js
@@ -71,7 +71,7 @@ room957.btnclick = function (name) {
             if (g.internal.counter > 7) {
                 nav.kill();
                 nav.bg("957_jobs/kissing1.webp");
-                room950.btnclick("bars")
+                invoker.invoke(950, "btnclick", "bars")
                 zcl.poseExpose(250, 900, .3, "", false);
                 nav.button({
                     "type": "img",
@@ -86,7 +86,7 @@ room957.btnclick = function (name) {
             }
             else if (g.rand(0, 2) === 1) {
                 nav.kill();
-                room950.btnclick("bars")
+                invoker.invoke(950, "btnclick", "bars")
                 nav.bg("957_jobs/kissing1.webp");
                 zcl.poseExpose(250, 900, .3, "", false);
                 nav.button({
@@ -103,7 +103,7 @@ room957.btnclick = function (name) {
             }
             else {
                 nav.kill();
-                room950.btnclick("bars")
+                invoker.invoke(950, "btnclick", "bars")
                 nav.bg("957_jobs/kissing1.webp");
                 zcl.poseExpose(250, 900, .3, "", false);
                 nav.button({
@@ -175,7 +175,7 @@ room957.btnclick = function (name) {
         case "toiletDraw":
             nav.kill();
             nav.bg("957_jobs/toilet_bg.webp");
-            room950.btnclick("bars");
+            invoker.invoke(950, "btnclick", "bars");
             nav.button({
                 "type": "img",
                 "name": "char",
@@ -234,7 +234,7 @@ room957.btnclick = function (name) {
             break;
         case "toilet":
             if (g.internal.counter > 13) {
-                room957.btnclick("toiletDraw");
+                invoker.invokeCurrent("btnclick", "toiletDraw");
                 nav.button({
                     "type": "img",
                     "name": "char",
@@ -249,7 +249,7 @@ room957.btnclick = function (name) {
             else {
                 switch (g.internal.events[0]) {
                     case 0:
-                        room957.btnclick("toiletDraw");
+                        invoker.invokeCurrent("btnclick", "toiletDraw");
                         nav.button({
                             "type": "img",
                             "name": "char",
@@ -265,7 +265,7 @@ room957.btnclick = function (name) {
                     case 1:
                     case 2:
                     case 3:
-                        room957.btnclick("toiletDraw");
+                        invoker.invokeCurrent("btnclick", "toiletDraw");
                         g.internal.asspiss++;
                         nav.button({
                             "type": "img",
@@ -283,7 +283,7 @@ room957.btnclick = function (name) {
                         break;
                     case 4:
                     case 5:
-                        room957.btnclick("toiletDraw");
+                        invoker.invokeCurrent("btnclick", "toiletDraw");
                         g.internal.facepiss++;
                         nav.button({
                             "type": "img",
@@ -301,7 +301,7 @@ room957.btnclick = function (name) {
                         chat(801, 957);
                         break;
                     case 6:
-                        room957.btnclick("toiletDraw");
+                        invoker.invokeCurrent("btnclick", "toiletDraw");
                         nav.button({
                             "type": "img",
                             "name": "char",
@@ -314,7 +314,7 @@ room957.btnclick = function (name) {
                         chat(35, 957);
                         break;
                     case 7:
-                        room957.btnclick("toiletDraw");
+                        invoker.invokeCurrent("btnclick", "toiletDraw");
                         nav.button({
                             "type": "img",
                             "name": "char",
@@ -332,7 +332,7 @@ room957.btnclick = function (name) {
                         chat(43, 957);
                         break;
                     case 9:
-                        room957.btnclick("toiletDraw");
+                        invoker.invokeCurrent("btnclick", "toiletDraw");
                         nav.button({
                             "type": "img",
                             "name": "char",
@@ -360,7 +360,7 @@ room957.btnclick = function (name) {
                 levels.piss(false, false, true, (value === "cult" ? "m" : "f"), value);
             });
             g.internal.facepissWho = [];
-            room957.chatcatch("toilet");
+            invoker.invokeCurrent("chatcatch", "toilet");
             break;
         case "toilet_swallow":
             $.each(g.internal.facepissWho, function (index, value) {
@@ -368,7 +368,7 @@ room957.btnclick = function (name) {
                 levels.piss(true, false, false, (value === "cult" ? "m" : "f"), value);
             });
             g.internal.facepissWho = [];
-            room957.chatcatch("toilet");
+            invoker.invokeCurrent("chatcatch", "toilet");
             break;
         default:
             break;
@@ -391,7 +391,7 @@ room957.chatcatch = function (callback) {
             nav.bg("957_jobs/" + callback + ".webp"); 
             break;
         case "toilet_8_4":
-            room957.btnclick("toiletDraw");
+            invoker.invokeCurrent("btnclick", "toiletDraw");
             nav.button({
                 "type": "img",
                 "name": "bg",
@@ -443,7 +443,7 @@ room957.chatcatch = function (callback) {
             break;
         case "kissing_ev0":
             g.internal.pose = "s";
-            room957.btnclick("kissingClose");
+            invoker.invokeCurrent("btnclick", "kissingClose");
             sc.modLevel("cult", 5, 10);
             nav.button({
                 "type": "img",
@@ -484,7 +484,7 @@ room957.chatcatch = function (callback) {
         case "kissing_ev3":
             nav.kill();
             g.internal.pose = "t";
-            room957.btnclick("kissingClose");
+            invoker.invokeCurrent("btnclick", "kissingClose");
             nav.button({
                 "type": "img",
                 "name": "bg",
@@ -502,7 +502,7 @@ room957.chatcatch = function (callback) {
         case "kissing_ev4":
             nav.kill();
             g.internal.pose = "w";
-            room957.btnclick("kissingClose");
+            invoker.invokeCurrent("btnclick", "kissingClose");
             nav.button({
                 "type": "img",
                 "name": "kissing_ev4",
@@ -515,7 +515,7 @@ room957.chatcatch = function (callback) {
             break;
         case "kissing_ev4_1":
             g.internal.pose = "t";
-            room957.btnclick("kissingClose");
+            invoker.invokeCurrent("btnclick", "kissingClose");
             nav.button({
                 "type": "img",
                 "name": "kissing_ev4",
@@ -533,7 +533,7 @@ room957.chatcatch = function (callback) {
         case "kissing_ev5":
             nav.kill();
             g.internal.pose = "t";
-            room957.btnclick("kissingClose");
+            invoker.invokeCurrent("btnclick", "kissingClose");
             nav.button({
                 "type": "img",
                 "name": "bg",
@@ -586,12 +586,12 @@ room957.chatcatch = function (callback) {
         case "kissingReset":
             nav.kill();
             nav.bg("957_jobs/kissing1.webp");
-            room950.btnclick("bars")
+            invoker.invoke(950, "btnclick", "bars")
             zcl.poseExpose(250, 900, .3, "", false);
             nav.wait("kissing"); 
             break;
         case "toilet":
-            room957.btnclick("toiletDraw");
+            invoker.invokeCurrent("btnclick", "toiletDraw");
             if (g.internal.facepissWho.length > 0) {
                 nav.button({
                     "type": "zbtn",
@@ -617,7 +617,7 @@ room957.chatcatch = function (callback) {
             }
             break;
         case "toilet_6_1":
-            room957.btnclick("toiletDraw");
+            invoker.invokeCurrent("btnclick", "toiletDraw");
             g.internal.facepiss++;
             nav.button({
                 "type": "img",
@@ -662,18 +662,18 @@ room957.chatcatch = function (callback) {
                     chat(48, 957);
             }
             else {
-                room957.chatcatch("leave");
+                invoker.invokeCurrent("chatcatch", "leave");
             }
             break;
         case "toilet_back1":
             nav.kill();
-            room950.btnclick("drawBG");
+            invoker.invoke(950, "btnclick", "drawBG");
             nav.killbutton("clean");
             zcl.assup(730, 400, .5, "", false);
             break;
         case "toilet_back2":
             gv.set("cultLastClean", new Date(gv.get("cultLastClean").getTime() - 604800000));
-            room950.btnclick("drawBG");
+            invoker.invoke(950, "btnclick", "drawBG");
             nav.killbutton("clean");
             nav.kill();
             nav.button({
@@ -690,7 +690,7 @@ room957.chatcatch = function (callback) {
         case "sweepHallway9":
             sc.completeMissionTask("bodhi", "cult", 4);
             sc.startMission("bodhi", "escape");
-            room957.chatcatch("leave");
+            invoker.invokeCurrent("chatcatch", "leave");
             break;
         case "toilet_back3":
             nav.kill();
@@ -1296,3 +1296,5 @@ room957.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(957, room957);

--- a/scripts/room/room958.js
+++ b/scripts/room/room958.js
@@ -28,7 +28,7 @@ room958.main = function () {
     }
     g.map.map[g.map.y][g.map.x].x = "c"; 
     
-    room958.btnclick("displayBackground");
+    invoker.invokeCurrent("btnclick", "displayBackground");
     if (gv.get("energy") < 1) {
         chat(67, 958);
         return;
@@ -88,7 +88,7 @@ room958.main = function () {
             else
                 nav.bg("958_wander/event_c3piss.webp");
             nav.kill();
-            room958.btnclick("displayDirection");
+            invoker.invokeCurrent("btnclick", "displayDirection");
             return;
         case "d":
             nav.bg("958_wander/event_empty.webp");
@@ -255,7 +255,7 @@ room958.btnclick = function (name) {
                     "image": "958_wander/bg_north.webp",
                 }, 958);
             }
-            room958.btnclick("displayDirection");
+            invoker.invokeCurrent("btnclick", "displayDirection");
             break;
         case "displayDirection":
             if (curY > 0 && grid[curY - 1][curX].x !== "x") {
@@ -446,7 +446,7 @@ room958.btnclick = function (name) {
             g.internal++;
             break;
         case "runAway":
-            room958.chatcatch("RunAway");
+            invoker.invokeCurrent("chatcatch", "RunAway");
             break;
         default:
             break;
@@ -604,7 +604,7 @@ room958.chatcatch = function (callback) {
             daily.set("958_slurppiss");
             levels.piss(true, false, false, "f", "!milkmaid");
             nav.bg("958_wander/event_c3.webp");
-            room958.btnclick("displayDirection");
+            invoker.invokeCurrent("btnclick", "displayDirection");
             break;
         case "event_d2":
             nav.bg("958_wander/event_d2.webp");
@@ -715,10 +715,10 @@ room958.chatcatch = function (callback) {
             break;
         case "dariaComplete":
             sc.completeMission("bodhi", "escape", false);
-            room958.btnclick("displayDirection");
+            invoker.invokeCurrent("btnclick", "displayDirection");
             break;
         case "displayDirection":
-            room958.btnclick("displayDirection");
+            invoker.invokeCurrent("btnclick", "displayDirection");
             break;
         case "escape":
             g.pass = "escape";
@@ -1359,3 +1359,5 @@ room958.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(958, room958);

--- a/scripts/room/room975.js
+++ b/scripts/room/room975.js
@@ -86,7 +86,7 @@ room975.chatcatch = function (callback) {
                 gv.st[r[i].i].t = r[i].t;
             }
             cl.display();
-            room2.chatcatch("proceed");
+            invoker.invoke(2, "chatcatch", "proceed");
             break;
         default:
             break;
@@ -143,3 +143,5 @@ room975.chat = function (chatID) {
     else
         return [];
 };
+
+invoker.registerRoom(975, room975);

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -1,44 +1,41 @@
-﻿var sstat = {};
+var sstat = {};
+
+sstat.hormoneText = function (hormone) {
+    if (hormone > 75)
+        return "Transformation Possible";
+    if (hormone > 50)
+        return "Little bit feminine";
+    return "Masculine";
+};
+
+sstat.updateLevelBar = function (stat) {
+    var barWidth = (stat.c / levels.getPointsCapForLevel(stat)) * 100;
+    var levelDesc = levels.desc(stat.n, stat.l);
+    $(".rl-levelheader[data-name='" + stat.n + "']").text(stat.d + " " + stat.l);
+    $(".rl-bar[data-name='" + stat.n + "']").css({ width: barWidth + "%" });
+    $(".rl-level[data-name='" + stat.n + "']").text(levelDesc.txt);
+};
 
 sstat.makeGraph = function () {
     sstat.updateGraph();
 };
 
 sstat.updateGraph = function () {
-    //money
     $("#char_money").text("$" + gv.get("money"));
-    let i, barWidth;
-    //energy
+
+    let i;
     var energy = gv.get("energy");
     var maxenergy = gv.get("maxenergy");
     var energyPercentage = (energy / maxenergy) * 100;
     $(".rl-bar[data-name='energy']").css({ width: energyPercentage + "%" });
     $(".rl-level[data-name='energy']").text(energy + "/" + maxenergy);
 
-    //hormone
     let hormone = gv.get("hormone");
-    let hormonetxt = "";
-    if (hormone > 75)
-        hormonetxt = "Transformation Possible";
-    else if (hormone > 50)
-        hormonetxt = "Little bit feminine";
-    else
-        hormonetxt = "Masculine";
-
     $(".rl-bar[data-name='hormone']").css({ width: hormone + "%" });
-    $(".rl-level[data-name='hormone']").text(hormonetxt);
-
-    
+    $(".rl-level[data-name='hormone']").text(sstat.hormoneText(hormone));
 
     for (i = 0; i < levels.st.length; i++) {
-        if (levels.st[i].display) {
-            barWidth = (levels.st[i].c / levels.getPointsCapForLevel(levels.st[i])) * 100;
-
-            var levelDesc = levels.desc(levels.st[i].n, levels.st[i].l);
-            //console.log($(".rl-levelheader[data-name='" + levels.st[i].n + "']"));
-            $(".rl-levelheader[data-name='" + levels.st[i].n + "']").text(levels.st[i].d + " " + levels.st[i].l);
-            $(".rl-bar[data-name='" + levels.st[i].n + "']").css({ width: barWidth + "%" });
-            $(".rl-level[data-name='" + levels.st[i].n + "']").text(levelDesc.txt);
-        }
+        if (levels.st[i].display)
+            sstat.updateLevelBar(levels.st[i]);
     }
 };

--- a/scripts/supportingChar.js
+++ b/scripts/supportingChar.js
@@ -2004,22 +2004,13 @@ sc.startMission = function (name, missionName, mStatus = 1) {
         sc.setMission(name, missionName, mStatus);
 };
 
-sc.getMission = function (name, missionName) {
+sc.getMissionEntry = function (name, missionName) {
     for (var i = 0; i < sc.charMission.length; i++) {
         if (sc.charMission[i].name === name) {
-
-            for (j = 0; j < sc.charMission[i].mission.length; j++) {
+            for (var j = 0; j < sc.charMission[i].mission.length; j++) {
                 if (sc.charMission[i].mission[j].missionName === missionName) {
-
                     return {
-                        mStatus: sc.charMission[i].mission[j].mStatus,
-                        notStarted: sc.charMission[i].mission[j].mStatus < 1,
-                        inProgress: sc.charMission[i].mission[j].mStatus > 0 && sc.charMission[i].mission[j].mStatus < 100,
-                        complete: sc.charMission[i].mission[j].mStatus > 99,
-                        success: sc.charMission[i].mission[j].mStatus === 100,
-                        fail: sc.charMission[i].mission[j].mStatus === 101,
-                        startedOrComplete: sc.charMission[i].mission[j].mStatus > 0,
-                        startedOrSuccess: sc.charMission[i].mission[j].mStatus > 0 && sc.charMission[i].mission[j].mStatus !== 101,
+                        mission: sc.charMission[i].mission[j],
                         i: i,
                         j: j
                     };
@@ -2032,24 +2023,61 @@ sc.getMission = function (name, missionName) {
     return null;
 };
 
-sc.getMissionTask = function (name, missionName, taskId) {
-    var ml = sc.getMission(name, missionName);
-    let i;
-    for (i = 0; i < sc.charMission[ml.i].mission[ml.j].task.length; i++) {
-        if (sc.charMission[ml.i].mission[ml.j].task[i].id === taskId) {
-            var mstatus = sc.charMission[ml.i].mission[ml.j].task[i].mStatus;
+sc.getMission = function (name, missionName) {
+    var missionEntry = sc.getMissionEntry(name, missionName);
+    if (missionEntry === null)
+        return null;
+
+    var mission = missionEntry.mission;
+    return {
+        mStatus: mission.mStatus,
+        notStarted: mission.mStatus < 1,
+        inProgress: mission.mStatus > 0 && mission.mStatus < 100,
+        complete: mission.mStatus > 99,
+        success: mission.mStatus === 100,
+        fail: mission.mStatus === 101,
+        startedOrComplete: mission.mStatus > 0,
+        startedOrSuccess: mission.mStatus > 0 && mission.mStatus !== 101,
+        i: missionEntry.i,
+        j: missionEntry.j
+    };
+};
+
+sc.getMissionTaskEntry = function (name, missionName, taskId) {
+    var missionInfo = sc.getMission(name, missionName);
+    if (missionInfo === null)
+        return null;
+
+    var taskList = sc.charMission[missionInfo.i].mission[missionInfo.j].task;
+    for (var i = 0; i < taskList.length; i++) {
+        if (taskList[i].id === taskId) {
             return {
-                mStatus: mstatus,
-                notStarted: mstatus < 1,
-                inProgress: mstatus > 0 && mstatus < 100,
-                complete: mstatus > 99,
-                success: mstatus === 100,
-                fail: mstatus === 101,
-                startedOrComplete: mstatus > 0,
+                task: taskList[i],
+                mission: missionInfo,
                 i: i
             };
         }
     }
+
+    return null;
+};
+
+sc.getMissionTask = function (name, missionName, taskId) {
+    var taskEntry = sc.getMissionTaskEntry(name, missionName, taskId);
+    if (taskEntry === null)
+        return null;
+
+    var mstatus = taskEntry.task.mStatus;
+    return {
+        mStatus: mstatus,
+        notStarted: mstatus < 1,
+        inProgress: mstatus > 0 && mstatus < 100,
+        complete: mstatus > 99,
+        success: mstatus === 100,
+        fail: mstatus === 101,
+        startedOrComplete: mstatus > 0,
+        i: taskEntry.i
+    };
 };
 
 sc.taskGetStepEndMission = function (name) {
@@ -2153,14 +2181,9 @@ sc.startMissionTask = function (name, missionName, taskId) {
 };
 
 sc.modMissionTask = function (name, missionName, taskId, modNum) {
-    var ml = sc.getMission(name, missionName);
-
-    for (var k = 0; k < sc.charMission[ml.i].mission[ml.j].task.length; k++) {
-        if (sc.charMission[ml.i].mission[ml.j].task[k].id === taskId) {
-            sc.charMission[ml.i].mission[ml.j].task[k].mStatus += modNum;
-            return;
-        }
-    }
+    var taskEntry = sc.getMissionTaskEntry(name, missionName, taskId);
+    if (taskEntry !== null)
+        taskEntry.task.mStatus += modNum;
 };
 
 sc.completeMission = function (name, missionName, success = true, closed = false) {
@@ -2181,12 +2204,12 @@ sc.taskGetStep = function (name, missionName) {
         return -1;
     else if (ml.fail)
         return -2;
-    for (var k = 0; k < sc.charMission[ml.i].mission[j].task.length; k++) {
-        if (sc.charMission[ml.i].mission[j].task[k].mStatus < 100)
-            return sc.charMission[ml.i].mission[j].task[k].id;
+    for (var k = 0; k < sc.charMission[ml.i].mission[ml.j].task.length; k++) {
+        if (sc.charMission[ml.i].mission[ml.j].task[k].mStatus < 100)
+            return sc.charMission[ml.i].mission[ml.j].task[k].id;
     }
 
-    return sc.charMission[ml.i].mission[j].task.length;
+    return sc.charMission[ml.i].mission[ml.j].task.length;
 };
 
 sc.setMission = function (name, missionName, mStatus) {
@@ -2195,14 +2218,9 @@ sc.setMission = function (name, missionName, mStatus) {
 };
 
 sc.setMissionTask = function (name, missionName, taskId, mStatus) {
-    var ml = sc.getMission(name, missionName);
-
-    for (var k = 0; k < sc.charMission[ml.i].mission[ml.j].task.length; k++) {
-        if (sc.charMission[ml.i].mission[ml.j].task[k].id === taskId) {
-            sc.charMission[ml.i].mission[ml.j].task[k].mStatus = mStatus;
-            return;
-        }
-    }
+    var taskEntry = sc.getMissionTaskEntry(name, missionName, taskId);
+    if (taskEntry !== null)
+        taskEntry.task.mStatus = mStatus;
 }
 
 sc.modSecret = function (name, amount) {
@@ -2285,25 +2303,47 @@ sc.getSecret = function (name) {
 };
 
 sc.getstep = function (name) {
-    //alert("sc.getstep: " + name);
-    console.log("error");
+    var i = sc.i(name);
+    if (i < 0)
+        return 0;
+    return sc.char[i].step;
 };
 
 sc.setstep = function (name, step) {
-    //alert(name + step);
-    console.log("error");
+    if (step < 0) {
+        sc.setEvent(name, step);
+        return;
+    }
+    var i = sc.i(name);
+    if (i < 0)
+        return;
+    sc.char[i].step = step;
 };
 
 sc.incstep = function (name, amount) {
-    console.log("error");
+    var i = sc.i(name);
+    if (i < 0)
+        return;
+    sc.char[i].step += amount;
 };
 
 sc.getEvent = function (name, step) {
-    console.log("error");
+    var i = sc.i(name);
+    if (i < 0)
+        return false;
+    if (!Array.isArray(sc.char[i].events))
+        sc.char[i].events = [];
+    return sc.char[i].events.includes(step);
 };
 
 sc.setEvent = function (name, step) {
-    console.log("error");
+    var i = sc.i(name);
+    if (i < 0)
+        return;
+    if (!Array.isArray(sc.char[i].events))
+        sc.char[i].events = [];
+    if (!sc.char[i].events.includes(step))
+        sc.char[i].events.push(step);
 };
 
 sc.save = function () {
@@ -2317,6 +2357,8 @@ sc.save = function () {
     for (i = 0; i < sc.char.length; i++) {
         retArra.char.push({
             name: sc.char[i].name,
+            step: sc.char[i].step,
+            events: Array.isArray(sc.char[i].events) ? sc.char[i].events.slice() : [],
             c: sc.char[i].c,
             l: sc.char[i].l,
             display: sc.char[i].display,
@@ -2347,6 +2389,8 @@ sc.load = function (ra) {
         for (j = 0; j < sc.char.length; j++) {
             if (ra.char[i].name === sc.char[j].name) {
                 sc.char[j].display = ra.char[i].display;
+                sc.char[j].step = typeof ra.char[i].step === "number" ? ra.char[i].step : 0;
+                sc.char[j].events = Array.isArray(ra.char[i].events) ? ra.char[i].events.slice() : [];
                 sc.char[j].c = ra.char[i].c;
                 sc.char[j].l = ra.char[i].l;
                 if (typeof ra.char[i].secret !== "undefined")
@@ -2788,29 +2832,50 @@ sc.getTimeline = function (char) {
     return retVar;
 };
 
-sc.selectBg = function (name) {
+sc.selectButtonPosition = function (index) {
+    return {
+        left: 400 + ((Math.abs(index) % 2) * 700),
+        top: 200 + (Math.floor(index / 2) * 120)
+    };
+};
+
+sc.drawSelectionButton = function (config, roomId = null) {
+    if (roomId === null)
+        roomId = g.roomID;
+
     nav.button({
-        "type": "img",
-        "name": name,
-        "left": 0,
-        "top": 0,
-        "width": 1920,
-        "height": 1080,
-        "image": "1001_rand/black_25.png"
-    }, g.roomID);
-}
+        "type": config.type,
+        "name": config.name,
+        "left": config.left,
+        "top": config.top,
+        "width": config.width,
+        "height": config.height,
+        "image": config.image
+    }, roomId);
+};
+
+sc.selectBg = function (name) {
+    sc.drawSelectionButton({
+        type: "img",
+        name: name,
+        left: 0,
+        top: 0,
+        width: 1920,
+        height: 1080,
+        image: "1001_rand/black_25.png"
+    });
+};
 
 sc.select = function (name, img, i, sRoomId = null) {
-    if (sRoomId === null)
-        sRoomId = g.roomID;
-    nav.button({
-        "type": "btn",
-        "name": name,
-        "left": 400 + ((Math.abs(i) % 2) * 700),
-        "top": 200 + (Math.floor(i / 2) * 120),
-        "width": 600,
-        "height": 100,
-        "image": img
+    const position = sc.selectButtonPosition(i);
+    sc.drawSelectionButton({
+        type: "btn",
+        name: name,
+        left: position.left,
+        top: position.top,
+        width: 600,
+        height: 100,
+        image: img
     }, sRoomId);
 };
 
@@ -2900,7 +2965,7 @@ sc.phone = function (char) {
                     else if (g.roomID === 10) {
                         g.pass = "phonecall";
                         menu.mClick("close");
-                        room7.main();
+                        invoker.invoke(7, "main");
                     }
                     else {
                         clist = [
@@ -2990,7 +3055,7 @@ sc.phone = function (char) {
                         else {
                             menu.mClick("close");
                             menu.mClick("close");
-                            room450.btnclick("lolaPark");
+                            invoker.invoke(450, "btnclick", "lolaPark");
                         }
                     }
                     else {
@@ -3017,7 +3082,7 @@ sc.phone = function (char) {
                         else {
                             menu.mClick("close");
                             menu.mClick("close");
-                            room450.btnclick("lolaPark12");
+                            invoker.invoke(450, "btnclick", "lolaPark12");
                         }
                     }
                     else {
@@ -3071,39 +3136,129 @@ sc.phoneChat = function (chatList, char) {
 };
 
 
+sc.trivialLookup = {
+    "!blank": { display: "DEV NOTES", image: "blank.png" },
+    "!burlysecurity": { display: "Security", image: "burlySecurity.png" },
+    "!fatdogguy": { display: "Fatty McGillicutty", image: "fatdogguy.png" },
+    "!constworker0": { display: "Tits McGee", image: "constWorker0.png" },
+    "!sanaria": { display: "Sanaria", image: "sanaria.png" },
+    "!philbert": { display: "Philbert", image: "philbert.png" },
+    "!sporty": { display: "Sporty", image: "sporty.png" },
+    "!jeremy": { display: "Jeremy", image: "jeremy.png" },
+    "!martin": { display: "Martin", image: "martin.png" },
+    "!missyguardday": { display: "Guard", image: "missyguardday.png" },
+    "!missyguardnight": { display: "Guard", image: "missyguardnight.png" },
+    "!stoner": { display: "Stoney", image: "stoner.png" },
+    "!cheezy": { display: "Cheezy Poof", image: "cheezy.png" },
+    "!nips": { display: "Nips McTits", image: "nips.png" },
+    "!lep": { display: "Telchar", image: "lep.png" },
+    "bitch": { display: "Bitch Face", image: "bitch.png" },
+    "!twat": { display: "Twaty Honey", image: "twat.png" },
+    "!madison": { display: "Nurse Madison", image: "madison.png" },
+    "!boy": { display: "Boy", image: "boy.png" },
+    "!man": { display: "Man", image: "boy.png" },
+    "!girl": { display: "Girl", image: "girl.png" },
+    "!oldlady": { display: "Old lady", image: "oldlady.png" },
+    "!football": { display: "Player", image: "football.png" },
+    "!waiter": { display: "Waiter", image: "waiter.png" },
+    "!plumber": { display: "Plumber", image: "plumber.png" },
+    "!bill": { display: "Bill", image: "bill.png" },
+    "!punk": { display: "Punk Rocker", image: "punk.png" },
+    "!m": { display: "Marilyn", image: "m.png" },
+    "!peeguy": { display: "Peeing Asshole", image: "peeguy.png" },
+    "!chem": { display: "Chemist", image: "chem.png" },
+    "!rex": { display: "Mr. Rex", image: "rex.png" },
+    "!gamerboy": { display: "Gamer", image: "gamerboy.png" },
+    "!gamergirl": { display: "Miss M.", image: "gamergirl.png" },
+    "!gameman": { display: "Some guy", image: "gameman.png" },
+    "!g": { display: "Geoffrey", image: "g.png" },
+    "!glory": { display: "Glory Hole Customer", image: "unk.png" },
+    "!poppy": { display: "Poppy", image: "poppy.png" },
+    "!juniper": { display: "Juniper", image: "juniper.png" },
+    "!emily": { display: "Emily", image: "emily.png" },
+    "!cindy": { display: "Cindy", image: "cindy.png" },
+    "!missx": { display: "Mistress Anaru", image: "missx.png" },
+    "!jenna": { display: "Jenna", image: "jenna.png" },
+    "!footballguard": { display: "Security", image: "footballguard.png" },
+    "!airwrecka": { display: "Airwrecka", image: "airwrecka.png" },
+    "!boxes": { display: "Mike", image: "boxes.png" },
+    "!bwc": { display: "BWC", image: "bwc.png" },
+    "!bbc": { display: "BBC", image: "bbc.png" },
+    "!deb": { display: "Deb", image: "deb.png" },
+    "!latika": { display: "Latika", image: "latika.png" },
+    "!doofus": { display: "Doofus", image: "doofus.png" },
+    "!custbitch": { display: "Mean girl", image: "custbitch.png" },
+    "!jabari": { display: "Jabari", image: "jabari.png" },
+    "!rape0": { display: "Rapist", image: "rape0.png" },
+    "!rape12": { display: "Big Benny Cox", image: "rape12.png" },
+    "!duo13": { display: "Abbot", image: "duo13.png" },
+    "!duo13a": { display: "Costello", image: "duo13a.png" },
+    "!peggy": { display: "Peggy", image: "peggy.png" },
+    "!caveslave": { display: "Slave", image: "caveslave.png" },
+    "!damselle": { display: "Damselle", image: "damselle.png" },
+    "!futa0": { display: "Domina Dix", image: "futa0.png" },
+    "!futa1": { display: "Jessica", image: "futa1.png" },
+    "!plant": { display: "Vines", image: "futa0.png" },
+    "!granola": { display: "Wild River", image: "granola.png" },
+    "!girl2": { display: "Tits McGee", image: "girl2.png" },
+    "!girl3": { display: "Delilah", image: "girl3.png" },
+    "!girl3a": { display: "Willow", image: "girl3a.png" },
+    "!butler": { display: "The Butler", image: "butler.png" },
+    "!cat": { display: "Kitty", image: "cat.png" },
+    "!jarome": { display: "Jarome", image: "jarome.png" },
+    "!freddy": { display: "Fat Freddy", image: "freddy.png" },
+    "!frank": { display: "Fat Franky", image: "frank.png" },
+    "!wolf": { display: "Dire wolf", image: "wolf.png" },
+    "!crystal": { display: "Crystal", image: "crystal.png" },
+    "!judge": { display: "Reginald Esq. III", image: "judge.png" },
+    "!fatnun": { display: "Sister Edna", image: "fatnun.png" },
+    "!jail0": { display: "Fat dick prisoner", image: "jail0.png" },
+    "!jail1": { display: "Long dick prisoner", image: "jail1.png" },
+    "!music": { display: "", image: "music.png" },
+    "!skank": { display: "Skanky Bitch", image: "skank.png" },
+    "!belle": { display: "Belle", image: "belle.png" },
+    "!seller": { display: "LeRoy", image: "seller.png" },
+    "!dog": { display: "Doggy", image: "dog.png" },
+    "!ann": { display: "Announcer", image: "ann.png" },
+    "!barker": { display: "Barker", image: "barker.png" },
+    "!statue": { display: "Stone Statue", image: "statue.png" },
+    "!security": { display: "Security", image: "security.png" },
+    "!rancher": { display: "Drake", image: "rancher.png" },
+    "!rancher1": { display: "Clint", image: "rancher1.png" },
+    "!hucow": { display: "Hucow", image: "hucow.png" },
+    "!pig": { display: "Piggy", image: "pig.png" },
+    "!horse": { display: "Horse", image: "horse.png" },
+    "!cowboy": { display: "Cowboy", image: "cowboy.png" },
+    "!chef": { display: "Fat Bastard", image: "chef.png" },
+    "!info": { display: "Information", image: "info.png" },
+    "!fatman": { display: "Fat Man", image: "fatman.png" },
+    "!milkmaid": { display: "Milk Maid", image: "milkmaid.png" },
+    "!sissy_ass": { display: "Rim Job Recipient ", image: "sissy_ass.png" },
+    "!sissy_trio": { display: "Pookykins", image: "sissy_trio.png" },
+    "!sissy_duo": { display: "Sapphire", image: "sissy_duo.png" },
+    "!sissy_duo1": { display: "Onyx", image: "sissy_duo1.png" },
+    "!sissy_smoke": { display: "Salvatore", image: "sissy_smoke.png" },
+    "!sissy_tiedup": { display: "Tangerine Tease", image: "sissy_tiedup.png" },
+    "!sissy_toilet": { display: "Toilet", image: "sissy_toilet.png" },
+    "!ledja": { display: "Ledja", image: "ledja.png" },
+    "!nar": { display: "Narrator ", image: "nar.png" },
+    "!wolfgirl": { display: "Snail Trail", image: "wolfgirl.png" },
+    "!tree": { display: "Tree branch", image: "tree.png" }
+};
+
 sc.trivial = function (charname) {
     var name, image;
+    var trivialEntry = sc.trivialLookup[charname];
+    if (trivialEntry)
+        return { display: trivialEntry.display, image: trivialEntry.image };
+
     switch (charname) {
-        case "!blank":
-            name = "DEV NOTES";
-            image = "blank.png";
-            break;
-        case "!burlysecurity":
-            name = "Security";
-            image = "burlySecurity.png";
-            break;
-        case "!fatdogguy":
-            name = "Fatty McGillicutty";
-            image = "fatdogguy.png";
-            break;
-        case "!constworker0":
-            name = "Tits McGee";
-            image = "constWorker0.png";
-            break;
-        case "!sanaria":
-            name = "Sanaria";
-            image = "sanaria.png";
-            break;
         case "!kareem":
             if (sissy.st[10].ach)
                 name = "Kesia"
             else
                 name = "Kareem";
             image = "kareem.png";
-            break;
-        case "!philbert":
-            name = "Philbert";
-            image = "philbert.png";
             break;
         case "!chris":
             if (sissy.st[10].ach)
@@ -3127,416 +3282,6 @@ sc.trivial = function (charname) {
                 name = "Timothy";
             }
             image = "timothy.png";
-            break;
-        case "!sporty":
-            name = "Sporty";
-            image = "sporty.png";
-            break;
-        case "!jeremy":
-            //if (sissy.st[10].ach) {
-            //    name = "Jenny"
-            //}
-            //else {
-            //    name = "Jeremy";
-            //}
-            name = "Jeremy";
-            image = "jeremy.png";
-            break;
-        case "!martin":
-            name = "Martin";
-            image = "martin.png";
-            break;
-        case "!missyguardday":
-            name = "Guard"; 
-            image = "missyguardday.png";
-            break;
-        case "!missyguardnight":
-            name = "Guard";
-            image = "missyguardnight.png";
-            break;
-        case "!stoner":
-            name = "Stoney";
-            image = "stoner.png";
-            break;
-        case "!cheezy":
-            name = "Cheezy Poof";
-            image = "cheezy.png";
-            break;
-        case "!nips":
-            name = "Nips McTits";
-            image = "nips.png";
-            break;
-        case "!lep":
-            name = "Telchar";
-            image = "lep.png";
-            break;
-        case "bitch":
-            name = "Bitch Face";
-            image = "bitch.png";
-            break;
-        case "!twat":
-            name = "Twaty Honey";
-            image = "twat.png";
-            break;
-        case "!madison":
-            name = "Nurse Madison";
-            image = "madison.png";
-            break;
-        case "!boy":
-            name = "Boy";
-            image = "boy.png";
-            break;
-        case "!man":
-            name = "Man";
-            image = "boy.png";
-            break;
-        case "!girl":
-            name = "Girl";
-            image = "girl.png";
-            break;
-        case "!oldlady":
-            name = "Old lady";
-            image = "oldlady.png";
-            break;
-        case "!football":
-            name = "Player";
-            image = "football.png";
-            break;
-        case "!waiter":
-            name = "Waiter";
-            image = "waiter.png";
-            break;
-        case "!plumber":
-            name = "Plumber";
-            image = "plumber.png";
-            break;
-        case "!bill":
-            name = "Bill";
-            image = "bill.png";
-            break;
-        case "!punk":
-            name = "Punk Rocker";
-            image = "punk.png";
-            break;
-        case "!m":
-            name = "Marilyn";
-            image = "m.png";
-            break;
-        case "!peeguy":
-            name = "Peeing Asshole";
-            image = "peeguy.png";
-            break;
-        case "!chem":
-            name = "Chemist";
-            image = "chem.png";
-            break;
-        case "!rex":
-            name = "Mr. Rex";
-            image = "rex.png";
-            break;
-        case "!gamerboy":
-            name = "Gamer";
-            image = "gamerboy.png";
-            break;
-        case "!gamergirl":
-            name = "Miss M.";
-            image = "gamergirl.png";
-            break;
-        case "!gameman":
-            name = "Some guy";
-            image = "gameman.png";
-            break;
-        case "!g":
-            name = "Geoffrey";
-            image = "g.png";
-            break;
-        case "!glory":
-            name = "Glory Hole Customer";
-            image = "unk.png";
-            break;
-        case "!poppy":
-            name = "Poppy";
-            image = "poppy.png";
-            break;
-        case "!juniper":
-            name = "Juniper";
-            image = "juniper.png";
-            break;
-        case "!emily":
-            name = "Emily";
-            image = "emily.png";
-            break;
-        case "!cindy":
-            name = "Cindy";
-            image = "cindy.png";
-            break;
-        case "!missx":
-            name = "Mistress Anaru";
-            image = "missx.png";
-            break;
-        case "!jenna":
-            name = "Jenna";
-            image = "jenna.png";
-            break;
-        case "!footballguard":
-            name = "Security";
-            image = "footballguard.png";
-            break;
-        case "!airwrecka":
-            name = "Airwrecka";
-            image = "airwrecka.png";
-            break;
-        case "!boxes":
-            name = "Mike";
-            image = "boxes.png";
-            break;
-        case "!bwc":
-            name = "BWC";
-            image = "bwc.png";
-            break;
-        case "!bbc":
-            name = "BBC";
-            image = "bbc.png";
-            break;
-        case "!deb":
-            name = "Deb";
-            image = "deb.png";
-            break;
-        case "!latika":
-            name = "Latika";
-            image = "latika.png";
-            break;
-        case "!doofus":
-            name = "Doofus";
-            image = "doofus.png";
-            break;
-        case "!custbitch":
-            name = "Mean girl";
-            image = "custbitch.png";
-            break;
-        case "!jabari":
-            name = "Jabari";
-            image = "jabari.png";
-            break;
-        case "!rape0":
-            name = "Rapist";
-            image = "rape0.png";
-            break;
-        case "!rape12":
-            name = "Big Benny Cox";
-            image = "rape12.png";
-            break;
-        case "!duo13":
-            name = "Abbot";
-            image = "duo13.png";
-            break;
-        case "!duo13a":
-            name = "Costello";
-            image = "duo13a.png";
-            break;
-        case "!peggy":
-            name = "Peggy";
-            image = "peggy.png";
-            break;
-        case "!caveslave":
-            name = "Slave";
-            image = "caveslave.png";
-            break;
-        case "!damselle":
-            name = "Damselle";
-            image = "damselle.png";
-            break;
-        case "!futa0":
-            name = "Domina Dix";
-            image = "futa0.png";
-            break;
-        case "!futa1":
-            name = "Jessica";
-            image = "futa1.png";
-            break;
-        case "!plant":
-            name = "Vines";
-            image = "futa0.png";
-            break;
-        case "!granola":
-            name = "Wild River"
-            image = "granola.png";
-            break;
-        case "!girl2":
-            name = "Tits McGee";
-            image = "girl2.png"
-            break;
-        case "!girl3":
-            name = "Delilah";
-            image = "girl3.png"
-            break;
-        case "!girl3a":
-            name = "Willow";
-            image = "girl3a.png"
-            break;
-        case "!butler":
-            name = "The Butler";
-            image = "butler.png";
-            break;
-        case "!cat":
-            name = "Kitty";
-            image = "cat.png";
-            break;
-        case "!jarome":
-            name = "Jarome";
-            image = "jarome.png";
-            break;
-        case "!freddy":
-            name = "Fat Freddy";
-            image = "freddy.png";
-            break;
-        case "!frank":
-            name = "Fat Franky";
-            image = "frank.png";
-            break;
-        case "!wolf":
-            name = "Dire wolf";
-            image = "wolf.png";
-            break;
-        case "!crystal":
-            name = "Crystal";
-            image = "crystal.png";
-            break;
-        case "!judge":
-            name = "Reginald Esq. III";
-            image = "judge.png";
-            break;
-        case "!fatnun":
-            name = "Sister Edna";
-            image = "fatnun.png";
-            break;
-        case "!jail0":
-            name = "Fat dick prisoner";
-            image = "jail0.png";
-            break;
-        case "!jail1":
-            name = "Long dick prisoner";
-            image = "jail1.png";
-            break;
-        case "!music":
-            name = "";
-            image = "music.png";
-            break;
-        case "!skank":
-            name = "Skanky Bitch";
-            image = "skank.png";
-            break;
-        case "!belle":
-            name = "Belle";
-            image = "belle.png";
-            break;
-        case "!seller":
-            name = "LeRoy";
-            image = "seller.png";
-            break;
-        case "!dog":
-            name = "Doggy";
-            image = "dog.png";
-            break;
-        case "!ann":
-            name = "Announcer";
-            image = "ann.png";
-            break;
-        case "!barker":
-            name = "Barker";
-            image = "barker.png";
-            break;
-        case "!statue":
-            name = "Stone Statue";
-            image = "statue.png";
-            break;
-        case "!security":
-            name = "Security";
-            image = "security.png";
-            break;
-        case "!rancher":
-            name = "Drake";
-            image = "rancher.png";
-            break;
-        case "!rancher1":
-            name = "Clint";
-            image = "rancher1.png";
-            break;
-        case "!hucow":
-            name = "Hucow";
-            image = "hucow.png";
-            break;
-        case "!pig":
-            name = "Piggy";
-            image = "pig.png";
-            break;
-        case "!horse":
-            name = "Horse";
-            image = "horse.png";
-            break;
-        case "!cowboy":
-            name = "Cowboy";
-            image = "cowboy.png";
-            break;
-        case "!chef":
-            name = "Fat Bastard";
-            image = "chef.png";
-            break;
-        case "!info":
-            name = "Information";
-            image = "info.png";
-            break;
-        case "!fatman":
-            name = "Fat Man";
-            image = "fatman.png";
-            break;
-        case "!milkmaid":
-            name = "Milk Maid";
-            image = "milkmaid.png";
-            break;
-        case "!sissy_ass":
-            name = "Rim Job Recipient ";
-            image = "sissy_ass.png";
-            break;
-        case "!sissy_trio":
-            name = "Pookykins";
-            image = "sissy_trio.png";
-            break;
-        case "!sissy_duo":
-            name = "Sapphire";
-            image = "sissy_duo.png";
-            break;
-        case "!sissy_duo1":
-            name = "Onyx";
-            image = "sissy_duo1.png";
-            break;
-        case "!sissy_smoke":
-            name = "Salvatore";
-            image = "sissy_smoke.png";
-            break;
-        case "!sissy_tiedup":
-            name = "Tangerine Tease";
-            image = "sissy_tiedup.png";
-            break;
-        case "!sissy_toilet":
-            name = "Toilet";
-            image = "sissy_toilet.png";
-            break;
-        case "!ledja":
-            name = "Ledja";
-            image = "ledja.png";
-            break;
-        case "!nar":
-            name = "Narrator ";
-            image = "nar.png";
-            break;
-        case "!wolfgirl":
-            name = "Snail Trail";
-            image = "wolfgirl.png";
-            break;
-        case "!tree":
-            name = "Tree branch";
-            image = "tree.png";
             break;
         default:
             console.log("unknown trivial char: (check capitilazation)" + charname);

--- a/scripts/trap.js
+++ b/scripts/trap.js
@@ -10,6 +10,35 @@ trap.callbackWin;
 trap.name;
 trap.internal;
 trap.location;
+trap.actionButtonLeft = 1600;
+trap.actionButtonTop = 480;
+trap.actionButtonSpacing = 75;
+
+trap.drawPanelBackground = function (image = "1005_trap/trap_message.png", name = "m1004-dx") {
+    nav.button({
+        "type": "zimg",
+        "name": name,
+        "left": 1600,
+        "top": 150,
+        "width": 300,
+        "height": 318,
+        "image": image
+    }, 1005);
+};
+
+trap.renderActionButtons = function (btnList, top = trap.actionButtonTop) {
+    for (let i = 0; i < btnList.length; i++) {
+        nav.button({
+            "type": "zbtn",
+            "name": "b1004-" + btnList[i].n,
+            "left": trap.actionButtonLeft,
+            "top": top + (i * trap.actionButtonSpacing),
+            "width": 300,
+            "height": 72,
+            "image": "1005_trap/" + btnList[i].i
+        }, 1005);
+    }
+};
 
 //hole, treasure, treasureAzrael, encounter, rope
 trap.init = function (trapType = "rope", location = "forest", roomId = g.roomID, callbackWin = "", trapNum = null) {
@@ -30,16 +59,7 @@ trap.init = function (trapType = "rope", location = "forest", roomId = g.roomID,
     }
 
     if (trap.type === "treasure" || trap.type === "treasureAzrael") {
-
-        nav.button({
-            "type": "zimg",
-            "name": "m1004-dx",
-            "left": 1600,
-            "top": 150,
-            "width": 300,
-            "height": 318,
-            "image": "1005_trap/trap_message_treasure.png"
-        }, 1005);
+        trap.drawPanelBackground("1005_trap/trap_message_treasure.png");
         trap.treasure(trapNum);
         return;
     }
@@ -58,29 +78,13 @@ trap.init = function (trapType = "rope", location = "forest", roomId = g.roomID,
     else if (location === "cave") {
         nav.bg("1005_trap/trap_c.jpg");
     }
-    nav.button({
-        "type": "zimg",
-        "name": "m1004-dx",
-        "left": 1600,
-        "top": 150,
-        "width": 300,
-        "height": 318,
-        "image": "1005_trap/trap_message.png"
-    }, 1005);
+    trap.drawPanelBackground();
     trap.displayMenu("init");
 };
 
 trap.roll = function () {
     nav.killbutton("m1004-dx");
-    nav.button({
-        "type": "zimg",
-        "name": "m1004-dx",
-        "left": 1600,
-        "top": 150,
-        "width": 300,
-        "height": 318,
-        "image": "1004_rape/icon_bg.png"
-    }, 1005);
+    trap.drawPanelBackground("1004_rape/icon_bg.png");
 
     var diceArray = new Array();
     var i;
@@ -225,17 +229,7 @@ trap.displayMenu = function (menu) {
             break;
     }
 
-    for (i = 0; i < btnList.length; i++) {
-        nav.button({
-            "type": "zbtn",
-            "name": "b1004-" + btnList[i].n,
-            "left": 1600,
-            "top": 480 + (i * 75),
-            "width": 300,
-            "height": 72,
-            "image": "1005_trap/" + btnList[i].i
-        }, 1005);
-    }
+    trap.renderActionButtons(btnList);
 };
 
 trap.message = function (message) {
@@ -941,7 +935,7 @@ trap.kill = function (roomId = null) {
     trap.counter = 0;
     if (roomId === null) {
         nav.killall();
-        window[g.room(trap.roomId)]["btnclick"](trap.callbackWin);
+        invoker.invoke(trap.roomId, "btnclick", trap.callbackWin);
     }
     else if(roomId === 701) {
         g.pass = 701;
@@ -2865,3 +2859,5 @@ room1005.chat = function (chatID) {
             return [];
     }
 };
+
+invoker.registerRoom(1005, room1005);

--- a/startGame.html
+++ b/startGame.html
@@ -9,6 +9,7 @@
     <script src="./scripts/jquery-3.2.1.min.js" type="text/javascript"></script>
 
     <script src="./scripts/global.js" type="text/javascript"></script>
+    <script src="./scripts/invoker.js" type="text/javascript"></script>
     <script src="./scripts/gamevariables.js" type="text/javascript"></script>
     <script src="./scripts/clothes.js" type="text/javascript"></script>
     <script src="./scripts/clothes_zcl.js" type="text/javascript"></script>
@@ -382,7 +383,7 @@
             <div id="room_left_map" class="left-menu">
             </div>
             <div id="room_left_walk" class="left-menu">
-                <div id="room_left_walk_sub" class="resize"></div>
+                <div id="room_left_walk_sub" class="glob-bg"></div>
             </div>
             <div id="room_left_graph" class="left-menu">
                 <div style="padding:5px; color: #fff; text-align:center;" class="glob-bg">
@@ -667,7 +668,7 @@
         <img src="./images/general/btnGraph.jpg" title="Graph" style="width:100%;" />
     </button>
     <button class="resize rl-change" data-type="walk" style="display:none;">
-        <img src="./images/general/btnHide.jpg" title="Walkthrough" style="width:100%;" />
+        <img src="./images/general/btnHide.jpg" title="History" style="width:100%;" />
     </button>
     <img src="./images/room/1001_rand/back_1.png" class="help-history hover-noevent" title="Back" style="width: 200px; height: 66.6px; z-index: 100; top:75px; left: 30px; position: absolute; display:none;" id="help_backButton" />
 </body>

--- a/style/global.css
+++ b/style/global.css
@@ -1032,9 +1032,11 @@ input[type=text]:disabled{
     overflow-y: scroll;
     width: 100%;
     height: 800px;
-    top: 100px;
     background: rgba(0,0,0,.7);
     color: #fff;
+    box-sizing: border-box;
+    padding: 5px 10px 10px 10px;
+    text-align: left;
 }
 
 .mt-adjust{


### PR DESCRIPTION
## Summary

This PR adds an Invoker-based room dispatch layer and migrates shared runtime dispatch to use it while keeping legacy room globals as fallback.

It does not rewrite room dialogue/content. The room system remains compatible with the existing `main` / `btnclick` / `chat` / `chatcatch` contract.

## Main changes

- added `scripts/invoker.js` as the shared room command dispatcher
- updated central dispatch paths to call invoker instead of direct dynamic room access
- kept legacy fallback resolution for unregistered rooms
- incrementally registered/migrated room files without doing a full room-content rewrite
- cleaned up repeated shell logic in shared UI/runtime files

## Shared interaction improvements

- `Space` advances single-action dialog / scene states where appropriate
- `1-9` selects visible chat choices by order
- `I` inventory hotkey remains guarded against typing fields
- `Esc` closes the phone
- `Phone > Help` now documents the active shortcuts

## Pre-existing issues fixed during the refactor

- fixed phone save/load/delete cancel flow
- fixed several stale overlay / menu restore / history issues
- fixed room 14 caged-option gating for the sleep scene
- fixed room 19 one-button callback progression
- fixed multiple room 555 exercise interaction paths
- fixed wardrobe hover text and a missing tampon icon fallback
- fixed several shop/UI refresh issues
- fixed legacy supporting-character compatibility helpers and old stat-mod aliasing
- applied a small set of safe asset/path corrections where the shipped files already existed

## Notes

- no `.gitignore` changes
- no mass room rewrite
- remaining missing-asset/content debt was intentionally left out of scope for this pass