### PR TITLE
Fix post-jQuery room input and navigation issues

### DIFF
--- a/scripts/char.js
+++ b/scripts/char.js
@@ -23,12 +23,24 @@ char.toggleMainInventoryHotkey = function () {
 };
 
 char.roomButtonShortcutRooms = {
+    328: true,
     475: true,
     1004: true,
     1005: true
 };
 
 char.roomButtonShortcutOrder = {
+    328: {
+        pig_left: 1,
+        pig_center: 2,
+        pig_right: 3,
+        pig_struggle: 4,
+        pig_fuck0: 5,
+        pig_fuck1: 6,
+        pig_fuck2: 7,
+        pig_fuck3: 8,
+        pig_fuck4: 9
+    },
     475: {
         north: 1,
         south: 2,

--- a/scripts/nav.js
+++ b/scripts/nav.js
@@ -638,6 +638,7 @@ nav.wait = function (btnClickName) {
     nav.button({
         "type": "zbtn",
         "name": btnClickName,
+        "spaceAdvance": true,
         "left": 1695,
         "top": 920,
         "width": 225,

--- a/scripts/phone.js
+++ b/scripts/phone.js
@@ -549,6 +549,9 @@ phone.build = function (selection = null) {
 phone.captureMenuOverlay = function () {
     var overlay = $('#room-menuButtons');
 
+    if (phone.preservedMenuOverlay !== null)
+        return;
+
     if (inv.isOpen || !overlay.is(":visible") || overlay.children().length === 0) {
         phone.preservedMenuOverlay = null;
         return;

--- a/scripts/room/room019.js
+++ b/scripts/room/room019.js
@@ -36,6 +36,7 @@ room19.main = function () {
 room19.btnclick = function (name) {
     switch (name) {
         case "toyBegin":
+            nav.killbutton("pump");
             if (daily.get("buttholePlay")) {
                 nav.killbutton("toyBegin");
                 chat(7, 19);
@@ -53,6 +54,7 @@ room19.btnclick = function (name) {
             }
             break;
         case "bjBegin":
+            nav.killbutton("pump");
             if (daily.get("dildoSuckPlay")) {
                 nav.killbutton("bjBegin");
                 chat(13, 19);

--- a/scripts/room/room952.js
+++ b/scripts/room/room952.js
@@ -614,7 +614,7 @@ room952.chatcatch = function (callback) {
             char.room(955);
             break;
         case "turnaround":
-            nav.back("turnaround");
+            char.room(952);
             break;
         case "leave":
             gv.mod("cultDayCounter", 1);


### PR DESCRIPTION
## What changed

- Restores room overlays after navigating inside the phone, including Shiny Jewels in room401.
- Adds Space support for the shared Wait button and numeric shortcuts for room328 actions.
- Hides the room19 Breast Pump overlay when entering the related scenes.
- Restores room952 navigation after turnaround dialogue callbacks.
- Prevents room10's personalized room layers from flashing the default room during entry.

## Why

These are small post-jQuery gameplay and UI fixes kept separate from the merged jQuery migration.

## Validation

- Rebased cleanly onto the current upstream master.
- `node --check` passed for the changed scripts.
- `git diff --check` passed.

Manual room testing is still recommended before merge.
