### PR TITLE
Add Strength to phone cheats

### DIFF
--- a/scripts/phone.js
+++ b/scripts/phone.js
@@ -1597,7 +1597,7 @@ phone.cheat = function () {
     if (gv.get("cheatMode")) {
         phone.showPanel("999_phone/cheat_bg.jpg");
 
-        var levelToMod = ["fitness", "charisma"];
+        var levelToMod = ["fitness", "charisma", "strength"];
 
         nav.t({
             type: "zimg",


### PR DESCRIPTION
## What changed

- Adds `Strength` to the phone cheat menu.
- Reuses the existing `+100` stats button and the current cheat layout.

## Why

Strength is already a registered level stat, so this exposes the existing mechanic without adding a new save field or changing game logic.

## Validation

- Based on the current upstream `master`.
- `node --check scripts/phone.js` passed.
- `git diff --check` passed.

Manual verification is recommended with Cheat Mode enabled.
