### PR TITLE
Fix room589 event state lookup

### DIFF
--- a/scripts/room/room589.js
+++ b/scripts/room/room589.js
@@ -1,6 +1,7 @@
 ﻿//Liam
 var room589 = {};
 room589.main = function () {
+    let roomEvents = room585.getRoomsNow(false);
     switch (Math.floor(g.gethourdecimal())) {
         case 20:
         case 21:


### PR DESCRIPTION
## What changed
Restores the room-local event-state lookup required by room589 before it reads `roomEvents.r9`.

## Why
A previous cleanup removed `let roomEvents = room585.getRoomsNow(false);`, leaving room589 with a `ReferenceError` on entry.

## Scope
One room-local compatibility fix. No dialogue, content, or shared API changes.

## Validation
- `node --check scripts/room/room589.js`
- `git diff --check`