### PR TITLE
Prevent room10 entry layer flash

### DIFF
--- a/scripts/room/room010.js
+++ b/scripts/room/room010.js
@@ -1,5 +1,23 @@
 ﻿//bedroom
 var room10 = {};
+room10.showWhenLoaded = function () {
+    var roomLayers = $('#room-background, #room-buttons');
+    var images = roomLayers.find('img');
+    var remaining = images.filter(function () {
+        return !this.complete;
+    }).length;
+
+    if (remaining === 0) {
+        roomLayers.show();
+        return;
+    }
+
+    images.one('load.room10 error.room10', function () {
+        remaining--;
+        if (remaining <= 0)
+            roomLayers.show();
+    });
+};
 room10.main = function () {
     if (inv.has("tifgift")) {
         chat(36, 10);
@@ -12,6 +30,7 @@ room10.main = function () {
     }
     else {
         $('.room-topper').show();
+        $('#room-background, #room-buttons').hide();
         invoker.invokeCurrent("btnclick", "drawRoom");
         var navList = [];
         var missingClothing = cl.hasoutfit("public");
@@ -44,6 +63,7 @@ room10.main = function () {
         }
 
         nav.buildnav(navList);
+        room10.showWhenLoaded();
     }
 };
 


### PR DESCRIPTION
## What changed

- Prevents room10's personalized room layers from flashing the default room during entry.

## Why

Room10 renders its base background first and then loads the selected bed, rug, posters, and other room layers. On slower image loads, the default room was briefly visible before those layers appeared.

## Implementation

Room10 keeps its background and room-button layers hidden until all images finish loading or fail, then reveals the completed room.

## Validation

- Based on the current upstream `master`, including merged PR #108.
- `node --check scripts/room/room010.js` passed.
- `git diff --check` passed.

Manual room10 entry testing is recommended before merge.
