### PR TITLE
Require upper classes before sissy final

### DIFF
--- a/scripts/room/room210.js
+++ b/scripts/room/room210.js
@@ -99,15 +99,13 @@ room210.btnclick = function (name) {
             }
         }
         if (id === 21) {//final
-            let finalcounter = 0;
+            let incompleteClasses = [];
             for (i = 0; i < sissy.st.length; i++) {
-                if (sissy.st[i].y === 5 && sissy.st[i].active && sissy.st[i].ach)
-                    finalcounter++;
+                if (i !== 21 && sissy.st[i].y >= 4 && sissy.st[i].active && !sissy.st[i].ach)
+                    incompleteClasses.push(sissy.st[i].name);
             }
-            if (finalcounter === 1)
-                prevToUnlock = "You need to take one more 400 level class.";
-            else if (finalcounter === 0)
-                prevToUnlock = "You need to take 2 400 level classes.";
+            if (incompleteClasses.length > 0)
+                prevToUnlock = "You need to complete: " + incompleteClasses.join(", ") + ".";
         }
         else {
             for (i = 0; i < sissy.st[id].pID.length; i++) {


### PR DESCRIPTION
## What changed
The Final class now remains locked while any active upper-level class (`y >= 4`) is incomplete.

## Why
The previous gate counted only completed `y === 5` classes, allowing the player to bypass unfinished prerequisites such as Exposure 317, Bondage 310, and Bondage 436.

## Scope
One progression-gate fix in `scripts/room/room210.js`. No dialogue or room content changes.

## Validation
- `node --check scripts/room/room210.js`
- `git diff --check`

This is intentionally separate from the room589 runtime fix so the progression rule can be reviewed independently.